### PR TITLE
Firestoreルールの重複解消と /matches・/gameSessions のアクセス制御強化

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,28 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function isParticipant() {
+      return isSignedIn() && (
+        request.auth.uid in resource.data.players ||
+        request.auth.uid in resource.data.members ||
+        request.auth.uid in resource.data.participants
+      );
+    }
+
+    function isOwner() {
+      return isSignedIn() && (
+        request.auth.uid == resource.data.ownerId ||
+        request.auth.uid == resource.data.createdBy ||
+        request.auth.uid == resource.data.hostId
+      );
+    }
+
     match /rooms/{roomId} {
-      allow read: if request.auth != null;
+      allow read: if isSignedIn();
       allow write: if false;
 
       match /games/{gameId} {
@@ -12,37 +32,35 @@ service cloud.firestore {
         match /appliedOps/{opId} { allow read, write: if false; }
 
         match /views/{uid} {
-          allow read: if request.auth != null && request.auth.uid == uid;
+          allow read: if isSignedIn() && request.auth.uid == uid;
           allow write: if false;
         }
       }
     }
-  }
-}
 
-rules_version = '2';
-service cloud.firestore {
-  match /databases/{database}/documents {
     // Matches collection
     match /matches/{matchId} {
-      allow read, write: if request.auth != null;
+      allow read: if isParticipant();
+      allow create: if isSignedIn();
+      allow update: if isParticipant();
+      allow delete: if isOwner();
     }
-    
+
     // User stats collection
     match /userStats/{userId} {
-      allow read: if request.auth != null;
-      allow write: if request.auth != null && request.auth.uid == userId;
+      allow read: if isSignedIn();
+      allow write: if isSignedIn() && request.auth.uid == userId;
     }
-    
+
     // Metrics collection (read-only for users)
     match /metrics/{document=**} {
-      allow read: if request.auth != null;
+      allow read: if isSignedIn();
       allow write: if false; // Only functions can write
     }
-    
+
     // Game sessions collection
     match /gameSessions/{sessionId} {
-      allow read, write: if request.auth != null;
+      allow read, write: if isParticipant();
     }
   }
 }


### PR DESCRIPTION
### Motivation
- `firestore.rules` に `service cloud.firestore` ブロックが重複しており一方が無視されるリスクを解消するため。 
- `/matches` と `/gameSessions` が認証済み全員に読み書きを許可しており、参加者ベースのアクセス制御にする必要があったため。 

### Description
- 2つに分かれていた `service cloud.firestore` ブロックを1つに統合して既存の `/rooms` 配下ルールをマージしました。 
- 共通ヘルパー関数として `isSignedIn()`, `isParticipant()`, `isOwner()` を追加し、参加者判定は `players`/`members`/`participants`、オーナー判定は `ownerId`/`createdBy`/`hostId` を候補として扱うようにしました。 
- `/matches/{matchId}` は `read`/`update` を参加者限定、`create` を認証済みユーザーに許可、`delete` はオーナーのみ許可するように変更しました。 
- `/gameSessions/{sessionId}` は `read`/`write` ともに参加者限定に変更し、`/userStats` と `/metrics` の既存ポリシーは維持しました。 

### Testing
- `rg` を使って関連コレクションや候補フィールド名（`matches`/`gameSessions`/`players`/`members`/`participants` 等）を確認し、コードベースに整合するフィールド候補を確認しました, 成功。 
- ルールファイルを表示して内容を確認するために `sed`/`nl` で `firestore.rules` を出力して意図した関数とマッチが含まれていることを確認しました, 成功。 
- `python` スニペットで `service cloud.firestore` の出現回数をカウントして `1` であることを確認しました, 成功。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998598c50a0832f9981926bbd4d19b7)