### PR TITLE
Improve friend battle sync and responsive lobby UI

### DIFF
--- a/apps/hub/app/api/friend/game/[roomId]/route.ts
+++ b/apps/hub/app/api/friend/game/[roomId]/route.ts
@@ -10,7 +10,7 @@ export async function GET(
   try {
     const roomId = params.roomId;
     if (!roomId) return NextResponse.json({ ok: false, reason: 'bad-request' }, { status: 400 });
-    const snap = getGame(roomId);
+    const snap = await getGame(roomId);
     if (!snap) return NextResponse.json({ ok: false, reason: 'not-found' }, { status: 404 });
     return NextResponse.json({ ok: true, snapshot: snap }, { status: 200 });
   } catch (e) {
@@ -31,13 +31,13 @@ export async function POST(
     if (type === 'init') {
       const { state, config } = body || {};
       if (!state || !config) return NextResponse.json({ ok: false, reason: 'bad-request' }, { status: 400 });
-      const snap = initGame(roomId, { state, config });
+      const snap = await initGame(roomId, { state, config });
       return NextResponse.json({ ok: true, snapshot: snap }, { status: 200 });
     }
     if (type === 'move') {
       const { move } = body || {};
       if (!move) return NextResponse.json({ ok: false, reason: 'bad-request' }, { status: 400 });
-      const snap = applyServerMove(roomId, move);
+      const snap = await applyServerMove(roomId, move);
       if (!snap) return NextResponse.json({ ok: false, reason: 'not-found' }, { status: 404 });
       return NextResponse.json({ ok: true, snapshot: snap }, { status: 200 });
     }

--- a/apps/hub/app/friend/create/page.tsx
+++ b/apps/hub/app/friend/create/page.tsx
@@ -2,12 +2,22 @@
 
 import { getNickname } from "@/lib/profile";
 import { upsertLocalRoom } from "@/lib/roomSystemUnified";
+import type { Room } from "@/types/room";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 export default function FriendCreatePage() {
   const router = useRouter();
-  const [settings, setSettings] = useState({
+  type FriendRoomSettings = {
+    roomSize: number;
+    turnSeconds: number;
+    maxCucumbers: number;
+  };
+
+  type SettingKey = keyof FriendRoomSettings;
+  type RadioOption = number | { value: number; label: string };
+
+  const [settings, setSettings] = useState<FriendRoomSettings>({
     roomSize: 4,
     turnSeconds: 15,
     maxCucumbers: 5
@@ -16,38 +26,42 @@ export default function FriendCreatePage() {
   const [error, setError] = useState<string | null>(null);
   const [announcement, setAnnouncement] = useState('');
 
-  const handleSettingChange = (key: string, value: any) => {
+  const getOptionValue = (option: RadioOption) =>
+    typeof option === 'number' ? option : option.value;
+
+  const handleSettingChange = (key: SettingKey, value: number) => {
     setSettings(prev => ({ ...prev, [key]: value }));
-    
-    // アクセシビリティ用の音声通知
-    const labels: Record<string, Record<any, string>> = {
+
+    const labels: Record<SettingKey, Record<number, string>> = {
       roomSize: { 2: '2人', 3: '3人', 4: '4人', 5: '5人', 6: '6人' },
       turnSeconds: { 5: '5秒', 15: '15秒', 30: '30秒', 0: '無制限' },
       maxCucumbers: { 4: '4本', 5: '5本', 6: '6本', 7: '7本' }
     };
-    
-    if (labels[key] && labels[key][value]) {
-      setAnnouncement(`${labels[key][value]}を選択`);
+
+    const label = labels[key]?.[value];
+    if (label) {
+      setAnnouncement(`${label}を選択`);
       setTimeout(() => setAnnouncement(''), 2000);
     }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent, options: any[], currentValue: any, key: string) => {
+  const handleKeyDown = (
+    e: React.KeyboardEvent,
+    options: RadioOption[],
+    currentValue: number,
+    key: SettingKey
+  ) => {
     if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
       e.preventDefault();
-      const currentIndex = options.findIndex(opt => 
-        typeof opt === 'object' ? opt.value === currentValue : opt === currentValue
-      );
+      const currentIndex = options.findIndex(opt => getOptionValue(opt) === currentValue);
       const prevIndex = currentIndex > 0 ? currentIndex - 1 : options.length - 1;
-      const prevValue = typeof options[prevIndex] === 'object' ? options[prevIndex].value : options[prevIndex];
+      const prevValue = getOptionValue(options[prevIndex]);
       handleSettingChange(key, prevValue);
     } else if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
       e.preventDefault();
-      const currentIndex = options.findIndex(opt => 
-        typeof opt === 'object' ? opt.value === currentValue : opt === currentValue
-      );
+      const currentIndex = options.findIndex(opt => getOptionValue(opt) === currentValue);
       const nextIndex = currentIndex < options.length - 1 ? currentIndex + 1 : 0;
-      const nextValue = typeof options[nextIndex] === 'object' ? options[nextIndex].value : options[nextIndex];
+      const nextValue = getOptionValue(options[nextIndex]);
       handleSettingChange(key, nextValue);
     }
   };
@@ -56,7 +70,7 @@ export default function FriendCreatePage() {
     document.title = 'ルーム作成 | Five Cucumber';
     document.body.setAttribute('data-bg', 'home');
     document.body.classList.add('no-scroll');
-    
+
     return () => {
       document.body.removeAttribute('data-bg');
       document.body.classList.remove('no-scroll');
@@ -77,14 +91,13 @@ export default function FriendCreatePage() {
       const res = await fetch('/api/friend/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ 
-          roomSize: settings.roomSize, 
+        body: JSON.stringify({
+          roomSize: settings.roomSize,
           nickname,
           turnSeconds: settings.turnSeconds,
           maxCucumbers: settings.maxCucumbers
         })
       }).catch((err) => {
-        // Safari/拡張のメッセージポートエラー等を吸収
         console.warn('Create room network error:', err);
         return new Response(JSON.stringify({ ok: false }), { status: 520 });
       });
@@ -93,7 +106,18 @@ export default function FriendCreatePage() {
         const data = await res.json();
         if (data.ok && data.roomId) {
           try {
-            upsertLocalRoom({ id: data.roomId, size: settings.roomSize, seats: Array.from({length: settings.roomSize}, () => null).map((v,i)=> i===0 ? { nickname } : v), status: 'waiting', createdAt: Date.now(), turnSeconds: settings.turnSeconds, maxCucumbers: settings.maxCucumbers } as any);
+            const localRoom: Room = {
+              id: data.roomId,
+              size: settings.roomSize,
+              seats: Array.from({ length: settings.roomSize }, (_, index) =>
+                index === 0 ? { nickname } : null
+              ),
+              status: 'waiting',
+              createdAt: Date.now(),
+              turnSeconds: settings.turnSeconds,
+              maxCucumbers: settings.maxCucumbers
+            };
+            upsertLocalRoom(localRoom);
           } catch {}
           router.push(`/friend/room/${data.roomId}`);
         } else {
@@ -126,125 +150,124 @@ export default function FriendCreatePage() {
   };
 
   return (
-    <main className="settings-page">
-      <div className="settings-container">
-        {/* 音声通知用 */}
-        <div aria-live="polite" className="sr-only">
-          {announcement}
-        </div>
+    <main className="friend-room-page">
+      <div className="friend-room-page__background" aria-hidden="true" />
+      <div className="friend-room-page__container">
+        <header className="friend-room-page__header">
+          <div>
+            <p className="friend-room-page__eyebrow">ROOM SETTINGS</p>
+            <h1 className="friend-room-page__title">フレンドルームを作成</h1>
+            <p className="friend-room-page__lead">
+              対戦人数・制限時間・きゅうり数を選んで、招待する友達にぴったりの設定にしましょう。
+            </p>
+          </div>
+        </header>
 
-        <h1 className="sr-only" aria-label="フレンド対戦ルーム作成">フレンド対戦ルーム作成</h1>
+        <section className="friend-room-page__content">
+          <div aria-live="polite" className="sr-only">
+            {announcement}
+          </div>
 
-        {/* 小見出し */}
-        <div className="settings-subtitle">
-          フレンド対戦のルームを作成します
-        </div>
-
-        {/* 対戦人数 */}
-        <section className="settings-group">
-          <h2 id="players-heading" className="settings-heading">対戦人数</h2>
-          <div 
-            role="radiogroup" 
-            aria-labelledby="players-heading"
-            className="settings-buttons"
-            onKeyDown={(e) => handleKeyDown(e, [2, 3, 4, 5, 6], settings.roomSize, 'roomSize')}
-          >
-            {[2, 3, 4, 5, 6].map((num, index) => (
-              <button
-                key={num}
-                role="radio"
-                aria-checked={settings.roomSize === num}
-                tabIndex={settings.roomSize === num ? 0 : -1}
-                onClick={() => handleSettingChange('roomSize', num)}
-                className={`settings-radio-btn ${settings.roomSize === num ? 'selected' : ''}`}
-                disabled={isCreating}
+          <div className="friend-room-card">
+            <div className="friend-room-card__section">
+              <h2 id="players-heading" className="friend-room-card__heading">対戦人数</h2>
+              <div
+                role="radiogroup"
+                aria-labelledby="players-heading"
+                className="friend-room-options"
+                onKeyDown={(e) => handleKeyDown(e, [2, 3, 4, 5, 6], settings.roomSize, 'roomSize')}
               >
-                {num}人
+                {[2, 3, 4, 5, 6].map((num) => (
+                  <button
+                    key={num}
+                    role="radio"
+                    aria-checked={settings.roomSize === num}
+                    tabIndex={settings.roomSize === num ? 0 : -1}
+                    onClick={() => handleSettingChange('roomSize', num)}
+                    className={`settings-radio-btn ${settings.roomSize === num ? 'selected' : ''}`}
+                    disabled={isCreating}
+                  >
+                    {num}人
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="friend-room-card__section">
+              <h2 id="time-heading" className="friend-room-card__heading">制限時間</h2>
+              <div
+                role="radiogroup"
+                aria-labelledby="time-heading"
+                className="friend-room-options"
+                onKeyDown={(e) => handleKeyDown(e, [{ value: 5, label: '5秒' }, { value: 15, label: '15秒' }, { value: 30, label: '30秒' }, { value: 0, label: '無制限' }], settings.turnSeconds, 'turnSeconds')}
+              >
+                {[
+                  { value: 5, label: '5秒' },
+                  { value: 15, label: '15秒' },
+                  { value: 30, label: '30秒' },
+                  { value: 0, label: '無制限' }
+                ].map(option => (
+                  <button
+                    key={option.value}
+                    role="radio"
+                    aria-checked={settings.turnSeconds === option.value}
+                    tabIndex={settings.turnSeconds === option.value ? 0 : -1}
+                    onClick={() => handleSettingChange('turnSeconds', option.value)}
+                    className={`settings-radio-btn ${settings.turnSeconds === option.value ? 'selected' : ''}`}
+                    disabled={isCreating}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="friend-room-card__section">
+              <h2 id="cucumbers-heading" className="friend-room-card__heading">お漬物きゅうり数</h2>
+              <div
+                role="radiogroup"
+                aria-labelledby="cucumbers-heading"
+                className="friend-room-options"
+                onKeyDown={(e) => handleKeyDown(e, [4, 5, 6, 7], settings.maxCucumbers, 'maxCucumbers')}
+              >
+                {[4, 5, 6, 7].map(num => (
+                  <button
+                    key={num}
+                    role="radio"
+                    aria-checked={settings.maxCucumbers === num}
+                    tabIndex={settings.maxCucumbers === num ? 0 : -1}
+                    onClick={() => handleSettingChange('maxCucumbers', num)}
+                    className={`settings-radio-btn ${settings.maxCucumbers === num ? 'selected' : ''}`}
+                    disabled={isCreating}
+                  >
+                    {num}本
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {error && (
+              <p className="friend-room-card__error" role="alert">{error}</p>
+            )}
+
+            <div className="friend-room-card__actions">
+              <button
+                onClick={handleCreateRoom}
+                disabled={!isAllSelected() || isCreating}
+                className={`friend-room-card__submit ${(!isAllSelected() || isCreating) ? 'is-disabled' : ''}`}
+              >
+                {isCreating ? '作成中...' : 'ルームを作成する'}
               </button>
-            ))}
+              <button
+                type="button"
+                onClick={() => router.push('/friend')}
+                className="friend-room-card__link"
+              >
+                フレンド対戦トップに戻る
+              </button>
+            </div>
           </div>
         </section>
-
-        {/* 制限時間 */}
-        <section className="settings-group">
-          <h2 id="time-heading" className="settings-heading">制限時間</h2>
-          <div 
-            role="radiogroup" 
-            aria-labelledby="time-heading"
-            className="settings-buttons"
-            onKeyDown={(e) => handleKeyDown(e, [{ value: 5, label: '5秒' }, { value: 15, label: '15秒' }, { value: 30, label: '30秒' }, { value: 0, label: '無制限' }], settings.turnSeconds, 'turnSeconds')}
-          >
-            {[
-              { value: 5, label: '5秒' },
-              { value: 15, label: '15秒' },
-              { value: 30, label: '30秒' },
-              { value: 0, label: '無制限' }
-            ].map(option => (
-              <button
-                key={option.value}
-                role="radio"
-                aria-checked={settings.turnSeconds === option.value}
-                tabIndex={settings.turnSeconds === option.value ? 0 : -1}
-                onClick={() => handleSettingChange('turnSeconds', option.value)}
-                className={`settings-radio-btn ${settings.turnSeconds === option.value ? 'selected' : ''}`}
-                disabled={isCreating}
-              >
-                {option.label}
-              </button>
-            ))}
-          </div>
-        </section>
-
-        {/* お漬物きゅうり数 */}
-        <section className="settings-group">
-          <h2 id="cucumbers-heading" className="settings-heading">お漬物きゅうり数</h2>
-          <div 
-            role="radiogroup" 
-            aria-labelledby="cucumbers-heading"
-            className="settings-buttons"
-            onKeyDown={(e) => handleKeyDown(e, [4, 5, 6, 7], settings.maxCucumbers, 'maxCucumbers')}
-          >
-            {[4, 5, 6, 7].map(num => (
-              <button
-                key={num}
-                role="radio"
-                aria-checked={settings.maxCucumbers === num}
-                tabIndex={settings.maxCucumbers === num ? 0 : -1}
-                onClick={() => handleSettingChange('maxCucumbers', num)}
-                className={`settings-radio-btn ${settings.maxCucumbers === num ? 'selected' : ''}`}
-                disabled={isCreating}
-              >
-                {num}本
-              </button>
-            ))}
-          </div>
-        </section>
-
-        {/* エラー表示 */}
-        {error && (
-          <div className="p-3 bg-red-100 border border-red-300 rounded-md">
-            <p className="text-red-600 text-sm">{error}</p>
-          </div>
-        )}
-
-        {/* アクションボタン */}
-        <div className="settings-actions">
-          <button
-            onClick={handleCreateRoom}
-            disabled={isCreating || !isAllSelected()}
-            className={`settings-start-btn ${(isAllSelected() && !isCreating) ? 'enabled' : 'disabled'}`}
-          >
-            {isCreating ? '作成中...' : 'ルーム作成'}
-          </button>
-          
-          <button
-            onClick={() => router.push('/friend')}
-            className="settings-back-btn"
-            disabled={isCreating}
-          >
-            ← フレンド対戦に戻る
-          </button>
-        </div>
       </div>
     </main>
   );

--- a/apps/hub/app/friend/page.tsx
+++ b/apps/hub/app/friend/page.tsx
@@ -9,45 +9,51 @@ export default function FriendPage() {
   }, []);
 
   return (
-    <main className="page-home min-h-screen w-full pt-20">
-      <div className="container mx-auto px-4">
-        {/* ヘッダー */}
-        <div className="flex justify-between items-center mb-8">
-          <h1 className="text-3xl font-bold">フレンド対戦</h1>
-          <Link 
-            href="/rules" 
-            className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700"
-          >
-            ルール
+    <main className="friend-page">
+      <div className="friend-page__background" aria-hidden="true" />
+      <div className="friend-page__container">
+        <header className="friend-page__header">
+          <div className="friend-page__title-group">
+            <p className="friend-page__eyebrow">ONLINE FRIEND MATCH</p>
+            <h1 className="friend-page__title">フレンド対戦</h1>
+            <p className="friend-page__lead">
+              あなたがホストとなってルームを作成するか、招待されたルームコードからすぐに合流できます。
+            </p>
+          </div>
+          <Link href="/rules" className="friend-page__rules">
+            ルールを見る
           </Link>
-        </div>
+        </header>
 
-        <div className="max-w-md mx-auto">
-          <div className="bg-white rounded-lg border border-gray-200 p-6 space-y-6">
-            <div className="text-center">
-              <h2 className="text-xl font-semibold mb-4">フレンド対戦</h2>
-              <p className="text-gray-600 mb-6">
-                ルームを作成するか、既存のルームに参加してください
+        <section className="friend-actions" aria-labelledby="friend-actions-heading">
+          <h2 id="friend-actions-heading" className="sr-only">
+            フレンド対戦の操作
+          </h2>
+
+          <article className="friend-action-card">
+            <div className="friend-action-card__body">
+              <h3 className="friend-action-card__title">ホストとしてルーム作成</h3>
+              <p className="friend-action-card__text">
+                プレイヤー人数・制限時間・きゅうり数を決めてフレンドを招待しましょう。
               </p>
             </div>
+            <Link href="/friend/create" className="friend-action-card__button friend-action-card__button--primary">
+              ルームを作成
+            </Link>
+          </article>
 
-            <div className="space-y-4">
-              <Link
-                href="/friend/create"
-                className="w-full py-3 bg-green-600 text-white rounded-md hover:bg-green-700 transition-colors text-center block"
-              >
-                ルーム作成
-              </Link>
-
-              <Link
-                href="/friend/join"
-                className="w-full py-3 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-center block"
-              >
-                ルーム参加
-              </Link>
+          <article className="friend-action-card">
+            <div className="friend-action-card__body">
+              <h3 className="friend-action-card__title">ルームコードで参加</h3>
+              <p className="friend-action-card__text">
+                6桁のルーム番号を入力して、進行中の友達のルームに合流しましょう。
+              </p>
             </div>
-          </div>
-        </div>
+            <Link href="/friend/join" className="friend-action-card__button friend-action-card__button--secondary">
+              ルームに参加
+            </Link>
+          </article>
+        </section>
       </div>
     </main>
   );

--- a/apps/hub/app/globals.css
+++ b/apps/hub/app/globals.css
@@ -736,6 +736,540 @@ body[data-bg="battle"]::before {
   background: rgba(107, 114, 128, 0.1);
 }
 
+/* フレンド対戦ページ */
+.friend-page {
+  position: relative;
+  min-height: 100svh;
+  padding: clamp(24px, 6vw, 72px) clamp(16px, 6vw, 88px);
+  display: flex;
+  justify-content: center;
+  color: #f5f0e6;
+}
+
+.friend-page__background {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top, rgba(37, 83, 62, 0.65), rgba(8, 28, 20, 0.95));
+  backdrop-filter: blur(12px);
+  z-index: 0;
+}
+
+.friend-page__container {
+  position: relative;
+  z-index: 1;
+  width: min(960px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 4vw, 48px);
+}
+
+.friend-page__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.friend-page__title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 640px;
+}
+
+.friend-page__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.friend-page__title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.friend-page__lead {
+  font-size: clamp(1rem, 2.2vw, 1.25rem);
+  line-height: 1.7;
+  color: rgba(245, 240, 230, 0.85);
+}
+
+.friend-page__rules {
+  align-self: flex-start;
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+  font-weight: 600;
+  transition: all 160ms ease;
+}
+
+.friend-page__rules:hover {
+  background: rgba(255, 255, 255, 0.25);
+  border-color: rgba(255, 255, 255, 0.55);
+}
+
+.friend-actions {
+  display: grid;
+  gap: clamp(16px, 3vw, 24px);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.friend-action-card {
+  position: relative;
+  background: rgba(17, 40, 30, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 18px;
+  padding: clamp(20px, 3vw, 28px);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 220px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.28);
+}
+
+.friend-action-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.friend-action-card__title {
+  font-size: clamp(1.25rem, 2.4vw, 1.5rem);
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.friend-action-card__text {
+  font-size: clamp(0.95rem, 2vw, 1.05rem);
+  line-height: 1.7;
+  color: rgba(232, 236, 230, 0.82);
+}
+
+.friend-action-card__button {
+  margin-top: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.9rem 1.5rem;
+  border-radius: 12px;
+  font-weight: 600;
+  font-size: 1rem;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+  border: none;
+}
+
+.friend-action-card__button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
+}
+
+.friend-action-card__button--primary {
+  background: linear-gradient(135deg, #34a853, #1e7c3a);
+  color: #ffffff;
+}
+
+.friend-action-card__button--secondary {
+  background: rgba(255, 255, 255, 0.18);
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+@media (max-width: 768px) {
+  .friend-page__header {
+    align-items: stretch;
+    gap: 1.25rem;
+  }
+
+  .friend-page__rules {
+    width: 100%;
+    text-align: center;
+  }
+
+  .friend-action-card {
+    min-height: 0;
+  }
+}
+
+.friend-room-page {
+  position: relative;
+  min-height: 100svh;
+  padding: clamp(20px, 5vw, 64px) clamp(16px, 6vw, 80px);
+  display: flex;
+  justify-content: center;
+}
+
+.friend-room-page__background {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(14, 46, 32, 0.92), rgba(8, 20, 18, 0.95));
+  z-index: 0;
+  backdrop-filter: blur(8px);
+}
+
+.friend-room-page__container {
+  position: relative;
+  z-index: 1;
+  width: min(960px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(20px, 4vw, 40px);
+  color: #f5f0e6;
+}
+
+.friend-room-page__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.friend-room-page__header--with-actions {
+  flex-direction: column;
+  gap: clamp(16px, 3vw, 28px);
+}
+
+.friend-room-page__header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.friend-room-page__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.25rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  background: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: all 160ms ease;
+}
+
+.friend-room-page__chip:hover {
+  background: rgba(255, 255, 255, 0.24);
+}
+
+.friend-room-page__chip--accent {
+  background: linear-gradient(135deg, rgba(102, 126, 234, 0.8), rgba(118, 75, 162, 0.85));
+  border-color: transparent;
+}
+
+.friend-room-page__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.friend-room-page__title {
+  font-size: clamp(1.75rem, 3.5vw, 2.5rem);
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.friend-room-page__lead {
+  font-size: clamp(0.95rem, 2.1vw, 1.15rem);
+  line-height: 1.7;
+  color: rgba(240, 241, 235, 0.85);
+}
+
+.friend-room-page__content {
+  display: flex;
+  justify-content: center;
+}
+
+.friend-room-card {
+  width: min(720px, 100%);
+  background: rgba(15, 34, 28, 0.85);
+  border-radius: 24px;
+  padding: clamp(20px, 4vw, 36px);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 3vw, 28px);
+}
+
+.friend-room-card--status {
+  gap: clamp(20px, 4vw, 32px);
+}
+
+.friend-room-card--form {
+  gap: clamp(16px, 3vw, 24px);
+}
+
+.friend-room-card__form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.friend-room-card__input {
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  background: rgba(6, 22, 18, 0.85);
+  color: #ffffff;
+  font-size: 1.1rem;
+  letter-spacing: 0.2em;
+  text-align: center;
+}
+
+.friend-room-card__input:focus {
+  outline: 2px solid rgba(111, 207, 151, 0.6);
+  outline-offset: 2px;
+}
+
+.friend-room-card__hint {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.friend-room-card__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.friend-room-card__section--grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem 1.5rem;
+}
+
+.friend-room-card__heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.friend-room-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-start;
+}
+
+.friend-room-card__error {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(220, 38, 38, 0.18);
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  color: #fecaca;
+  font-size: 0.95rem;
+}
+
+.friend-room-card__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.friend-room-card__actions--wide {
+  align-items: stretch;
+}
+
+.friend-room-card__submit {
+  width: 100%;
+  padding: 0.95rem 1.5rem;
+  border-radius: 12px;
+  border: none;
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: #ffffff;
+  background: linear-gradient(135deg, #2fb15f, #1a7841);
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, opacity 150ms ease;
+}
+
+.friend-room-card__submit:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 24px rgba(0, 0, 0, 0.25);
+}
+
+.friend-room-card__submit.is-disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.friend-room-card__secondary {
+  width: 100%;
+  padding: 0.85rem 1.25rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: transparent;
+  color: #ffffff;
+  font-weight: 600;
+  transition: background 150ms ease, border 150ms ease;
+}
+
+.friend-room-card__secondary:hover {
+  background: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.55);
+}
+
+.friend-room-card__link {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 0.95rem;
+  text-decoration: underline;
+  align-self: center;
+  cursor: pointer;
+}
+
+.friend-room-card__link:hover {
+  color: #ffffff;
+}
+
+.friend-room-card__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 1rem;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  width: fit-content;
+  letter-spacing: 0.3em;
+  font-size: 0.9rem;
+}
+
+.friend-room-info-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  background: rgba(0, 0, 0, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.95rem;
+}
+
+.friend-room-banner {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+}
+
+.friend-room-banner--info {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.25), rgba(37, 99, 235, 0.25));
+  border: 1px solid rgba(59, 130, 246, 0.4);
+}
+
+.friend-room-banner--waiting {
+  background: linear-gradient(135deg, rgba(251, 191, 36, 0.18), rgba(217, 119, 6, 0.18));
+  border: 1px solid rgba(251, 191, 36, 0.35);
+}
+
+.friend-room-banner__title {
+  font-weight: 600;
+}
+
+.friend-room-banner__text {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.friend-room-seat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.friend-room-seat {
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.2);
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+}
+
+.friend-room-seat--occupied {
+  background: rgba(46, 125, 50, 0.18);
+  border-color: rgba(46, 125, 50, 0.35);
+}
+
+.friend-room-seat--empty {
+  opacity: 0.7;
+}
+
+.friend-room-seat__title {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.friend-room-seat__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.5rem;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.2);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.friend-room-seat__badge--me {
+  background: rgba(59, 130, 246, 0.5);
+}
+
+.friend-room-card--message {
+  align-items: center;
+  text-align: center;
+  gap: 1.25rem;
+}
+
+.friend-room-card__message {
+  font-size: 1.1rem;
+  line-height: 1.7;
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.friend-room-banner span {
+  font-size: 1.8rem;
+}
+
+@media (max-width: 640px) {
+  .friend-room-page__header-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .friend-room-seat-grid {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .friend-room-card {
+    border-radius: 18px;
+    padding: clamp(18px, 6vw, 28px);
+  }
+
+  .friend-room-card__heading {
+    text-align: left;
+  }
+
+  .friend-room-options {
+    justify-content: center;
+  }
+}
+
 .debug-section {
   background: rgba(255, 243, 205, 0.5);
   border-radius: 12px;

--- a/apps/hub/lib/roomsRedis.ts
+++ b/apps/hub/lib/roomsRedis.ts
@@ -1,5 +1,5 @@
 import { redis } from './redis';
-import type { Room } from '@/types/room';
+import type { Room, RoomGameSnapshot } from '@/types/room';
 
 const key = (id: string) => `room:${id}`;
 
@@ -23,6 +23,15 @@ export async function updateRoomRedis(roomId: string, patch: Partial<Room>): Pro
   const next = { ...current, ...patch } as Room;
   await redis.set(key(roomId), JSON.stringify(next));
   return true;
+}
+
+export async function getRoomGameSnapshotRedis(roomId: string): Promise<RoomGameSnapshot | null> {
+  const room = await getRoomByIdRedis(roomId);
+  return room?.gameSnapshot ?? null;
+}
+
+export async function saveRoomGameSnapshotRedis(roomId: string, snapshot: RoomGameSnapshot): Promise<void> {
+  await updateRoomRedis(roomId, { gameSnapshot: snapshot });
 }
 
 

--- a/apps/hub/lib/roomsStore.ts
+++ b/apps/hub/lib/roomsStore.ts
@@ -1,5 +1,5 @@
 import { db } from '@/lib/firebase';
-import { Room } from '@/types/room';
+import { Room, RoomGameSnapshot } from '@/types/room';
 import { doc, getDoc, setDoc, updateDoc } from 'firebase/firestore';
 
 const collectionName = 'rooms';
@@ -17,10 +17,25 @@ export async function putRoom(room: Room): Promise<void> {
   await setDoc(ref, room, { merge: true });
 }
 
-export async function updateRoom(roomId: string, data: Partial<Room & { seed?: number; gameState?: string; gameConfig?: any }>): Promise<void> {
+export async function updateRoom(roomId: string, data: Partial<Room>): Promise<void> {
   if (!db) throw new Error('no-db');
   const ref = doc(db, collectionName, roomId);
   await updateDoc(ref, data as any);
+}
+
+export async function getRoomGameSnapshot(roomId: string): Promise<RoomGameSnapshot | null> {
+  if (!db) return null;
+  const ref = doc(db, collectionName, roomId);
+  const snap = await getDoc(ref);
+  if (!snap.exists()) return null;
+  const data = snap.data() as Room;
+  return data.gameSnapshot ?? null;
+}
+
+export async function saveRoomGameSnapshot(roomId: string, snapshot: RoomGameSnapshot): Promise<void> {
+  if (!db) throw new Error('no-db');
+  const ref = doc(db, collectionName, roomId);
+  await updateDoc(ref, { gameSnapshot: snapshot } as Partial<Room>);
 }
 
 

--- a/apps/hub/types/room.ts
+++ b/apps/hub/types/room.ts
@@ -4,6 +4,15 @@ export type RoomSeat = { nickname: string } | null;
 
 export type RoomStatus = 'waiting' | 'playing' | 'closed';
 
+import type { GameConfig, GameState } from '@/lib/game-core';
+
+export interface RoomGameSnapshot {
+  state: GameState;
+  config: GameConfig;
+  version: number;
+  updatedAt: number;
+}
+
 export interface Room {
   id: string;
   size: number;             // 2..6
@@ -13,6 +22,8 @@ export interface Room {
   // ゲーム設定
   turnSeconds: number;      // ターン時間（秒）
   maxCucumbers: number;     // きゅうり上限
+  // フレンド対戦の同期用スナップショット（任意）
+  gameSnapshot?: RoomGameSnapshot;
 }
 
 export interface CreateRoomRequest {


### PR DESCRIPTION
## Summary
- persist friend battle snapshots in Firestore/Redis with fallbacks and update API handlers to await the new async store
- refresh the friend battle landing, create, join and waiting room pages with responsive layouts and mobile-friendly styling
- expand shared CSS utilities to cover the new layouts and badges for room details

## Testing
- `pnpm --filter @five-cucumber/hub lint` *(fails: existing lint errors across untouched files, see log)*

------
https://chatgpt.com/codex/tasks/task_e_68cd008de2a4832fbedaeb02248dcda5