### PR TITLE
fix(game-core): エンジンの状態コピーを深くコピーに修正とデッキ枚数定数化

### DIFF
--- a/apps/hub/lib/game-core/engine.ts
+++ b/apps/hub/lib/game-core/engine.ts
@@ -16,6 +16,23 @@ import {
 } from './rules';
 import { ActionResult, GameConfig, GamePhase, GameState, GameView, Move } from './types';
 
+
+function cloneState(state: GameState): GameState {
+  return {
+    ...state,
+    players: state.players.map(player => ({
+      ...player,
+      hand: [...player.hand],
+      graveyard: [...player.graveyard]
+    })),
+    sharedGraveyard: [...state.sharedGraveyard],
+    trickCards: state.trickCards.map(trickCard => ({ ...trickCard })),
+    gameOverPlayers: [...state.gameOverPlayers],
+    remainingCards: [...state.remainingCards],
+    cardCounts: [...state.cardCounts]
+  };
+}
+
 export function createInitialState(config: GameConfig, rng: SeededRng): GameState {
   const deck = rng.shuffle(createDeck());
   const hands = dealCards(deck, config.players, config.initialCards);
@@ -117,7 +134,7 @@ export function applyMove(state: GameState, move: Move, config: GameConfig, rng:
 }
 
 export function endTrick(state: GameState, config: GameConfig, rng: SeededRng): ActionResult {
-  const newState = { ...state };
+  const newState = cloneState(state);
   
   // 勝者を決定
   const winner = determineTrickWinner(newState.trickCards);
@@ -140,7 +157,7 @@ export function endTrick(state: GameState, config: GameConfig, rng: SeededRng): 
 }
 
 export function finalRound(state: GameState, config: GameConfig, rng: SeededRng): ActionResult {
-  const newState = { ...state };
+  const newState = cloneState(state);
   
   // 最終トリックのペナルティを計算
   const { winner, penalty } = calculateFinalTrickPenalty(newState.trickCards, config);
@@ -162,7 +179,7 @@ export function finalRound(state: GameState, config: GameConfig, rng: SeededRng)
 }
 
 export function startNewRound(state: GameState, config: GameConfig, rng: SeededRng): ActionResult {
-  const newState = { ...state };
+  const newState = cloneState(state);
   
   // 新しいデッキを作成
   const deck = rng.shuffle(createDeck());

--- a/apps/hub/lib/game-core/rules.ts
+++ b/apps/hub/lib/game-core/rules.ts
@@ -2,6 +2,10 @@
 
 import { GameConfig, GameState, Move } from './types';
 
+const MIN_CARD_NUMBER = 1;
+const MAX_CARD_NUMBER = 15;
+const CARDS_PER_NUMBER = 7;
+
 export function getCucumberCount(cardNumber: number): number {
   if (cardNumber >= 2 && cardNumber <= 5) return 1;
   if (cardNumber >= 6 && cardNumber <= 9) return 2;
@@ -81,8 +85,8 @@ export function getGameOverPlayers(state: GameState, config: GameConfig): number
 // デッキを生成
 export function createDeck(): number[] {
   const deck: number[] = [];
-  for (let num = 1; num <= 15; num++) {
-    for (let i = 0; i < 4; i++) {
+  for (let num = MIN_CARD_NUMBER; num <= MAX_CARD_NUMBER; num++) {
+    for (let i = 0; i < CARDS_PER_NUMBER; i++) {
       deck.push(num);
     }
   }
@@ -109,9 +113,9 @@ export function dealCards(deck: number[], players: number, cardsPerPlayer: numbe
 
 // カード枚数カウントを初期化
 export function initializeCardCounts(): number[] {
-  const counts = new Array(16).fill(0); // 0は未使用
-  for (let i = 1; i <= 15; i++) {
-    counts[i] = 4;
+  const counts = new Array(MAX_CARD_NUMBER + 1).fill(0); // 0は未使用
+  for (let i = MIN_CARD_NUMBER; i <= MAX_CARD_NUMBER; i++) {
+    counts[i] = CARDS_PER_NUMBER;
   }
   return counts;
 }
@@ -120,7 +124,7 @@ export function initializeCardCounts(): number[] {
 export function updateCardCounts(counts: number[], playedCards: number[]): number[] {
   const newCounts = [...counts];
   for (const card of playedCards) {
-    if (card >= 1 && card <= 15) {
+    if (card >= MIN_CARD_NUMBER && card <= MAX_CARD_NUMBER) {
       newCounts[card] = Math.max(0, newCounts[card] - 1);
     }
   }
@@ -130,7 +134,7 @@ export function updateCardCounts(counts: number[], playedCards: number[]): numbe
 // 残りカードを推定
 export function estimateRemainingCards(counts: number[]): number[] {
   const remaining: number[] = [];
-  for (let i = 1; i <= 15; i++) {
+  for (let i = MIN_CARD_NUMBER; i <= MAX_CARD_NUMBER; i++) {
     for (let j = 0; j < counts[i]; j++) {
       remaining.push(i);
     }


### PR DESCRIPTION
### Motivation
- エンジン遷移で `...state` による浅いコピーのままだと `players` 配列が参照共有されたままになり、`players[winner].cucumbers += penalty` のようなミューテーションが元の state を破壊する問題を解消するため。
- ルール実装間でデッキ枚数やカードカウントロジックが不整合だったため、カード数を定数化して `7` 枚×1〜15 の合計 `105` 枚に統一するため。 

### Description
- `apps/hub/lib/game-core/engine.ts` に `cloneState(state: GameState): GameState` ヘルパーを追加し、`players`（各プレイヤーの `hand` / `graveyard` を含む）・`trickCards`・`sharedGraveyard`・`remainingCards`・`cardCounts`・`gameOverPlayers` を深くコピーする実装を追加しました。 
- `endTrick` / `finalRound` / `startNewRound` の `const newState = { ...state }` を `const newState = cloneState(state)` に置換して遷移中の入力 state 破壊を防止しました。 
- `applyMove` は既に各配列/プレイヤーを個別コピーして新しい state を組み立てているため方針と整合しており、そのまま維持しました。 
- `apps/hub/lib/game-core/rules.ts` に `MIN_CARD_NUMBER`, `MAX_CARD_NUMBER`, `CARDS_PER_NUMBER = 7` を導入し、`createDeck` / `initializeCardCounts` / `updateCardCounts` / `estimateRemainingCards` を定数参照に置換してデッキを 105 枚に統一しました。 

### Testing
- 型チェックとして `pnpm --filter @five-cucumber/hub type-check` を実行し、型エラーは発生しませんでした（成功）。
- 状態コピー箇所の検索で `...state` / `Object.assign({}, state)` を確認するために `rg -n "\.\.\.state|Object\.assign\(\{\}, state\)" apps/hub/lib/game-core/engine.ts` を実行し、残っているのは `applyMove` の意図した新規組み立てと `cloneState` 実装のみであることを確認しました（成功）。
- `rg -n "function cloneState|const newState = cloneState(state)" apps/hub/lib/game-core/engine.ts` を実行して置換箇所を検証しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d38623c88832fa1f9d72496c81bce)