### PR TITLE
Fix ESLint configuration and clean up friend game snapshot typing

### DIFF
--- a/apps/hub/.eslintrc.json
+++ b/apps/hub/.eslintrc.json
@@ -1,23 +1,17 @@
 {
-  "extends": ["next/core-web-vitals"],
-  "rules": {
-    // TEST: forbid numeric-only fetch URL usage that caused 404s like fetch("123456")
-    "no-restricted-syntax": [
-      "error",
-      {
-        "selector": "CallExpression[callee.name='fetch'] Literal[value]",
-        "message": "Do not call fetch() with a numeric-only path. Use apiJson('/api/...') via lib/api instead."
-      }
-    ]
-  }
-}
-{
   "root": true,
   "extends": ["next/core-web-vitals", "plugin:@typescript-eslint/recommended"],
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
   "ignorePatterns": ["**/.next/**", "**/node_modules/**"],
   "rules": {
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "CallExpression[callee.name='fetch'] Literal[value=/^\\d+$/u]",
+        "message": "Do not call fetch() with a numeric-only path. Use apiJson('/api/...') via lib/api instead."
+      }
+    ],
     "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-unused-vars": [
       "warn",

--- a/apps/hub/app/api/health/env/route.ts
+++ b/apps/hub/app/api/health/env/route.ts
@@ -1,8 +1,10 @@
 export const runtime = 'nodejs';
 
+type GlobalWithEdgeRuntime = typeof globalThis & { EdgeRuntime?: unknown };
+
 function getRuntime() {
-  // @ts-ignore
-  return typeof (globalThis as any).EdgeRuntime !== 'undefined' ? 'edge' : 'node';
+  const edgeAwareGlobal = globalThis as GlobalWithEdgeRuntime;
+  return typeof edgeAwareGlobal.EdgeRuntime !== 'undefined' ? 'edge' : 'node';
 }
 
 export async function GET(req: Request) {


### PR DESCRIPTION
## Summary
- consolidate the hub ESLint config into valid JSON and scope the fetch restriction to numeric-only literals
- replace the health env runtime guard's ts-ignore with a typed helper
- extend the friend game snapshot type so rng state can be stored without ts-ignore casts

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_69074b33b758832f8226893dae31017d