### PR TITLE
fix(hub): prevent duplicated home background rendering

### DIFF
--- a/apps/hub/app/globals.css
+++ b/apps/hub/app/globals.css
@@ -608,6 +608,10 @@ body::before {
   background-attachment: fixed;
 }
 
+body[data-page="home"]::before {
+  display: none;
+}
+
 /* ホーム背景 */
 body[data-bg="home"]::before {
   background-image: url("/images/home1.png");

--- a/apps/hub/app/home/_components/DesktopHero.tsx
+++ b/apps/hub/app/home/_components/DesktopHero.tsx
@@ -9,13 +9,16 @@ export default function DesktopHero({ username = "GUEST" }: Props) {
   return (
     <>
       <div
-        className="bg-cover bg-center bg-no-repeat"
         style={{
           position: "fixed",
-          inset: 0,
+          top: 0,
+          left: 0,
           width: "100vw",
           height: "100vh",
           backgroundImage: "url('/assets/home_f.png')",
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          backgroundRepeat: "no-repeat",
           pointerEvents: "none",
           zIndex: 0,
         }}

--- a/apps/hub/app/layout.tsx
+++ b/apps/hub/app/layout.tsx
@@ -59,10 +59,12 @@ function resolveLocale(): 'ja' | 'en' {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   const locale = resolveLocale();
+  const pathname = headers().get('x-pathname') || '';
+  const isHome = pathname.startsWith('/home');
 
   return (
     <html lang={locale} data-theme="light">
-      <body>
+      <body data-page={isHome ? 'home' : ''}>
         <Script id="suppress-extension-noise" strategy="beforeInteractive">
           {`
             (function(){


### PR DESCRIPTION
### Motivation
- The home screen showed the background twice because a global `body::before` background layer and the `DesktopHero` component both rendered full-viewport images, causing vertical repeat and double-draw.
- Tailwind background utilities could be overridden by other styles, so the hero background needed deterministic inline control to guarantee `no-repeat` and full coverage.

### Description
- Updated `DesktopHero` to remove the Tailwind background utility and set the background layer with explicit inline styles including `backgroundSize: 'cover'`, `backgroundPosition: 'center'`, `backgroundRepeat: 'no-repeat'`, and fixed placement via `top/left` and `width/height: 100vw/100vh` in `apps/hub/app/home/_components/DesktopHero.tsx`.
- Added body page detection in `RootLayout` using `headers()` and applied `data-page="home"` to the root `<body>` when the request path indicates the home page in `apps/hub/app/layout.tsx`.
- Disabled the global `body::before` background on the home page by adding `body[data-page="home"]::before { display: none; }` to `apps/hub/app/globals.css`, removing the possibility of double backgrounds while preserving `body::before` for other pages.

### Testing
- Ran `pnpm --filter @five-cucumber/hub lint` which completed (one unrelated lint warning remains in `app/api/game/move/route.ts`).
- Started the dev server with `pnpm --filter @five-cucumber/hub dev -p 3000` and confirmed the app served `/home` successfully.
- Captured a screenshot of `/home` using a Playwright WebKit run which shows a single full-viewport hero image (screenshot produced), while a Chromium-based Playwright run failed with a SIGSEGV in the browser in this environment and is considered an environment-level issue rather than a code regression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3b502754832fb29d03a4b833efd7)