### PR TITLE
Gracefully handle Firestore read failures when joining rooms

### DIFF
--- a/apps/hub/lib/roomsStore.ts
+++ b/apps/hub/lib/roomsStore.ts
@@ -6,36 +6,62 @@ const collectionName = 'rooms';
 
 export async function getRoomById(roomId: string): Promise<Room | null> {
   if (!db) return null;
-  const ref = doc(db, collectionName, roomId);
-  const snap = await getDoc(ref);
-  return snap.exists() ? (snap.data() as Room) : null;
+
+  try {
+    const ref = doc(db, collectionName, roomId);
+    const snap = await getDoc(ref);
+    return snap.exists() ? (snap.data() as Room) : null;
+  } catch (error) {
+    console.warn('[roomsStore] getRoomById failed:', error);
+    return null;
+  }
 }
 
 export async function putRoom(room: Room): Promise<void> {
   if (!db) throw new Error('no-db');
-  const ref = doc(db, collectionName, room.id);
-  await setDoc(ref, room, { merge: true });
+  try {
+    const ref = doc(db, collectionName, room.id);
+    await setDoc(ref, room, { merge: true });
+  } catch (error) {
+    console.warn('[roomsStore] putRoom failed:', error);
+    throw error;
+  }
 }
 
 export async function updateRoom(roomId: string, data: Partial<Room>): Promise<void> {
   if (!db) throw new Error('no-db');
-  const ref = doc(db, collectionName, roomId);
-  await updateDoc(ref, data as any);
+  try {
+    const ref = doc(db, collectionName, roomId);
+    await updateDoc(ref, data as Partial<Room>);
+  } catch (error) {
+    console.warn('[roomsStore] updateRoom failed:', error);
+    throw error;
+  }
 }
 
 export async function getRoomGameSnapshot(roomId: string): Promise<RoomGameSnapshot | null> {
   if (!db) return null;
-  const ref = doc(db, collectionName, roomId);
-  const snap = await getDoc(ref);
-  if (!snap.exists()) return null;
-  const data = snap.data() as Room;
-  return data.gameSnapshot ?? null;
+  try {
+    const ref = doc(db, collectionName, roomId);
+    const snap = await getDoc(ref);
+    if (!snap.exists()) return null;
+    const data = snap.data() as Room;
+    return data.gameSnapshot ?? null;
+  } catch (error) {
+    console.warn('[roomsStore] getRoomGameSnapshot failed:', error);
+    return null;
+  }
 }
 
 export async function saveRoomGameSnapshot(roomId: string, snapshot: RoomGameSnapshot): Promise<void> {
   if (!db) throw new Error('no-db');
-  const ref = doc(db, collectionName, roomId);
-  await updateDoc(ref, { gameSnapshot: snapshot } as Partial<Room>);
+  try {
+    const ref = doc(db, collectionName, roomId);
+    await updateDoc(ref, { gameSnapshot: snapshot } as Partial<Room>);
+  } catch (error) {
+    console.warn('[roomsStore] saveRoomGameSnapshot failed:', error);
+    throw error;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- add defensive error handling around Firestore reads so permission errors return null instead of aborting
- preserve existing error bubbling for writes while logging the failure for easier diagnosis

## Testing
- pnpm --filter @five-cucumber/hub lint --dir apps/hub/lib

------
https://chatgpt.com/codex/tasks/task_e_68cd66c489d4832fb0439e751534b936