### PR TITLE
PR 17: ビルド・設定の整理（Next/Firebase/TS/ESLint/Redis）

### DIFF
--- a/apps/hub/lib/redisAvail.ts
+++ b/apps/hub/lib/redisAvail.ts
@@ -7,24 +7,8 @@ export async function isSharedStoreAvailable(): Promise<boolean> {
   // Vercel Redis（RESTスタイル）
   if (process.env.VERCEL_REDIS_URL && process.env.VERCEL_REDIS_TOKEN) return true;
 
-  // TCP Redis via REDIS_URL: node-redis で ping
-  if (process.env.REDIS_URL) {
-    const { createClient } = await import('redis');
-    try {
-      const c = createClient({ url: process.env.REDIS_URL });
-      c.on('error', () => {});
-      await c.connect();
-      await c.ping();
-      await c.quit();
-      return true;
-    } catch {
-      return false;
-    }
-  }
   return false;
 }
 
 // Backward compatibility export (if any old import remains)
 export const isRedisAvailable = isSharedStoreAvailable;
-
-

--- a/apps/hub/lib/roomsRedis.ts
+++ b/apps/hub/lib/roomsRedis.ts
@@ -35,25 +35,6 @@ export async function putRoomRedis(room: Room): Promise<void> {
   }
 }
 
-// TCP Redis (REDIS_URL) writer used when Vercel KV/REST is not configured
-export async function putRoomRedisTcp(room: Room): Promise<void> {
-  const url = process.env.REDIS_URL;
-  if (!url) {
-    throw new Error('REDIS_URL not configured');
-  }
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { createClient } = require('redis');
-    const client = createClient({ url, socket: { reconnectStrategy: () => 0, connectTimeout: 2000 } });
-    await client.connect();
-    await client.set(key(room.id), JSON.stringify(room));
-    await client.quit();
-  } catch (error) {
-    console.warn('[Redis TCP] Failed to save room:', error);
-    throw error;
-  }
-}
-
 export async function updateRoomRedis(roomId: string, patch: Partial<Room>): Promise<boolean> {
   if (!isRedisAvailable()) {
     console.log('[Redis] Vercel KV not available, skipping Redis update');

--- a/apps/hub/next.config.js
+++ b/apps/hub/next.config.js
@@ -7,11 +7,19 @@ const __dirname = path.dirname(__filename);
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: { externalDir: true },
   eslint: { ignoreDuringBuilds: true }, // ビルド時にlintで失敗させない
   transpilePackages: ['@five-cucumber/sdk', '@five-cucumber/ui', '@five-cucumber/metrics', '@five-cucumber/game-cucumber5'],
   images: {
-    domains: ['localhost'],
+    remotePatterns: [
+      {
+        protocol: 'http',
+        hostname: 'localhost',
+      },
+      {
+        protocol: 'https',
+        hostname: 'localhost',
+      },
+    ],
   },
   webpack: (config) => {
     config.resolve = config.resolve || {};

--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -13,7 +13,6 @@
     "clean": "rm -rf .next dist"
   },
   "dependencies": {
-    "redis": "^4.6.13",
     "@five-cucumber/metrics": "workspace:*",
     "@five-cucumber/sdk": "workspace:*",
     "@five-cucumber/ui": "workspace:*",

--- a/firebase.json
+++ b/firebase.json
@@ -13,17 +13,11 @@
     "rules": "database.rules.json"
   },
   "hosting": {
-    "public": "apps/hub/out",
+    "source": "apps/hub",
     "ignore": [
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
-    ],
-    "rewrites": [
-      {
-        "source": "**",
-        "destination": "/index.html"
-      }
     ]
   },
   "emulators": {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   },
   "devDependencies": {
     "@types/node": "^20.10.0",
-    "@typescript-eslint/eslint-plugin": "^6.13.0",
-    "@typescript-eslint/parser": "^6.13.0",
-    "eslint": "^8.54.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "eslint": "^8.57.0",
     "eslint-config-next": "^14.0.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-react": "^7.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       firebase:
         specifier: ^10.7.0
         version: 10.14.1
+      firebase-admin:
+        specifier: ^12.7.0
+        version: 12.7.0
       i18next:
         specifier: ^23.7.0
         version: 23.16.8

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "es6"],
+    "lib": [
+      "es2022",
+      "dom",
+      "dom.iterable"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -20,9 +24,15 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./apps/hub/*"],
-      "@packages/*": ["./packages/*"],
-      "@games/*": ["./games/*"]
+      "@/*": [
+        "./apps/hub/*"
+      ],
+      "@packages/*": [
+        "./packages/*"
+      ],
+      "@games/*": [
+        "./games/*"
+      ]
     }
   },
   "include": [


### PR DESCRIPTION
### Motivation
- Next.js の非推奨設定や画像設定、Firebase Hosting の静的SPA向け設定、古い TypeScript lib、未使用の Redis クライアント、及び ESLint のメジャーバージョン不一致を一括で解消してビルド/デプロイ互換性を改善するため。
- Vercel/KV を中心とする運用に合わせてコードパスと依存関係を整理するため。 

### Description
- `apps/hub/next.config.js` から `experimental.externalDir` を削除し、`images.domains` を `images.remotePatterns`（`localhost` の `http`/`https`）へ移行した。 
- `firebase.json` の Hosting 設定を静的 `public` + `index.html` の SPA 書き換えから `hosting.source: "apps/hub"` に変更して Next.js の App Router/API Routes と競合しない構成にした。 
- `tsconfig.json` の `lib` を `[

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699860821f04832f884537ff570afa76)