### PR TITLE
fix(hub): avoid duplicated home background on home screen

### DIFF
--- a/apps/hub/app/home/_components/DesktopHero.tsx
+++ b/apps/hub/app/home/_components/DesktopHero.tsx
@@ -17,7 +17,7 @@ export default function DesktopHero({ username = "GUEST" }: Props) {
           height: "100vh",
           backgroundImage: "url('/assets/home_f.png')",
           pointerEvents: "none",
-          zIndex: -1,
+          zIndex: 0,
         }}
         aria-hidden
       />


### PR DESCRIPTION
### Motivation
- Fix a visible seam/duplicate-background effect on the home screen caused by overlapping fixed full-screen backgrounds from the global `body::before` layer and the `DesktopHero` component.

### Description
- Updated `apps/hub/app/home/_components/DesktopHero.tsx` to change the fixed background layer `z-index` from `-1` to `0` so the hero background renders above the global `body::before` layer and prevents the visual double-background.

### Testing
- Ran `pnpm -C apps/hub lint` which completed (existing unrelated warning remains), started the dev server with `pnpm -C apps/hub dev -p 3000` and loaded `/home`, and captured a Playwright screenshot of the home page; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b38ae01ac832fabffc9c39ca117ae)