### PR TITLE
Simplify battle screens to place players directly on the background

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/game.css
+++ b/apps/hub/app/cucumber/cpu/play/game.css
@@ -1,42 +1,49 @@
-/* ゲーム画面専用スタイル */
-.game-root {
+/* テーブルの基礎レイアウト */
+.ellipse-table {
   position: relative;
-  min-height: 100vh;
-  z-index: 0; /* レイヤー背景 */
-}
-
-/* 文字の可読性を上げる薄いビネット */
-.game-root::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(ellipse at center, rgba(0,0,0,.10) 0%, rgba(0,0,0,.25) 65%, rgba(0,0,0,.35) 100%);
-  pointer-events: none;
-  z-index: 1;
+  flex: 1;
+  width: 100%;
+  min-height: clamp(540px, 68vh, 760px);
 }
 
 .game-container {
   position: relative;
-  height: 100vh;
-  display: grid;
-  grid-template-areas: 
-    "hud-left hud-center hud-right"
-    "seats seats seats"
-    "center-area center-area center-area"
-    "player-hand player-hand player-hand";
-  grid-template-rows: 60px 120px 1fr 130px;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: 12px;
-  padding: 12px;
-  z-index: 2;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 2vw, 28px);
+  padding: clamp(16px, 3vw, 32px);
 }
 
-.seats-container {
-  grid-area: seats;
-  position: relative;
-  width: 100%;
-  height: 100%;
-  z-index: 10; /* レイヤー座席 */
+.ellipse-table__center {
+  position: absolute;
+  top: 46%;
+  left: 50%;
+  transform: translate(-50%, -58%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(32px, 6vw, 96px);
+  pointer-events: none;
+}
+
+.ellipse-table__field,
+.ellipse-table__grave {
+  display: grid;
+  place-items: center;
+  pointer-events: none;
+}
+
+.ellipse-table__grave {
+  opacity: 0.9;
+}
+
+.ellipse-table__hand {
+  pointer-events: none;
+}
+
+.ellipse-table__hand .hand {
+  pointer-events: auto;
 }
 
 /* HUD（上部の情報帯） */

--- a/apps/hub/app/globals.css
+++ b/apps/hub/app/globals.css
@@ -1493,79 +1493,66 @@ body[data-bg="battle"]::before {
 
 /* レイヤー順序を固定 */
 #oval-inner { position: absolute; inset: 0; z-index: 20; }
-#seats { 
-  position: absolute; 
-  top: 0; 
-  left: 0; 
-  right: 0; 
-  bottom: 140px; /* 手札エリアを避けるため下部マージンを設定 */
-  z-index: 15; 
-  pointer-events: none; 
+#seats {
+  position: absolute;
+  inset: 0;
+  bottom: clamp(140px, 18vh, 220px);
+  z-index: 15;
+  pointer-events: none;
 }
-#hand-dock { 
-  position: absolute; 
-  left: 0; 
-  right: 0; 
+#hand-dock {
+  position: absolute;
+  left: 0;
+  right: 0;
   bottom: calc(12px + env(safe-area-inset-bottom, 0));
-  z-index: 30; 
-  display: flex; 
-  flex-direction: column; 
-  align-items: center; 
-  gap: 0.5rem; 
-  min-height: 120px; /* 手札エリアの最小高さを確保 */
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 120px;
 }
 
-/* 場と墓地（内側楕円の内側に収める） */
-#oval-inner {
-  display: grid; 
-  place-items: center;
-  transform: translateY(-60px); /* 場全体を上に移動 */
-}
-
+/* 中央の場レイアウト */
 #field {
-  width: min(22vw, 300px);
+  width: min(20vw, 260px);
   aspect-ratio: 3/4;
-  display: grid; 
+  display: grid;
   place-items: center;
 }
 
 #grave {
-  position: absolute;
-  right: calc(50% - min(24vw, 320px));
-  top: 50%;
-  transform: translateY(-50%);
-  width: min(12vw, 160px);
+  width: min(11vw, 150px);
   aspect-ratio: 3/4;
-  display: grid; 
+  display: grid;
   place-items: center;
-  opacity: 0.95;
 }
 
 /* 座席ボックス */
 #seats .seat {
   position: absolute;
-  width: clamp(180px, 18vw, 240px);
-  height: clamp(90px, 9vw, 130px);
+  width: clamp(160px, 16vw, 220px);
   transform: translate(-50%, -50%);
-  pointer-events: auto;
+  pointer-events: none;
 }
 
 #seats .seat .content {
-  background: rgba(0, 0, 0, 0.28);
-  border: 1.5px solid rgba(255, 255, 255, 0.18);
-  border-radius: 14px;
-  padding: 0.5rem 0.7rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.5rem;
   color: #fff;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.75);
 }
 
 /* 5/6人で軽く縮小して重なり回避 */
-#seats.players-5 .seat { transform: translate(-50%, -50%) scale(0.9); }
-#seats.players-6 .seat { transform: translate(-50%, -50%) scale(0.86); }
+#seats.players-5 .seat { transform: translate(-50%, -50%) scale(0.92); }
+#seats.players-6 .seat { transform: translate(-50%, -50%) scale(0.88); }
 
 /* 手番ハイライト（枠を光らせる） */
 #seats .seat[data-active="true"] .content {
-  box-shadow: 0 0 0 2px #ffe7a1, 0 0 16px #ffd15c, 0 0 36px rgba(255, 178, 0, 0.55), 0 6px 18px rgba(0, 0, 0, 0.35);
+  text-shadow: 0 0 14px rgba(255, 190, 59, 0.9), 0 2px 8px rgba(0, 0, 0, 0.9);
 }
 
 /* 手札ドック（下辺中央） */
@@ -1574,25 +1561,22 @@ body[data-bg="battle"]::before {
   font-size: clamp(14px, 1.2vw, 18px);
   padding: 0.2rem 0.6rem;
   color: #f5efe4;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.85);
 }
 
 #hand-dock .hand {
-  display: flex; 
+  display: flex;
   gap: 0.5rem;
   padding: 0.4rem 0.6rem;
-  background: rgba(0, 0, 0, 0.22);
-  border: 1.5px solid rgba(255, 255, 255, 0.18);
   border-radius: 14px;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(4px);
+  backdrop-filter: none;
 }
 
 /* 画面幅が狭い時は全体的に軸を小さく */
 @media (max-width: 640px) {
-  #seats .seat { width: 42vw; height: 22vw; }
-  #field { width: 40vw; }
-  #grave { width: 22vw; right: calc(50% - 44vw); }
+  #seats .seat { width: 42vw; }
+  #field { width: 38vw; }
+  #grave { width: 20vw; }
 }
 
 /* ルーム情報表示 */

--- a/apps/hub/components/ui/EllipseTable.tsx
+++ b/apps/hub/components/ui/EllipseTable.tsx
@@ -58,11 +58,13 @@ export function EllipseTable({ state, config, currentPlayerIndex, onCardClick, c
     };
   }, [config.players, mySeatIndex]);
 
+  const rootClassName = ['ellipse-table', className].filter(Boolean).join(' ');
+
   return (
-    <>
-      {/* 内側楕円：場と墓地 */}
-      <section id="oval-inner" className="layer-field panel-soft">
-        <div id="field" aria-label="場のカード">
+    <div className={rootClassName}>
+      {/* 中央の場と墓地 */}
+      <div className="ellipse-table__center">
+        <div id="field" className="ellipse-table__field" aria-label="場のカード">
           {state.fieldCard !== null ? (
             <div className="card current-card">
               <div className="card-number">{state.fieldCard}</div>
@@ -80,20 +82,20 @@ export function EllipseTable({ state, config, currentPlayerIndex, onCardClick, c
             </div>
           )}
         </div>
-        <div id="grave" aria-label="墓地">
+        <div id="grave" className="ellipse-table__grave" aria-label="墓地">
           {state.sharedGraveyard.length > 0 && (
             <div className="graveyard-card">
               {state.sharedGraveyard[state.sharedGraveyard.length - 1]}
             </div>
           )}
         </div>
-      </section>
+      </div>
 
       {/* 楕円座席（外枠と内枠の間の帯） */}
       <section id="seats" className={`players-${config.players}`}>
         {state.players.map((player, i) => {
           const isTurn = i === currentPlayerIndex;
-          
+
           return (
             <div
               key={i}
@@ -134,7 +136,7 @@ export function EllipseTable({ state, config, currentPlayerIndex, onCardClick, c
       </section>
 
       {/* 自分の手札と名前（下辺） */}
-      <section id="hand-dock" aria-label="自分の手札">
+      <section id="hand-dock" className="ellipse-table__hand" aria-label="自分の手札">
         <div className="me-name">{getPlayerName(mySeatIndex)}</div>
         <div className="hand">
           {state.players[mySeatIndex]?.hand.map((card, index) => {
@@ -181,6 +183,6 @@ export function EllipseTable({ state, config, currentPlayerIndex, onCardClick, c
           })}
         </div>
       </section>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the EllipseTable content in a single container so the field, seats, and hand sit directly on the background
- restyle the CPU and friend battle layouts to remove the extra panel layers and rely on the background art
- refresh seat and hand styling to keep circular placement legible without overlapping

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69070c3efbbc832fa01cfa534daa56d0