### PR TITLE
HTMLのlang属性をロケールに応じて動的化

### DIFF
--- a/apps/hub/app/layout.tsx
+++ b/apps/hub/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Header from "../components/Header";
 import Script from 'next/script';
+import { cookies, headers } from 'next/headers';
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -42,9 +43,25 @@ const COMMIT = (process.env.NEXT_PUBLIC_COMMIT_SHA || process.env.VERCEL_GIT_COM
 const BUILD_TIME = new Date().toISOString().replace(/\..+$/, 'Z');
 const RUNTIME = 'nodejs';
 
+function resolveLocale(): 'ja' | 'en' {
+  const languageFromCookie = cookies().get('language')?.value;
+  if (languageFromCookie === 'ja' || languageFromCookie === 'en') {
+    return languageFromCookie;
+  }
+
+  const acceptLanguage = headers().get('accept-language')?.toLowerCase() ?? '';
+  if (acceptLanguage.startsWith('en')) {
+    return 'en';
+  }
+
+  return 'ja';
+}
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const locale = resolveLocale();
+
   return (
-    <html lang="ja" data-theme="light">
+    <html lang={locale} data-theme="light">
       <body>
         <Script id="suppress-extension-noise" strategy="beforeInteractive">
           {`


### PR DESCRIPTION
### Motivation
- `apps/hub/app/layout.tsx` で `<html lang="ja">` が固定されており、i18n設定に関わらず常に日本語が宣言されていたため、ユーザーのロケールに応じて正しい `lang` を返す必要があった。 

### Description
- `next/headers` の `cookies` / `headers` を読み込む `resolveLocale()` を追加してロケールを判定する処理を実装した。 
- 判定優先順は `language` Cookie (`'ja'`/`'en'`) → `Accept-Language` ヘッダーで `en` を判定 → デフォルト `'ja'` である。 
- `<html lang="ja">` を `<html lang={locale}>` に置換してハードコードを除去した。 
- サーバー側でCookieを読む方針は既存のクライアント側 `setLanguage()` が `language` Cookie を設定している実装に整合する。 

### Testing
- 型チェックを実行して成功したことを確認した: `pnpm --filter @five-cucumber/hub type-check` (成功)。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69985f939bec832fada27ed7b0d7b415)