### PR TITLE
processFinalTrick の同値最高カード時ペナルティ対象を1人に修正

### DIFF
--- a/games/cucumber5/rules.ts
+++ b/games/cucumber5/rules.ts
@@ -154,26 +154,25 @@ export class Cucumber5Rules {
       return { cucumberAwards: [], hasOne: false };
     }
 
-    // Find maximum card - FIXED: Use spread operator correctly
+    // Find maximum card number
     const maxCardNumber = Math.max(...finalCards.map(card => card.number));
     const hasOne = finalCards.some(card => card.number === 1);
-    
-    // Get losers (players with max card)
-    const losers = trickCards.filter(tc => tc.card.number === maxCardNumber);
-    
-    const cucumberAwards = losers.map(loser => {
-      let cucumbers = this.getCucumberCount(maxCardNumber);
-      
-      // Double cucumbers if someone played a 1
-      if (hasOne) {
-        cucumbers *= 2;
-      }
-      
-      return {
-        player: loser.player,
-        cucumbers
-      };
-    });
+
+    // If multiple players have max card, last one is penalized
+    const maxCardPlayers = trickCards.filter(tc => tc.card.number === maxCardNumber);
+    const loser = maxCardPlayers[maxCardPlayers.length - 1];
+
+    let cucumbers = this.getCucumberCount(maxCardNumber);
+
+    // Double cucumbers if someone played a 1
+    if (hasOne) {
+      cucumbers *= 2;
+    }
+
+    const cucumberAwards = [{
+      player: loser.player,
+      cucumbers
+    }];
 
     return { cucumberAwards, hasOne };
   }


### PR DESCRIPTION
### Motivation
- 最終トリックで `processFinalTrick` が最高値カードを出した全員にペナルティを付与しており、ルール（同値最高は最後に出した1人のみがペナルティ）に反していたため修正。

### Description
- `finalCards` から `maxCardNumber` を算出し、`trickCards` をフィルタして最高カードを出したプレイヤー群を `maxCardPlayers` として抽出しました。 
- `maxCardPlayers` の配列末尾の要素を `loser` として選び、その1人だけに対してきゅうり付与を行うよう変更しました。 
- 既存の最終トリック固有ロジック（全員が1の特例、1が含まれるときの2倍ルール）は維持しています。 

### Testing
- `pnpm --filter @five-cucumber/game-cucumber5 type-check` を実行しましたが、ワークスペースの型依存関係未解決や既存の型エラーにより失敗し、失敗は今回の変更によるものではありませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d3774803c832f8f010bf5f49fcff9)