### PR TITLE
Add consistent home navigation to setup screens

### DIFF
--- a/apps/hub/app/cucumber/cpu/settings/page.tsx
+++ b/apps/hub/app/cucumber/cpu/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { OptionToggleGroup, SettingsLayout } from '@/components/ui';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
@@ -84,17 +85,15 @@ export default function CpuSettings() {
       description="ゲームの設定を調整してください"
       footer={
         <>
-          <button
-            type="button"
-            onClick={() => router.push('/home')}
-            className="inline-flex items-center justify-center rounded-full px-6 py-3 font-semibold text-[#f8fafc] bg-black/35 border border-white/10 hover:bg-black/45 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
-          >
-            ホームに戻る
-          </button>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Link href="/home" className="btn-secondary layout-footer__button">
+              ホームに戻る
+            </Link>
+          </div>
           <button
             onClick={handleStart}
             disabled={!isAllSelected()}
-            className="inline-flex items-center justify-center rounded-full px-6 py-3 font-semibold text-[#f8fafc] bg-black/35 border border-white/10 hover:bg-black/45 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60 disabled:opacity-40"
+            className="btn-primary layout-footer__button"
           >
             CPU対戦を開始
           </button>

--- a/apps/hub/app/friend/create/page.tsx
+++ b/apps/hub/app/friend/create/page.tsx
@@ -4,6 +4,7 @@ import { FriendRoomLayout, RoomSettingsForm } from "@/components/ui";
 import { apiJson } from "@/lib/api";
 import { getNickname } from "@/lib/profile";
 import { upsertLocalRoom } from "@/lib/roomSystemUnified";
+import Link from "next/link";
 import type { Room } from "@/types/room";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -133,17 +134,18 @@ export default function FriendCreatePage() {
       description="対戦人数・制限時間・きゅうり数を選んで、招待する友達にぴったりの設定にしましょう。"
       footer={
         <>
-          <button
-            type="button"
-            onClick={() => router.push('/friend')}
-            className="inline-flex items-center justify-center rounded-full px-6 py-3 font-semibold text-[#f8fafc] bg-black/35 border border-white/10 hover:bg-black/45 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60 disabled:opacity-40"
-          >
-            フレンド対戦トップに戻る
-          </button>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Link href="/home" className="btn-secondary layout-footer__button">
+              ホームに戻る
+            </Link>
+            <Link href="/friend" className="btn-secondary layout-footer__button">
+              フレンド対戦トップに戻る
+            </Link>
+          </div>
           <button
             onClick={handleCreateRoom}
             disabled={!isAllSelected() || isCreating}
-            className="inline-flex items-center justify-center rounded-full px-6 py-3 font-semibold text-[#f8fafc] bg-black/35 border border-white/10 hover:bg-black/45 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60 disabled:opacity-40"
+            className="btn-primary layout-footer__button"
           >
             {isCreating ? '作成中...' : 'ルームを作成する'}
           </button>

--- a/apps/hub/app/globals.css
+++ b/apps/hub/app/globals.css
@@ -121,6 +121,31 @@
   outline-offset: 2px;
 }
 
+.layout-footer__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 9999px;
+  padding: 12px 24px;
+  font-size: clamp(14px, 1.8vw, 16px);
+  font-weight: 600;
+  text-decoration: none;
+  width: 100%;
+  min-height: 48px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.layout-footer__button:active {
+  transform: translateY(1px);
+}
+
+@media (min-width: 640px) {
+  .layout-footer__button {
+    width: auto;
+  }
+}
+
 /* === 無効状態 === */
 .btn-disabled {
   opacity: 0.5;


### PR DESCRIPTION
## Summary
- add a dedicated home navigation link to the friend room creation footer and align button styling
- update the CPU settings footer to reuse the shared button styling while linking back to home
- introduce a reusable footer button style for consistent spacing and sizing across layouts

## Testing
- pnpm --filter hub lint *(fails: Unexpected non-whitespace character after JSON at position 400 in .eslintrc.json)*

------
https://chatgpt.com/codex/tasks/task_e_69070bb2a350832f97b9da31fb882282