### PR TITLE
feat(hub): staged trick animations and winner highlight in CPU play

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/game.css
+++ b/apps/hub/app/cucumber/cpu/play/game.css
@@ -51,6 +51,45 @@
   pointer-events: none;
 }
 
+.trick-cards-queue {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: clamp(8px, 1.8vw, 16px);
+  min-height: calc(var(--ellipse-card-height) + 28px);
+}
+
+.trick-card-entry {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.trick-card-player {
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
+}
+
+.trick-card-entry.winner .card.current-card {
+  border-color: #ffd15c;
+  box-shadow: 0 0 0 2px rgba(255, 209, 92, 0.75), 0 0 22px rgba(255, 209, 92, 0.8);
+}
+
+.trick-winner-banner {
+  margin-top: 10px;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #fff;
+  background: rgba(255, 209, 92, 0.28);
+  border: 1px solid rgba(255, 209, 92, 0.7);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+}
+
 .ellipse-table__grave {
   opacity: 0.9;
 }
@@ -107,6 +146,21 @@
 /* カードアニメーション */
 .card-slide-to-field {
   animation: slideToField 0.3s ease-out forwards;
+}
+
+.card-play {
+  animation: card-appear 0.3s ease-out;
+}
+
+@keyframes card-appear {
+  from {
+    opacity: 0;
+    transform: translateY(20px) scale(0.8);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 .card-slide-to-graveyard {

--- a/apps/hub/components/ui/EllipseTable.tsx
+++ b/apps/hub/components/ui/EllipseTable.tsx
@@ -1,6 +1,6 @@
 // 楕円卓レイアウト用テーブルコンポーネント
 
-import { GameConfig, GameState } from '@/lib/game-core/types';
+import { GameConfig, GameState, Move } from '@/lib/game-core/types';
 import { layoutSeatsEllipse } from '@/lib/layoutEllipse';
 import { useEffect } from 'react';
 
@@ -15,9 +15,13 @@ interface EllipseTableProps {
   lockedCardId?: number | null; // ロックされたカードID
   names?: string[]; // 座席ごとの表示名（任意）
   mySeatIndex?: number; // 自分の座席インデックス（フレンド対戦用）
+  trickCards?: Move[];
+  latestPlayedCardKey?: string | null;
+  trickWinner?: number | null;
+  trickWinnerText?: string | null;
 }
 
-export function EllipseTable({ state, config, currentPlayerIndex, onCardClick, className = '', showAllHands = false, isSubmitting = false, lockedCardId = null, names, mySeatIndex = 0 }: EllipseTableProps) {
+export function EllipseTable({ state, config, currentPlayerIndex, onCardClick, className = '', showAllHands = false, isSubmitting = false, lockedCardId = null, names, mySeatIndex = 0, trickCards = [], latestPlayedCardKey = null, trickWinner = null, trickWinnerText = null }: EllipseTableProps) {
   const playerNames = ['あなた', 'CPU-A', 'CPU-B', 'CPU-C', 'CPU-D', 'CPU-E'];
   
   // デバッグログ（開発時のみ）
@@ -65,7 +69,38 @@ export function EllipseTable({ state, config, currentPlayerIndex, onCardClick, c
       {/* 中央の場と墓地 */}
       <div className="ellipse-table__center">
         <div id="field" className="ellipse-table__field" aria-label="場のカード">
-          {state.fieldCard !== null ? (
+          {trickCards.length > 0 ? (
+            <div className="trick-cards-queue" aria-live="polite">
+              {trickCards.map((trickCard) => {
+                const cardKey = `${trickCard.player}-${trickCard.timestamp}`;
+                const isLatestPlayed = latestPlayedCardKey === cardKey;
+                const isWinnerCard = trickWinner !== null && trickCard.player === trickWinner;
+
+                return (
+                  <div
+                    key={cardKey}
+                    className={[
+                      'trick-card-entry',
+                      isLatestPlayed ? 'card-play' : '',
+                      isWinnerCard ? 'winner' : ''
+                    ].filter(Boolean).join(' ')}
+                  >
+                    <div className="trick-card-player">{getPlayerName(trickCard.player)}</div>
+                    <div className="card current-card">
+                      <div className="card-number">{trickCard.card}</div>
+                      <div className="cucumber-icons">
+                        {trickCard.card >= 2 && trickCard.card <= 5 && '🥒'}
+                        {trickCard.card >= 6 && trickCard.card <= 9 && '🥒🥒'}
+                        {trickCard.card >= 10 && trickCard.card <= 11 && '🥒🥒🥒'}
+                        {trickCard.card >= 12 && trickCard.card <= 14 && '🥒🥒🥒🥒'}
+                        {trickCard.card === 15 && '🥒🥒🥒🥒🥒'}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : state.fieldCard !== null ? (
             <div className="card current-card">
               <div className="card-number">{state.fieldCard}</div>
               <div className="cucumber-icons">
@@ -81,6 +116,7 @@ export function EllipseTable({ state, config, currentPlayerIndex, onCardClick, c
               <div className="card-number">?</div>
             </div>
           )}
+          {trickWinnerText ? <div className="trick-winner-banner">{trickWinnerText}</div> : null}
         </div>
         <div id="grave" className="ellipse-table__grave" aria-label="墓地">
           {state.sharedGraveyard.length > 0 && (


### PR DESCRIPTION
### Motivation
- 場にカードが即時切り替わって誰が何を出したか分かりづらい表示を改善するため、カードプレイの可視化を導入した。 
- 各プレイヤーのカードを順番に表示して出目を追いやすくし、トリック解決時に結果を明示したい。 
- 3Dや複雑な演出は避けつつ、CSSトランジションで自然な見た目を実現する。 

### Description
- `apps/hub/app/cucumber/cpu/play/page.tsx` にトリック表示用のUI状態を追加し、`tableTrickCards` / `latestPlayedKey` / `trickWinner` / `trickWinnerText` を導入してプレイ中の中間表示を行うようにした。 
- `playMove` のフローを変更して `previewState` を先に描画し、`await delay(...)` による段階的表示（場表示 → 勝者バナー）を挟んでから実際の `newState` を反映するようにした。 
- CPUの待ち時間を短縮してカードが順次（ほぼ0.5〜1秒間隔）出る見え方になるよう `thinkingTime` を調整した。 
- `apps/hub/components/ui/EllipseTable.tsx` を拡張して `trickCards` / `latestPlayedCardKey` / `trickWinner` / `trickWinnerText` を受け取り、プレイヤー名付きのトリックカード一覧レンダリング、最新カードのエントリアニメーション、勝者ハイライトを追加した。 
- `apps/hub/app/cucumber/cpu/play/game.css` にシンプルな `card-appear` アニメーション、トリックカードの横並びレイアウト、勝者バナーや勝者カードの強調スタイルを追加した。 

### Testing
- 型チェックは `pnpm -C apps/hub type-check` を実行して成功した。 
- リントは `pnpm -C apps/hub lint` を実行して成功（既存の unrelated warning が `app/api/game/move/route.ts` に残るが本変更に影響なし）。 
- 開発サーバーを起動して `pnpm -C apps/hub dev -p 3000` により画面をビルド/表示確認した。 
- Playwright スクリプトで `http://127.0.0.1:3000/cucumber/cpu/play?...` にアクセスしてスクリーンショットを取得し、段階的なトリック表示と勝者バナーが表示される動作を確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699911c6265c832fad4adb16646c0746)