### PR TITLE
fix: game-core のデッキ枚数を 105 枚に統一

### DIFF
--- a/apps/hub/lib/game-core/rules.ts
+++ b/apps/hub/lib/game-core/rules.ts
@@ -2,6 +2,10 @@
 
 import { GameConfig, GameState, Move } from './types';
 
+const MIN_CARD_NUMBER = 1;
+const MAX_CARD_NUMBER = 15;
+const CARDS_PER_NUMBER = 7;
+
 export function getCucumberCount(cardNumber: number): number {
   if (cardNumber >= 2 && cardNumber <= 5) return 1;
   if (cardNumber >= 6 && cardNumber <= 9) return 2;
@@ -81,8 +85,8 @@ export function getGameOverPlayers(state: GameState, config: GameConfig): number
 // デッキを生成
 export function createDeck(): number[] {
   const deck: number[] = [];
-  for (let num = 1; num <= 15; num++) {
-    for (let i = 0; i < 4; i++) {
+  for (let num = MIN_CARD_NUMBER; num <= MAX_CARD_NUMBER; num++) {
+    for (let i = 0; i < CARDS_PER_NUMBER; i++) {
       deck.push(num);
     }
   }
@@ -109,9 +113,9 @@ export function dealCards(deck: number[], players: number, cardsPerPlayer: numbe
 
 // カード枚数カウントを初期化
 export function initializeCardCounts(): number[] {
-  const counts = new Array(16).fill(0); // 0は未使用
-  for (let i = 1; i <= 15; i++) {
-    counts[i] = 4;
+  const counts = new Array(MAX_CARD_NUMBER + 1).fill(0); // 0は未使用
+  for (let i = MIN_CARD_NUMBER; i <= MAX_CARD_NUMBER; i++) {
+    counts[i] = CARDS_PER_NUMBER;
   }
   return counts;
 }
@@ -120,7 +124,7 @@ export function initializeCardCounts(): number[] {
 export function updateCardCounts(counts: number[], playedCards: number[]): number[] {
   const newCounts = [...counts];
   for (const card of playedCards) {
-    if (card >= 1 && card <= 15) {
+    if (card >= MIN_CARD_NUMBER && card <= MAX_CARD_NUMBER) {
       newCounts[card] = Math.max(0, newCounts[card] - 1);
     }
   }
@@ -130,7 +134,7 @@ export function updateCardCounts(counts: number[], playedCards: number[]): numbe
 // 残りカードを推定
 export function estimateRemainingCards(counts: number[]): number[] {
   const remaining: number[] = [];
-  for (let i = 1; i <= 15; i++) {
+  for (let i = MIN_CARD_NUMBER; i <= MAX_CARD_NUMBER; i++) {
     for (let j = 0; j < counts[i]; j++) {
       remaining.push(i);
     }


### PR DESCRIPTION
### Motivation
- `apps/hub/lib/game-core/rules.ts` が `CARDS_PER_NUMBER = 4` 相当の60枚デッキを扱っており、`games/cucumber5/rules.ts` の 7枚×15種=105枚実装と矛盾していたため、ゲーム開始時にカード不足が発生していた。 
- ルール実装間でカード総数とカウントロジックを揃え、`game-core` 経由で開始するゲームでも正しい枚数で動作するようにするための修正を行った。 

### Description
- `apps/hub/lib/game-core/rules.ts` に定数を追加して `MIN_CARD_NUMBER`, `MAX_CARD_NUMBER`, `CARDS_PER_NUMBER = 7` を導入した。 
- `createDeck` を定数参照に置き換えて 1〜15 の各数字を `CARDS_PER_NUMBER` 回生成するように変更した（合計105枚）。 
- `initializeCardCounts` の配列サイズと初期値、ならびに `updateCardCounts` と `estimateRemainingCards` のカード範囲チェックを定数化してハードコードされた `4` や `16` 前提を撤去した。 
- 変更は `apps/hub/lib/game-core/rules.ts` のみに加え、`games/cucumber5/rules.ts` のロジックに合わせた整合性を確保している。 

### Testing
- 型チェックとして `pnpm --filter @five-cucumber/hub type-check` を実行しエラーなしで成功した。 
- Python スクリプトで `MIN_CARD_NUMBER`/`MAX_CARD_NUMBER`/`CARDS_PER_NUMBER` からデッキ総枚数を計算して `105` を確認する自動検証を実行し成功した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d38623c88832fa1f9d72496c81bce)