### PR TITLE
CPU対戦ページに最小ゲームループを実装

### DIFF
--- a/apps/hub/app/cpu/settings/page.tsx
+++ b/apps/hub/app/cpu/settings/page.tsx
@@ -25,7 +25,11 @@ export default function CpuSettingsPage() {
 
   const handleStartGame = () => {
     if (isAllSettingsComplete) {
-      router.push('/play/cpu');
+      const query = new URLSearchParams({
+        players: String(settings.players),
+        difficulty: settings.difficulty
+      });
+      router.push(`/play/cpu?${query.toString()}`);
     }
   };
 

--- a/apps/hub/app/play/cpu/page.tsx
+++ b/apps/hub/app/play/cpu/page.tsx
@@ -1,62 +1,274 @@
 'use client';
 
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { applyMove, createInitialState } from '@/lib/game-core/engine';
+import { SeededRng } from '@/lib/game-core/rng';
+import { getCucumberCount, getLegalMoves, getPlayerName } from '@/lib/game-core/rules';
+import type { GameConfig, GameState } from '@/lib/game-core/types';
+import type { Cucumber5Card, Cucumber5Player, Cucumber5State } from '@five-cucumber/sdk';
+import { cpuManager } from 'games/cucumber5/cpu';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+const HUMAN_PLAYER_INDEX = 0;
+
+function toSdkCard(card: number): Cucumber5Card {
+  return { number: card, cucumbers: getCucumberCount(card) };
+}
+
+function toSdkState(state: GameState): Cucumber5State {
+  return {
+    players: state.players.map((player, index) => ({
+      id: `p-${index}`,
+      name: getPlayerName(index),
+      hand: player.hand.map(toSdkCard),
+      cucumbers: player.cucumbers,
+      graveyard: player.graveyard.map(toSdkCard),
+      isCPU: index !== HUMAN_PLAYER_INDEX
+    })),
+    currentPlayer: state.currentPlayer,
+    fieldCard: state.fieldCard === null ? null : toSdkCard(state.fieldCard),
+    sharedGraveyard: state.sharedGraveyard.map(toSdkCard),
+    round: state.currentRound,
+    trick: state.currentTrick,
+    trickCards: state.trickCards.map((entry) => ({
+      player: entry.player,
+      card: toSdkCard(entry.card)
+    })),
+    timeLeft: 0,
+    phase: state.phase === 'GameEnd' ? 'game_over' : 'playing',
+    turn: state.currentTrick,
+    data: {}
+  };
+}
 
 export default function PlayCpuPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [gameTime, setGameTime] = useState(0);
+  const [gameState, setGameState] = useState<GameState | null>(null);
+  const [config, setConfig] = useState<GameConfig | null>(null);
+  const [statusText, setStatusText] = useState('ゲームを初期化しています...');
+
+  const rngRef = useRef<SeededRng | null>(null);
+  const cpuTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const gameSettings = useMemo(() => {
+    const playersParam = Number(searchParams.get('players') || '4');
+    const players = Number.isInteger(playersParam) ? Math.min(6, Math.max(2, playersParam)) : 4;
+    const cpuLevelParam = searchParams.get('difficulty');
+    const cpuLevel = cpuLevelParam === 'easy' || cpuLevelParam === 'hard' || cpuLevelParam === 'normal'
+      ? cpuLevelParam
+      : 'normal';
+
+    return {
+      players,
+      cpuLevel
+    } as const;
+  }, [searchParams]);
 
   useEffect(() => {
     document.title = 'CPU対戦 | Five Cucumber';
-    
-    // ダミーのゲームタイマー
+
     const timer = setInterval(() => {
-      setGameTime(prev => prev + 1);
+      setGameTime((prev) => prev + 1);
     }, 1000);
 
-    return () => clearInterval(timer);
+    return () => {
+      clearInterval(timer);
+      if (cpuTimerRef.current) {
+        clearTimeout(cpuTimerRef.current);
+      }
+    };
   }, []);
+
+  useEffect(() => {
+    const nextConfig: GameConfig = {
+      players: gameSettings.players,
+      turnSeconds: null,
+      maxCucumbers: 5,
+      initialCards: 7,
+      cpuLevel: gameSettings.cpuLevel,
+      seed: Date.now()
+    };
+
+    const rng = new SeededRng(nextConfig.seed);
+    rngRef.current = rng;
+    setConfig(nextConfig);
+    setGameState(createInitialState(nextConfig, rng));
+    setStatusText('ゲーム開始。あなたの手札から1枚選んでください。');
+    setGameTime(0);
+  }, [gameSettings]);
+
+  useEffect(() => {
+    if (!gameState || !config || gameState.isGameOver) {
+      return;
+    }
+
+    if (gameState.currentPlayer === HUMAN_PLAYER_INDEX || gameState.phase !== 'AwaitMove') {
+      return;
+    }
+
+    const currentPlayer = gameState.currentPlayer;
+    setStatusText(`${getPlayerName(currentPlayer)} が考え中...`);
+
+    cpuTimerRef.current = setTimeout(() => {
+      setGameState((prev) => {
+        if (!prev || prev.currentPlayer === HUMAN_PLAYER_INDEX || prev.phase !== 'AwaitMove' || !rngRef.current) {
+          return prev;
+        }
+
+        const sdkState = toSdkState(prev);
+        const sdkPlayer = sdkState.players[prev.currentPlayer] as Cucumber5Player;
+        const cpuAction = cpuManager.getCPUAction(sdkPlayer, sdkState, config.cpuLevel);
+        const legalMoves = getLegalMoves(prev, prev.currentPlayer);
+        const selectedCard = cpuAction?.number ?? legalMoves[0];
+
+        const result = applyMove(prev, {
+          player: prev.currentPlayer,
+          card: selectedCard,
+          timestamp: Date.now()
+        }, config, rngRef.current);
+
+        if (!result.success) {
+          setStatusText(`CPUの行動に失敗しました: ${result.message ?? 'unknown error'}`);
+          return prev;
+        }
+
+        if (result.newState.isGameOver) {
+          setStatusText('ゲーム終了！結果を確認してください。');
+        } else if (result.newState.currentPlayer === HUMAN_PLAYER_INDEX) {
+          setStatusText('あなたのターンです。手札を選択してください。');
+        } else {
+          setStatusText(`${getPlayerName(result.newState.currentPlayer)} のターンです。`);
+        }
+
+        return result.newState;
+      });
+    }, cpuManager.getThinkingTime(config.cpuLevel));
+
+    return () => {
+      if (cpuTimerRef.current) {
+        clearTimeout(cpuTimerRef.current);
+      }
+    };
+  }, [config, gameState]);
+
+  const handlePlayCard = (card: number) => {
+    if (!gameState || !config || !rngRef.current) {
+      return;
+    }
+
+    if (gameState.currentPlayer !== HUMAN_PLAYER_INDEX || gameState.phase !== 'AwaitMove') {
+      return;
+    }
+
+    const result = applyMove(gameState, {
+      player: HUMAN_PLAYER_INDEX,
+      card,
+      timestamp: Date.now()
+    }, config, rngRef.current);
+
+    if (!result.success) {
+      setStatusText(`カードを出せません: ${result.message ?? 'illegal move'}`);
+      return;
+    }
+
+    if (result.newState.isGameOver) {
+      setStatusText('ゲーム終了！結果を確認してください。');
+    } else {
+      setStatusText(`${getPlayerName(result.newState.currentPlayer)} のターンです。`);
+    }
+
+    setGameState(result.newState);
+  };
 
   const handleEndGame = () => {
     router.push('/cpu/settings');
   };
 
+  const humanHand = gameState?.players[HUMAN_PLAYER_INDEX]?.hand ?? [];
+  const legalMoves = gameState ? getLegalMoves(gameState, HUMAN_PLAYER_INDEX) : [];
+
   return (
     <main className="min-h-screen w-full pt-20">
-      <div className="container mx-auto px-4">
+      <div className="container mx-auto px-4 pb-10">
         <div className="text-center">
-          <h1 className="text-3xl font-bold mb-8">CPU対戦</h1>
-          
-          <div className="bg-white rounded-lg border border-gray-200 p-8 max-w-md mx-auto">
-            <div className="mb-6">
-              <h2 className="text-xl font-semibold mb-4">ゲーム中...</h2>
-              <p className="text-gray-600 mb-4">
-                プレースホルダー画面です
-              </p>
-              <p className="text-sm text-gray-500">
-                経過時間: {gameTime}秒
-              </p>
+          <h1 className="text-3xl font-bold mb-4">CPU対戦</h1>
+          <p className="text-sm text-gray-600 mb-1">経過時間: {gameTime}秒</p>
+          <p className="text-sm text-gray-600 mb-6">{statusText}</p>
+
+          <div className="bg-white rounded-lg border border-gray-200 p-6 max-w-3xl mx-auto text-left space-y-4">
+            <div className="text-sm text-gray-700">
+              <div>ラウンド: {gameState?.currentRound ?? '-'}</div>
+              <div>トリック: {gameState?.currentTrick ?? '-'}</div>
+              <div>場札: {gameState?.fieldCard ?? 'なし'}</div>
+              <div>現在手番: {gameState ? getPlayerName(gameState.currentPlayer) : '-'}</div>
+              <div>設定: {gameSettings.players}人 / CPU {gameSettings.cpuLevel}</div>
             </div>
 
-            <div className="space-y-4">
-              <div className="bg-gray-50 p-4 rounded-md">
-                <h3 className="font-semibold mb-2">プレイヤー状況</h3>
-                <div className="space-y-2 text-sm">
-                  <div>あなた: きゅうり 2本</div>
-                  <div>CPU-A: きゅうり 1本</div>
-                  <div>CPU-B: きゅうり 3本</div>
-                  <div>CPU-C: きゅうり 1本</div>
-                </div>
+            <div className="rounded border p-3 bg-gray-50">
+              <h2 className="font-semibold mb-2">プレイヤー状況</h2>
+              <div className="space-y-1 text-sm">
+                {gameState?.players.map((player, idx) => (
+                  <div key={idx}>
+                    {getPlayerName(idx)}: きゅうり {player.cucumbers}本 / 手札 {player.hand.length}枚
+                  </div>
+                ))}
               </div>
-
-              <button
-                onClick={handleEndGame}
-                className="w-full py-3 bg-red-600 text-white rounded-md hover:bg-red-700 transition-colors"
-              >
-                対戦終了
-              </button>
             </div>
+
+            <div className="rounded border p-3">
+              <h2 className="font-semibold mb-2">このトリックで出たカード</h2>
+              <div className="text-sm text-gray-700">
+                {gameState?.trickCards.length
+                  ? gameState.trickCards.map((entry) => `${getPlayerName(entry.player)}:${entry.card}`).join(' / ')
+                  : 'まだ出ていません'}
+              </div>
+            </div>
+
+            <div className="rounded border p-3">
+              <h2 className="font-semibold mb-2">あなたの手札（クリックして出す）</h2>
+              <div className="flex flex-wrap gap-2">
+                {humanHand.map((card, idx) => {
+                  const canPlay = gameState?.currentPlayer === HUMAN_PLAYER_INDEX && legalMoves.includes(card);
+
+                  return (
+                    <button
+                      key={`${card}-${idx}`}
+                      type="button"
+                      onClick={() => handlePlayCard(card)}
+                      disabled={!canPlay || Boolean(gameState?.isGameOver)}
+                      className={`px-3 py-2 rounded border text-sm ${
+                        canPlay ? 'bg-blue-600 text-white border-blue-600' : 'bg-gray-100 text-gray-400 border-gray-300'
+                      }`}
+                    >
+                      {card} ({getCucumberCount(card)}🥒)
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {gameState?.isGameOver && (
+              <div className="rounded border border-green-300 bg-green-50 p-3">
+                <h2 className="font-semibold mb-2">ゲーム結果</h2>
+                <ul className="text-sm space-y-1">
+                  {gameState.players
+                    .map((player, idx) => ({ idx, cucumbers: player.cucumbers }))
+                    .sort((a, b) => a.cucumbers - b.cucumbers)
+                    .map((row) => (
+                      <li key={row.idx}>{getPlayerName(row.idx)}: {row.cucumbers}本</li>
+                    ))}
+                </ul>
+              </div>
+            )}
+
+            <button
+              onClick={handleEndGame}
+              className="w-full py-3 bg-red-600 text-white rounded-md hover:bg-red-700 transition-colors"
+            >
+              対戦終了
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- プレースホルダーだった CPU 対戦ページを実際のエンジン接続で動く最小限のゲームループに置き換え、エンジンとの結合と1ゲーム完走を確認できるようにするため。 
- 設定画面の値がプレイ画面に引き継がれていなかったため、対戦人数と難易度を渡す仕組みを追加するため。 
- UI は簡素でも良いので「手札表示 → クリックで出す → CPU 自動応答 → トリック完了／ゲーム終了」が動作することを優先するため。 

### Description
- `apps/hub/app/play/cpu/page.tsx` を差し替え、`game-core/engine` の `createInitialState` と `applyMove`、および `rng` を使ってデッキ生成・配布と状態遷移を React 状態で管理する実装を追加しました。 
- CPU の手選択に既存の `games/cucumber5/cpu.ts` の `cpuManager` を利用するため、`GameState` を SDK 互換の `Cucumber5State` に変換して `cpuManager.getCPUAction` を呼ぶ橋渡しを実装しました。 
- 設定画面 `apps/hub/app/cpu/settings/page.tsx` から `players` と `difficulty` をクエリに載せて `/play/cpu` に遷移するよう変更し、プレイ画面でクエリを読み取ってデフォルトは `4人 / normal` とするようにしました。 
- 最小 UI を実装し、人間プレイヤーの手札表示と合法手クリック、CPU の思考タイマー／自動出し、トリック内の出札表示、ラウンド／トリック情報、ゲーム終了時の結果表示を追加しました。 

### Testing
- 型チェックは `pnpm --filter @five-cucumber/hub type-check` を実行して成功しました. 
- リントは `pnpm --filter @five-cucumber/hub lint` を実行して成功し、既存ファイル由来の警告（`lib/realtime-ably.ts` の未使用変数）が出ていますがコマンドは通りました. 
- 開発サーバーを起動して Playwright スクリプトで `http://127.0.0.1:3000/play/cpu?players=4&difficulty=normal` を読み込み、ページのスクリーンショット取得に成功しましたが、開発環境の認証導線により一部アクセスで `/setup` にリダイレクトされる挙動が確認されています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997c8a2a6e8832faa01320b17a38262)