### PR TITLE
Ensure friend rooms sync to both Firestore and Redis

### DIFF
--- a/apps/hub/app/api/friend/create/route.ts
+++ b/apps/hub/app/api/friend/create/route.ts
@@ -86,27 +86,35 @@ export async function POST(req: NextRequest): Promise<NextResponse<RoomResponse>
     };
 
     const hasFirestoreEnv = !!process.env.NEXT_PUBLIC_FIREBASE_API_KEY && !!process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+    const hasRedisEnv = !!process.env.UPSTASH_REDIS_REST_URL && !!process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    let persisted = false;
+
     if (hasFirestoreEnv) {
       try {
         await withTimeout(putRoom(room), 2000);
-        return NextResponse.json({ ok: true, roomId: id }, { status: 200 });
+        persisted = true;
       } catch (e) {
-        console.warn('[API] Firestore putRoom failed or timed out, falling back:', e instanceof Error ? e.message : e);
+        const msg = e instanceof Error ? e.message : String(e);
+        console.warn('[API] Firestore putRoom failed or timed out:', msg);
       }
     }
 
-    // Redis がある場合はRedisに保存
-    if (process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN) {
+    if (hasRedisEnv) {
       try {
         await putRoomRedis(room);
-        return NextResponse.json({ ok: true, roomId: id }, { status: 200 });
+        persisted = true;
       } catch (e) {
-        console.warn('[API] Redis putRoom failed, fallback to memory:', e);
+        console.warn('[API] Redis putRoom failed:', e);
       }
     }
 
-    // サーバー共有ストレージが無い場合は失敗を返す（serverlessでの分断を避ける）
-    return NextResponse.json({ ok: false, reason: 'server-error' }, { status: 500 });
+    if (!persisted) {
+      // サーバー共有ストレージが無い場合は失敗を返す（serverlessでの分断を避ける）
+      return NextResponse.json({ ok: false, reason: 'server-error' }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true, roomId: id }, { status: 200 });
 
   } catch (error) {
     console.error('Room creation error:', error);


### PR DESCRIPTION
## Summary
- ensure friend room creation persists to any available shared store and attempts to sync both Firestore and Redis copies
- update friend room join API to save seat assignments in both data stores and surface persistence failures

## Testing
- pnpm --filter hub lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ce18081dc0832f80b732b68b49e455