### PR TITLE
Fix race conditions in friend join/leave with KV-backed distributed lock

### DIFF
--- a/apps/hub/lib/lock.ts
+++ b/apps/hub/lib/lock.ts
@@ -1,0 +1,39 @@
+import { randomUUID } from 'crypto';
+import { kv } from './kv';
+
+type LockOptions = {
+  ttlMs?: number;
+  retry?: number;
+  retryDelayMs?: number;
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function withLock<T>(
+  key: string,
+  fn: () => Promise<T>,
+  { ttlMs = 5000, retry = 1, retryDelayMs = 100 }: LockOptions = {},
+): Promise<T> {
+  const lockKey = `lock:${key}`;
+  const token = randomUUID();
+
+  for (let attempt = 0; attempt <= retry; attempt += 1) {
+    const acquired = await kv.set(lockKey, token, { nx: true, px: ttlMs });
+    if (acquired) {
+      try {
+        return await fn();
+      } finally {
+        const currentToken = await kv.get<string>(lockKey);
+        if (currentToken === token) {
+          await kv.del(lockKey);
+        }
+      }
+    }
+
+    if (attempt < retry) {
+      await sleep(retryDelayMs);
+    }
+  }
+
+  throw new Error(`Could not acquire lock for key: ${key}`);
+}


### PR DESCRIPTION
### Motivation
- Prevent lost/incorrect seat updates when concurrent `join`/`leave` requests perform non-atomic read-modify-write against the KV-backed room object.

### Description
- Add `withLock` distributed-lock utility at `apps/hub/lib/lock.ts` that uses KV `SET NX PX` with a UUID token, retries, and token-checked release to avoid deleting another request's lock.
- Wrap friend `join` (`apps/hub/app/api/friend/join/route.ts`) read-modify-write flow inside `withLock` and return the same error responses (`not-found`, `locked`, `full`) when appropriate.
- Wrap friend `leave` (`apps/hub/app/api/friend/leave/route.ts`) read-modify-write flow inside `withLock` and move post-update publish logic to run after the locked update completes.
- Use retry options `{ retry: 2, retryDelayMs: 100 }` and default lock TTL `5000ms` to reduce transient lock failures and prevent deadlocks.

### Testing
- Ran linting with `pnpm --filter @five-cucumber/hub exec eslint app/api/friend/join/route.ts app/api/friend/leave/route.ts lib/lock.ts` which passed.
- Ran type-check with `pnpm --filter @five-cucumber/hub type-check`, which failed due to pre-existing React typing errors unrelated to the changes.
- Local commit created with message `Fix race conditions in friend join/leave with KV lock` (commit `b527440`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69985c227860832fadd14333fff83c38)