### PR TITLE
Add root-level Next.js error boundaries for hub app

### DIFF
--- a/apps/hub/app/error.tsx
+++ b/apps/hub/app/error.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect } from 'react';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <main
+      style={{
+        minHeight: '100vh',
+        display: 'grid',
+        placeItems: 'center',
+        padding: '24px',
+        textAlign: 'center',
+      }}
+    >
+      <div style={{ display: 'grid', gap: '12px', maxWidth: '420px' }}>
+        <h1 style={{ fontSize: '1.5rem', margin: 0 }}>予期しないエラーが発生しました</h1>
+        <p style={{ margin: 0, color: '#555' }}>
+          お手数ですが、再試行するかホームに戻ってください。
+        </p>
+        <div style={{ display: 'flex', justifyContent: 'center', gap: '8px', flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            onClick={() => reset()}
+            style={{ padding: '8px 14px', cursor: 'pointer' }}
+          >
+            再試行
+          </button>
+          <Link href="/" style={{ padding: '8px 14px', border: '1px solid #ccc', borderRadius: '4px' }}>
+            ホームに戻る
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/hub/app/global-error.tsx
+++ b/apps/hub/app/global-error.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="ja" data-theme="light">
+      <body>
+        <main
+          style={{
+            minHeight: '100vh',
+            display: 'grid',
+            placeItems: 'center',
+            padding: '24px',
+            textAlign: 'center',
+          }}
+        >
+          <div style={{ display: 'grid', gap: '12px', maxWidth: '420px' }}>
+            <h1 style={{ fontSize: '1.5rem', margin: 0 }}>重大なエラーが発生しました</h1>
+            <p style={{ margin: 0, color: '#555' }}>
+              いったんホームに戻るか、再試行してください。
+            </p>
+            <div style={{ display: 'flex', justifyContent: 'center', gap: '8px', flexWrap: 'wrap' }}>
+              <button
+                type="button"
+                onClick={() => reset()}
+                style={{ padding: '8px 14px', cursor: 'pointer' }}
+              >
+                再試行
+              </button>
+              <Link
+                href="/"
+                style={{ padding: '8px 14px', border: '1px solid #ccc', borderRadius: '4px' }}
+              >
+                ホームに戻る
+              </Link>
+            </div>
+          </div>
+        </main>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
### Motivation
- The root layout lacked React error boundaries, causing uncaught exceptions to render a blank page.
- Add App Router error boundaries to provide a user-facing fallback and recovery actions for both route-level and layout-level failures.

### Description
- Added `apps/hub/app/error.tsx` as an app-level Error Boundary client component that logs the error, shows a Japanese error message, exposes a `再試行` button that calls `reset()`, and a link back to `/`.
- Added `apps/hub/app/global-error.tsx` as a client component that renders a full document (`<html>`/`<body>`) for errors thrown inside `layout.tsx`, with the same logging, retry, and home link UX.
- Both files begin with the `'use client'` directive and contain compact inline styling for a simple fallback UI.

### Testing
- Verified both files exist using `test -f apps/hub/app/error.tsx && test -f apps/hub/app/global-error.tsx` and the check succeeded.
- Verified both files start with `'use client'` via `head -n 1` checks and the check succeeded.
- Ran linter with `pnpm --filter @five-cucumber/hub lint`, which completed successfully (one unrelated pre-existing warning was reported in another file).
- Started the dev server with `pnpm --filter @five-cucumber/hub dev -p 3100`, which launched successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69985df42994832fb61f06a57d12011c)