### PR TITLE
fix(hub): ensure home hero full-height and suppress middleware debug UI

### DIFF
--- a/apps/hub/app/home/page.tsx
+++ b/apps/hub/app/home/page.tsx
@@ -1,27 +1,18 @@
 "use client";
 
 import { useI18n } from "@/hooks/useI18n";
-import { apiRequest } from "@/lib/api";
 import { getNickname } from "@/lib/profile";
 import { useEffect, useState } from "react";
 import DesktopHero from "./_components/DesktopHero";
 
 export default function Home() {
-  const [gateStatus, setGateStatus] = useState<string>('');
   const [nickname, setNickname] = useState<string | null>(null);
   const { t } = useI18n();
 
   useEffect(() => {
     document.title = `${t("homeTitle")} | Five Cucumber`;
     setNickname(getNickname());
-    if (process.env.NODE_ENV === "development") {
-      apiRequest('/home', { method: 'HEAD', parseAs: 'none' })
-        .then((response) => {
-          const gateHeader = response.headers.get("x-profile-gate");
-          setGateStatus(gateHeader || "unknown");
-        })
-        .catch(() => setGateStatus("error"));
-    }
+
     const handleStorageChange = () => {
       setNickname(getNickname());
     };
@@ -32,16 +23,8 @@ export default function Home() {
   }, [t]);
 
   return (
-    <>
+    <main className="min-h-screen w-full">
       <DesktopHero username={nickname || t("nicknameUnset")} />
-      {process.env.NODE_ENV === "development" && (
-        <div className="debug-section">
-          <p>
-            <strong>Middleware Status:</strong> {gateStatus}
-          </p>
-          <p className="opacity-80">allow: 許可 / passed: 認証済み / required: 未認証→/setup</p>
-        </div>
-      )}
-    </>
+    </main>
   );
 }

--- a/apps/hub/middleware.ts
+++ b/apps/hub/middleware.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 const ALLOW = [
+  /^\/home(?:\/|$)/,
   /^\/setup/,
   /^\/_next\//,
   /^\/assets\//,
@@ -13,14 +14,12 @@ const ALLOW = [
 export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
-  if (ALLOW.some((r) => r.test(pathname))) {
-    const res = NextResponse.next();
-    res.headers.set('x-profile-gate', 'allow');
-    return res;
+  const res = NextResponse.next();
+
+  if (process.env.NODE_ENV === 'development') {
+    res.headers.set('x-profile-gate', ALLOW.some((r) => r.test(pathname)) ? 'allow' : 'disabled');
   }
 
-  const res = NextResponse.next();
-  res.headers.set('x-profile-gate', 'disabled');
   return res;
 }
 


### PR DESCRIPTION
### Motivation
- The home hero background did not always cover the full viewport and a middleware debug probe/UI was leaking into the production view, so the home page must be guaranteed to be full-height and not show middleware debug information.

### Description
- Wrap the `/home` root with a full-height container by returning `<main className="min-h-screen w-full">` in `apps/hub/app/home/page.tsx` so the hero background covers the viewport.
- Remove the `HEAD /home` debug probe and the `Middleware Status` debug UI from `apps/hub/app/home/page.tsx` to avoid exposing middleware diagnostics in production.
- Add `/home` to the middleware allow-list and limit emission of the `x-profile-gate` diagnostic header to development only in `apps/hub/middleware.ts` so the home page is treated as public and debug headers are not sent in production.

### Testing
- Ran `pnpm --filter @five-cucumber/hub lint` and the command completed successfully (an unrelated ESLint warning remains but is unchanged). 
- Ran `pnpm --filter @five-cucumber/hub type-check` and TypeScript checks passed. 
- Launched the local dev server and captured a `/home` screenshot with Playwright for visual verification, which completed successfully (note: the environment showed a pre-existing `GET /images/home_f.png 404` unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3035a190832f9440c82cef97b21c)