### PR TITLE
UI改善: ホーム画面の中央配置とボタンサイズを調整

### DIFF
--- a/apps/hub/app/home/_components/DesktopHero.tsx
+++ b/apps/hub/app/home/_components/DesktopHero.tsx
@@ -1,86 +1,93 @@
-import Link from "next/link";
-import LanguageToggle from "./LanguageToggle";
+import Link from 'next/link';
+import LanguageToggle from './LanguageToggle';
 
 type Props = { username?: string };
 
-export default function DesktopHero({ username = "GUEST" }: Props) {
-  const normalizedName = username?.trim() || "GUEST";
+export default function DesktopHero({ username = 'GUEST' }: Props) {
+  const normalizedName = username?.trim() || 'GUEST';
 
   return (
     <>
       <div
         style={{
-          position: "fixed",
+          position: 'fixed',
           top: 0,
           left: 0,
-          width: "100vw",
-          height: "100vh",
+          width: '100vw',
+          height: '100vh',
           backgroundImage: "url('/assets/home_f.png')",
-          backgroundSize: "cover",
-          backgroundPosition: "center",
-          backgroundRepeat: "no-repeat",
-          pointerEvents: "none",
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          backgroundRepeat: 'no-repeat',
+          pointerEvents: 'none',
           zIndex: -1,
         }}
         aria-hidden
       />
-      <section className="home-hero-fonts relative flex min-h-screen w-full flex-col items-center justify-center text-[#2a2a2a]"
-        style={{ position: "relative", zIndex: 1 }}>
-        <div className="relative flex min-h-screen w-full max-w-5xl flex-col items-center justify-between px-6 py-8 sm:px-10 sm:py-10">
-          <div className="flex w-full items-start justify-between gap-4 text-sm font-semibold sm:text-base">
-            <nav aria-label="補助リンク" className="flex flex-col gap-2 text-left">
-              <Link href="/rules" className="underline underline-offset-4">
-                📖 ルール説明
-              </Link>
-              <LanguageToggle className="underline underline-offset-4" />
-            </nav>
-
-            <div className="inline-flex items-center gap-2">
-              <span>ユーザー:</span>
-              <Link href="/setup" className="font-bold text-[#155724] underline underline-offset-4" aria-label={`${normalizedName}のプロフィール設定を開く`}>
-                {normalizedName}
-              </Link>
-            </div>
-          </div>
-
-          <div className="flex w-full flex-1 flex-col items-center justify-center px-2 text-center">
-            <h1 className="m-0 text-[clamp(40px,9vw,84px)] tracking-[0.12em] text-[#1f3d2a]">５本のきゅうり</h1>
-            <div className="mt-6 grid w-full max-w-md gap-4">
-              <Link
-                href="/cucumber/cpu/settings"
-                className="fc-button fc-button--primary w-full"
-                aria-label="CPU対戦を始める"
-              >
-                CPU対戦
-              </Link>
-              <Link
-                href="/friend/create"
-                className="fc-button fc-button--secondary w-full"
-                aria-label="フレンド対戦を始める"
-              >
-                フレンド対戦
-              </Link>
-            </div>
-          </div>
-
-          <footer aria-label="その他のリンク" className="flex flex-wrap items-center justify-center gap-3 text-sm font-semibold sm:gap-6 sm:text-base">
+      <section
+        className="home-hero-fonts relative min-h-screen w-full text-[#2a2a2a]"
+        style={{ position: 'relative', zIndex: 1 }}
+      >
+        <header className="absolute left-4 top-4 right-4 z-10 flex items-center justify-between gap-4 text-sm font-semibold sm:text-base">
+          <nav aria-label="補助リンク" className="flex items-center gap-4 text-left">
             <Link href="/rules" className="underline underline-offset-4">
-              ルール
+              📖 ルール説明
             </Link>
-            <Link href="/cucumber/cpu/settings" className="underline underline-offset-4">
-              CPU対戦設定
+            <LanguageToggle className="underline underline-offset-4" />
+          </nav>
+
+          <div className="inline-flex items-center gap-2">
+            <span>ユーザー:</span>
+            <Link
+              href="/setup"
+              className="font-bold text-[#155724] underline underline-offset-4"
+              aria-label={`${normalizedName}のプロフィール設定を開く`}
+            >
+              {normalizedName}
             </Link>
-            <Link href="/online" className="underline underline-offset-4">
-              オンライン対戦
+          </div>
+        </header>
+
+        <div className="flex min-h-screen w-full flex-col items-center justify-center px-6 text-center sm:px-10">
+          <h1 className="mb-12 text-5xl font-bold text-green-900 md:text-6xl">5本のきゅうり</h1>
+          <div className="flex w-64 flex-col gap-6">
+            <Link
+              href="/cucumber/cpu/settings"
+              aria-label="CPU対戦を始める"
+              className="w-full rounded-lg bg-gradient-to-b from-green-400 to-green-600 px-8 py-4 text-xl font-bold text-white shadow-lg transition-all hover:scale-105 hover:shadow-xl"
+            >
+              CPU対戦
             </Link>
-            <Link href="/friend/create" className="underline underline-offset-4">
+            <Link
+              href="/online"
+              aria-label="フレンド対戦を始める"
+              className="w-full rounded-lg bg-gradient-to-b from-orange-300 to-orange-500 px-8 py-4 text-xl font-bold text-white shadow-lg transition-all hover:scale-105 hover:shadow-xl"
+            >
               フレンド対戦
             </Link>
-            <Link href="/setup" className="underline underline-offset-4">
-              プロフィール設定
-            </Link>
-          </footer>
+          </div>
         </div>
+
+        <footer
+          aria-label="その他のリンク"
+          className="absolute bottom-8 left-1/2 flex -translate-x-1/2 flex-wrap items-center justify-center gap-6 text-sm font-semibold text-green-800 sm:text-base"
+        >
+          <Link href="/rules" className="underline underline-offset-4">
+            ルール
+          </Link>
+          <Link href="/cucumber/cpu/settings" className="underline underline-offset-4">
+            CPU対戦設定
+          </Link>
+          <Link href="/online" className="underline underline-offset-4">
+            オンライン対戦
+          </Link>
+          <Link href="/friend/create" className="underline underline-offset-4">
+            フレンド対戦
+          </Link>
+          <Link href="/setup" className="underline underline-offset-4">
+            プロフィール設定
+          </Link>
+        </footer>
       </section>
     </>
   );


### PR DESCRIPTION
### Motivation
- ホーム画面のメインコンテンツが上に寄りすぎていたため、視認性と操作性を向上させる目的でレイアウトとボタンサイズを改善しました。
- モバイルやタッチ操作でボタンが押しにくかったため、ボタンのサイズと間隔を広げて操作性を高めます。

### Description
- `DesktopHero` を再構成してヘッダー（ルール説明・言語切替・ユーザー名）を画面上部に絶対配置し、メインコンテンツを中央寄せにしました。
- タイトルを `text-5xl md:text-6xl` に拡大して可視性を向上させました。
- CTA を縦並びにしてボタンに `w-64`, `px-8`, `py-4`, `text-xl`, `gap-6` を適用し、グラデーション背景・ホバー効果・影を追加しました。
- フッターリンクを画面下部に固定しリンク間隔を `gap-6` に広げ、フレンド対戦CTAの遷移先を `/online` に変更しました.

### Testing
- `pnpm -C apps/hub lint` を実行して成功しました（別ファイルの既存警告1件が表示されましたが今回の変更に影響なし）。
- `pnpm prettier --write apps/hub/app/home/_components/DesktopHero.tsx` を実行してファイル整形を行い成功しました。
- 開発サーバを `pnpm -C apps/hub dev -p 3000` で起動してページをレンダリングできることを確認しました。
- Playwright スクリプトでホーム画面のスクリーンショット `artifacts/desktophero-home.png` を取得できることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b4133d93c832fb8d07bf3398f029c)