### PR TITLE
fix(hub): stabilize home hero fullscreen background

### DIFF
--- a/apps/hub/app/globals.css
+++ b/apps/hub/app/globals.css
@@ -590,6 +590,10 @@ html, body, #__next {
   overflow: auto;
 }
 
+body {
+  background-color: #2d5a27;
+}
+
 /* 固定背景レイヤ（最背面） */
 body::before {
   content: '';

--- a/apps/hub/app/home/_components/DesktopHero.tsx
+++ b/apps/hub/app/home/_components/DesktopHero.tsx
@@ -7,65 +7,78 @@ export default function DesktopHero({ username = "GUEST" }: Props) {
   const normalizedName = username?.trim() || "GUEST";
 
   return (
-    <section
-      className="home-hero-fonts fixed inset-0 flex min-h-screen w-full flex-col items-center justify-center bg-cover bg-center bg-no-repeat text-[#2a2a2a]"
-      style={{ backgroundImage: "url('/assets/home_f.png')" }}
-    >
-      <div className="relative flex min-h-screen w-full max-w-5xl flex-col items-center justify-between px-6 py-8 sm:px-10 sm:py-10">
-        <div className="flex w-full items-start justify-between gap-4 text-sm font-semibold sm:text-base">
-          <nav aria-label="補助リンク" className="flex flex-col gap-2 text-left">
-            <Link href="/rules" className="underline underline-offset-4">
-              📖 ルール説明
-            </Link>
-            <LanguageToggle className="underline underline-offset-4" />
-          </nav>
+    <>
+      <div
+        className="bg-cover bg-center bg-no-repeat"
+        style={{
+          position: "fixed",
+          inset: 0,
+          width: "100vw",
+          height: "100vh",
+          backgroundImage: "url('/assets/home_f.png')",
+          pointerEvents: "none",
+          zIndex: -1,
+        }}
+        aria-hidden
+      />
+      <section className="home-hero-fonts relative flex min-h-screen w-full flex-col items-center justify-center text-[#2a2a2a]"
+        style={{ zIndex: 1 }}>
+        <div className="relative flex min-h-screen w-full max-w-5xl flex-col items-center justify-between px-6 py-8 sm:px-10 sm:py-10">
+          <div className="flex w-full items-start justify-between gap-4 text-sm font-semibold sm:text-base">
+            <nav aria-label="補助リンク" className="flex flex-col gap-2 text-left">
+              <Link href="/rules" className="underline underline-offset-4">
+                📖 ルール説明
+              </Link>
+              <LanguageToggle className="underline underline-offset-4" />
+            </nav>
 
-          <div className="inline-flex items-center gap-2">
-            <span>ユーザー:</span>
-            <Link href="/setup" className="font-bold text-[#155724] underline underline-offset-4" aria-label={`${normalizedName}のプロフィール設定を開く`}>
-              {normalizedName}
-            </Link>
+            <div className="inline-flex items-center gap-2">
+              <span>ユーザー:</span>
+              <Link href="/setup" className="font-bold text-[#155724] underline underline-offset-4" aria-label={`${normalizedName}のプロフィール設定を開く`}>
+                {normalizedName}
+              </Link>
+            </div>
           </div>
-        </div>
 
-        <div className="flex w-full flex-1 flex-col items-center justify-center px-2 text-center">
-          <h1 className="m-0 text-[clamp(40px,9vw,84px)] tracking-[0.12em] text-[#1f3d2a]">５本のきゅうり</h1>
-          <div className="mt-6 grid w-full max-w-md gap-4">
-            <Link
-              href="/cucumber/cpu/settings"
-              className="fc-button fc-button--primary w-full"
-              aria-label="CPU対戦を始める"
-            >
-              CPU対戦
+          <div className="flex w-full flex-1 flex-col items-center justify-center px-2 text-center">
+            <h1 className="m-0 text-[clamp(40px,9vw,84px)] tracking-[0.12em] text-[#1f3d2a]">５本のきゅうり</h1>
+            <div className="mt-6 grid w-full max-w-md gap-4">
+              <Link
+                href="/cucumber/cpu/settings"
+                className="fc-button fc-button--primary w-full"
+                aria-label="CPU対戦を始める"
+              >
+                CPU対戦
+              </Link>
+              <Link
+                href="/friend/create"
+                className="fc-button fc-button--secondary w-full"
+                aria-label="フレンド対戦を始める"
+              >
+                フレンド対戦
+              </Link>
+            </div>
+          </div>
+
+          <footer aria-label="その他のリンク" className="flex flex-wrap items-center justify-center gap-3 text-sm font-semibold sm:gap-6 sm:text-base">
+            <Link href="/rules" className="underline underline-offset-4">
+              ルール
             </Link>
-            <Link
-              href="/friend/create"
-              className="fc-button fc-button--secondary w-full"
-              aria-label="フレンド対戦を始める"
-            >
+            <Link href="/cucumber/cpu/settings" className="underline underline-offset-4">
+              CPU対戦設定
+            </Link>
+            <Link href="/online" className="underline underline-offset-4">
+              オンライン対戦
+            </Link>
+            <Link href="/friend/create" className="underline underline-offset-4">
               フレンド対戦
             </Link>
-          </div>
+            <Link href="/setup" className="underline underline-offset-4">
+              プロフィール設定
+            </Link>
+          </footer>
         </div>
-
-        <footer aria-label="その他のリンク" className="flex flex-wrap items-center justify-center gap-3 text-sm font-semibold sm:gap-6 sm:text-base">
-          <Link href="/rules" className="underline underline-offset-4">
-            ルール
-          </Link>
-          <Link href="/cucumber/cpu/settings" className="underline underline-offset-4">
-            CPU対戦設定
-          </Link>
-          <Link href="/online" className="underline underline-offset-4">
-            オンライン対戦
-          </Link>
-          <Link href="/friend/create" className="underline underline-offset-4">
-            フレンド対戦
-          </Link>
-          <Link href="/setup" className="underline underline-offset-4">
-            プロフィール設定
-          </Link>
-        </footer>
-      </div>
-    </section>
+      </section>
+    </>
   );
 }


### PR DESCRIPTION
### Motivation
- The home hero background could leave the page bottom showing the site’s beige base because the background depended on a single element inside layout and was affected by parent sizing/overflow and paint timing. 
- The goal is to ensure the home background always covers the viewport and avoid visible fallback color when the image is unavailable or delayed.

### Description
- Refactored `DesktopHero` into a two-layer structure with a dedicated viewport-fixed background `div` (`position: fixed; inset: 0; width: 100vw; height: 100vh`) and a separate content `section` rendered above it with adjusted stacking (`z-index`).
- The background element uses `pointer-events: none` and `aria-hidden` so it doesn't affect interaction or accessibility semantics, and the content layer keeps the original layout and CTA buttons intact.
- Added a fallback `body { background-color: #2d5a27; }` in `apps/hub/app/globals.css` to prevent a beige flash/bleed when background imagery is missing or slow to load.
- Adjusted image path usage to reference the existing asset (`/assets/home_f.png`) and ensured stacking styles so the background always fills the viewport independent of parent containers.

### Testing
- Ran the investigation commands `rg`/`cat` to inspect `globals.css`, `layout.tsx`, `DesktopHero.tsx`, and `page.tsx` to confirm root cause and current structure.
- Ran lint with `pnpm -C apps/hub lint`, which completed (only an unrelated pre-existing `no-explicit-any` warning remains outside the change). 
- Launched the dev server and performed visual validation using a Playwright script that opened `/home` and captured screenshots to confirm the background covers the full viewport and page controls remain visible and clickable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3553ef7c832fb68f255c702c9b53)