### PR TITLE
Ablyトークン認証強化とユーザー別チャンネル分離

### DIFF
--- a/apps/hub/lib/clientAuth.ts
+++ b/apps/hub/lib/clientAuth.ts
@@ -9,3 +9,13 @@ export async function getClientAuthToken(): Promise<string | null> {
   const credential = await signInAnonymously(auth);
   return credential.user.getIdToken();
 }
+
+
+export async function getClientAuthUid(): Promise<string> {
+  if (auth.currentUser) {
+    return auth.currentUser.uid;
+  }
+
+  const credential = await signInAnonymously(auth);
+  return credential.user.uid;
+}

--- a/apps/hub/lib/realtime-ably.ts
+++ b/apps/hub/lib/realtime-ably.ts
@@ -1,5 +1,4 @@
 import Ably from 'ably/promises';
-import type { Types } from 'ably';
 import type { RealtimeAdapter } from './realtime-adapter';
 
 let restInstance: InstanceType<typeof Ably.Rest> | null = null;
@@ -20,10 +19,9 @@ export const ablyAdapter: RealtimeAdapter = {
   async publishToUser(roomId, uid, event, payload) {
     try {
       const rest = getRest();
-      const channel = rest.channels.get(`room-${roomId}`);
-      console.log('[Ably] Publishing to room (user-targeted payload):', roomId, uid, event);
-      const data: Record<string, unknown> = { ...payload, __targetUid: uid };
-      await channel.publish(event, data);
+      const channel = rest.channels.get(`room-${roomId}-user-${uid}`);
+      console.log('[Ably] Publishing to user channel:', roomId, uid, event);
+      await channel.publish(event, payload);
     } catch (error) {
       console.error('[Ably] Failed to publish to user via room channel:', error);
       throw error;
@@ -32,26 +30,25 @@ export const ablyAdapter: RealtimeAdapter = {
   async publishToMany(roomId, uids, event, build) {
     try {
       const rest = getRest();
-      const channel = rest.channels.get(`room-${roomId}`);
-      console.log('[Ably] Publishing to room for many users:', roomId, uids.length, event);
+      console.log('[Ably] Publishing to many user channels:', roomId, uids.length, event);
 
       if (uids.length === 0) {
         console.log('[Ably] No users to publish to, skipping');
         return;
       }
 
-      const messages = uids.map((uid) => ({
-        name: event,
-        data: { ...build(uid), __targetUid: uid },
-      }));
-      await channel.publish(messages);
+      await Promise.all(
+        uids.map((uid) => {
+          const channel = rest.channels.get(`room-${roomId}-user-${uid}`);
+          return channel.publish(event, build(uid));
+        })
+      );
 
-      console.log('[Ably] Successfully published to room channel');
+      console.log('[Ably] Successfully published to user channels');
     } catch (error) {
       console.error('[Ably] Failed to publish to room channel:', error);
       console.warn('[Ably] Some publishes may have failed, but continuing...');
     }
   },
 };
-
 

--- a/apps/hub/lib/realtime-client.ts
+++ b/apps/hub/lib/realtime-client.ts
@@ -7,12 +7,12 @@ type AblyTokenResponse =
   | { ok: true; token: Types.TokenRequest }
   | { ok: false; reason: string; message?: string };
 
-export function makeClient(uid: string, channelName: string): Types.RealtimePromise {
-  console.log('[Ably] Creating client for user:', uid, 'channel:', channelName);
+export function makeClient(clientId: string, channelName: string): Types.RealtimePromise {
+  console.log('[Ably] Creating client for user:', clientId, 'channel:', channelName);
 
   const authCallback: NonNullable<Types.AuthOptions['authCallback']> = async (_tokenParams, callback) => {
     try {
-      const qs = new URLSearchParams({ uid, channel: channelName, rnd: Date.now().toString() }).toString();
+      const qs = new URLSearchParams({ channel: channelName, rnd: Date.now().toString() }).toString();
       const data = await apiJson<AblyTokenResponse>(`/api/ably/token?${qs}`);
       if (!data.ok) {
         throw new Error(data.reason);
@@ -28,12 +28,11 @@ export function makeClient(uid: string, channelName: string): Types.RealtimeProm
   const clientOptions: Types.ClientOptions = {
     authUrl: `/api/ably/token`,
     authParams: {
-      uid,
       channel: channelName,
       rnd: Date.now().toString(),
     },
     authCallback,
-    clientId: uid,
+    clientId,
     autoConnect: true,
     transportParams: {
       heartbeatInterval: 30000,


### PR DESCRIPTION
### Motivation
- 修正はプレイヤー固有情報が同一チャネルで配信され閲覧可能だった問題と、Ablyトークン発行エンドポイントが認証無しで任意チャネルのトークンを発行できていたセキュリティリスクに対処するためです。
- サーバー側で見せて良い情報を確実に分離できるよう、チャネル設計とトークン発行ポリシーを見直します。

### Description
- `apps/hub/app/api/ably/token/route.ts` を強化し `verifyAuth` を必須化して未認証は `401` を返すようにし、要求チャネルを厳格にパースして `room-{roomId}-user-{participant}` 形式のみ許可し、KV（`friend:room:{roomId}`）で参加確認が取れないと `403` を返すようにしました。トークンの `clientId` はリクエスト値ではなく `auth.uid` を使用し、capability は要求された単一チャネルに限定します。
- `apps/hub/lib/realtime-ably.ts` を変更して共有 `room-{roomId}` チャネルへ全員分を流す手法を廃止し、ユーザー個別チャネル `room-{roomId}-user-{uid}` へ配信するように `publishToUser` / `publishToMany` を更新して `__targetUid` へのクライアント側フィルタ依存をやめました。
- クライアント側での接続ロジックを `apps/hub/lib/realtime-client.ts` / `apps/hub/lib/clientAuth.ts` / `apps/hub/app/friend/room/[roomId]/page.tsx` にて調整し、匿名認証の Firebase `uid` を Ably `clientId` として使い、購読チャネルを `room-{roomId}-user-{nickname}` に変更しました（`getClientAuthUid()` を追加して UID を取得します）。
- 変更対象ファイル: `apps/hub/app/api/ably/token/route.ts`, `apps/hub/lib/realtime-ably.ts`, `apps/hub/lib/realtime-client.ts`, `apps/hub/lib/clientAuth.ts`, `apps/hub/app/friend/room/[roomId]/page.tsx`。

### Testing
- Lint を実行して該当ファイルに対する `eslint` チェックを実行し `pnpm --filter @five-cucumber/hub exec eslint app/api/ably/token/route.ts lib/realtime-ably.ts lib/realtime-client.ts app/friend/room/[roomId]/page.tsx lib/clientAuth.ts` は成功しました。
- 型チェックで `pnpm --filter @five-cucumber/hub type-check` を実行しましたが、既存の別領域（React/JSX の型不整合）に起因する大量の型エラーにより失敗し、今回の変更箇所が直接の原因ではないことを確認しています。
- 以上の自動チェック結果に基づき、Ablyトークン発行の未認証/未参加取得に対する保護とサーバー側の配信分離は実装済みです。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699857ba6834832f8b96082886073ee6)