### PR TITLE
fix(hub): restore DesktopHero z-index stacking for interactive content

### DIFF
--- a/apps/hub/app/home/_components/DesktopHero.tsx
+++ b/apps/hub/app/home/_components/DesktopHero.tsx
@@ -20,12 +20,12 @@ export default function DesktopHero({ username = "GUEST" }: Props) {
           backgroundPosition: "center",
           backgroundRepeat: "no-repeat",
           pointerEvents: "none",
-          zIndex: 0,
+          zIndex: -1,
         }}
         aria-hidden
       />
       <section className="home-hero-fonts relative flex min-h-screen w-full flex-col items-center justify-center text-[#2a2a2a]"
-        style={{ zIndex: 1 }}>
+        style={{ position: "relative", zIndex: 1 }}>
         <div className="relative flex min-h-screen w-full max-w-5xl flex-col items-center justify-between px-6 py-8 sm:px-10 sm:py-10">
           <div className="flex w-full items-start justify-between gap-4 text-sm font-semibold sm:text-base">
             <nav aria-label="補助リンク" className="flex flex-col gap-2 text-left">


### PR DESCRIPTION
### Motivation
- Background layer in the hero was placed in front of interactive content which caused buttons and text to be hidden and unclickable.

### Description
- Set the hero background's `zIndex` to `-1` in `apps/hub/app/home/_components/DesktopHero.tsx` so it stays behind UI.
- Explicitly set the hero content container to `position: "relative"` with `zIndex: 1` so text and buttons reliably appear above the background.

### Testing
- Ran `pnpm -C apps/hub lint` which completed successfully (there is an unrelated lint warning in another file). 
- Started the app with `pnpm -C apps/hub dev --port 3000` and loaded `/home`, and captured a screenshot with a Playwright script confirming hero content and buttons render above the background.
- Verified the modified file `apps/hub/app/home/_components/DesktopHero.tsx` compiles and the page displays the background as a single non-repeating cover image with no double background observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3ddf5950832fbae7b7d75c65339b)