### PR TITLE
Fix discard flow for CPU play and clean up table UI

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/game.css
+++ b/apps/hub/app/cucumber/cpu/play/game.css
@@ -13,7 +13,14 @@
   gap: clamp(16px, 3vw, 32px);
   overflow: hidden;
   box-sizing: border-box;
-  background: radial-gradient(circle at 50% 30%, rgba(255, 255, 255, 0.08), transparent 68%);
+  background:
+    radial-gradient(circle at 50% 30%, rgba(255, 255, 255, 0.08), transparent 68%),
+    radial-gradient(120% 80% at 50% 55%, rgba(8, 34, 28, 0.35), rgba(0, 0, 0, 0) 70%);
+  border: none;
+  outline: none;
+  box-shadow:
+    inset 0 20px 40px rgba(255, 255, 255, 0.04),
+    inset 0 -26px 50px rgba(0, 0, 0, 0.25);
   --ellipse-card-width: clamp(44px, 6vw, 72px);
   --ellipse-card-height: clamp(60px, 9vw, 108px);
   --ellipse-card-gap: clamp(6px, 2vw, 14px);
@@ -75,7 +82,9 @@
 
 .trick-card-entry.winner .card.current-card {
   border-color: #ffd15c;
-  box-shadow: 0 0 0 2px rgba(255, 209, 92, 0.75), 0 0 22px rgba(255, 209, 92, 0.8);
+  box-shadow:
+    0 0 0 2px rgba(255, 209, 92, 0.75),
+    0 0 22px rgba(255, 209, 92, 0.8);
 }
 
 .trick-winner-banner {
@@ -214,10 +223,22 @@
 }
 
 @keyframes fadeInOut {
-  0% { opacity: 0; transform: translate(-50%, -50%) scale(0.8); }
-  20% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
-  80% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
-  100% { opacity: 0; transform: translate(-50%, -50%) scale(0.8); }
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.8);
+  }
+  20% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+  80% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.8);
+  }
 }
 
 /* ゲーム終了時のキュウリ表示 */
@@ -235,10 +256,22 @@
 }
 
 @keyframes slideUp {
-  0% { opacity: 0; transform: translate(-50%, -50%) translateY(50px); }
-  10% { opacity: 1; transform: translate(-50%, -50%) translateY(0); }
-  90% { opacity: 1; transform: translate(-50%, -50%) translateY(0); }
-  100% { opacity: 0; transform: translate(-50%, -50%) translateY(-50px); }
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) translateY(50px);
+  }
+  10% {
+    opacity: 1;
+    transform: translate(-50%, -50%) translateY(0);
+  }
+  90% {
+    opacity: 1;
+    transform: translate(-50%, -50%) translateY(0);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) translateY(-50px);
+  }
 }
 
 /* プレイヤー手札の横並び表示 */
@@ -303,8 +336,15 @@
 }
 
 @keyframes pulse-warning {
-  0%, 100% { transform: scale(1); box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4); }
-  50% { transform: scale(1.08); box-shadow: 0 8px 30px rgba(247, 70, 95, 0.6); }
+  0%,
+  100% {
+    transform: scale(1);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  }
+  50% {
+    transform: scale(1.08);
+    box-shadow: 0 8px 30px rgba(247, 70, 95, 0.6);
+  }
 }
 
 .game-title {
@@ -344,7 +384,7 @@
 
 .player-panel.current-turn {
   border: 4px solid #ffbe3b;
-  box-shadow: 
+  box-shadow:
     0 0 30px rgba(255, 190, 59, 0.8),
     0 6px 25px rgba(0, 0, 0, 0.4);
   background: linear-gradient(135deg, rgba(255, 190, 59, 0.25), rgba(255, 190, 59, 0.12));
@@ -352,20 +392,35 @@
 }
 
 /* 手番ハイライト（光る枠） */
-.player-zone[data-active="true"]::after {
-  content: "";
+.player-zone[data-active='true']::after {
+  content: '';
   position: absolute;
   inset: -6px;
   border-radius: 16px;
-  box-shadow: 0 0 0 2px #ffe7a1, 0 0 16px #ffd15c, 0 0 36px rgba(255, 178, 0, 0.55);
+  box-shadow:
+    0 0 0 2px #ffe7a1,
+    0 0 16px #ffd15c,
+    0 0 36px rgba(255, 178, 0, 0.55);
   animation: pulse 1.2s ease-in-out infinite;
   pointer-events: none;
 }
 
 @keyframes pulse {
-  0% { box-shadow: 0 0 0 2px #ffe7a1, 0 0 10px #ffd15c; }
-  50% { box-shadow: 0 0 0 4px #ffd15c, 0 0 24px #ffb400; }
-  100% { box-shadow: 0 0 0 2px #ffe7a1, 0 0 10px #ffd15c; }
+  0% {
+    box-shadow:
+      0 0 0 2px #ffe7a1,
+      0 0 10px #ffd15c;
+  }
+  50% {
+    box-shadow:
+      0 0 0 4px #ffd15c,
+      0 0 24px #ffb400;
+  }
+  100% {
+    box-shadow:
+      0 0 0 2px #ffe7a1,
+      0 0 10px #ffd15c;
+  }
 }
 
 .turn-badge {
@@ -382,8 +437,16 @@
 }
 
 @keyframes glow-pulse {
-  0% { box-shadow: 0 0 30px rgba(255, 190, 59, 0.8), 0 6px 25px rgba(0, 0, 0, 0.4); }
-  100% { box-shadow: 0 0 40px rgba(255, 190, 59, 1), 0 8px 30px rgba(0, 0, 0, 0.4); }
+  0% {
+    box-shadow:
+      0 0 30px rgba(255, 190, 59, 0.8),
+      0 6px 25px rgba(0, 0, 0, 0.4);
+  }
+  100% {
+    box-shadow:
+      0 0 40px rgba(255, 190, 59, 1),
+      0 8px 30px rgba(0, 0, 0, 0.4);
+  }
 }
 
 .player-info {
@@ -544,7 +607,9 @@
   justify-content: center;
   font-weight: bold;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
   position: relative;
   border: 2px solid rgba(255, 255, 255, 0.4);
   box-shadow: 0 3px 12px rgba(0, 0, 0, 0.4);
@@ -605,8 +670,14 @@
 }
 
 @keyframes card-glow {
-  0% { box-shadow: 0 0 30px rgba(49, 153, 255, 0.8); }
-  100% { box-shadow: 0 0 40px rgba(49, 153, 255, 1), 0 0 60px rgba(255, 190, 59, 0.6); }
+  0% {
+    box-shadow: 0 0 30px rgba(49, 153, 255, 0.8);
+  }
+  100% {
+    box-shadow:
+      0 0 40px rgba(49, 153, 255, 1),
+      0 0 60px rgba(255, 190, 59, 0.6);
+  }
 }
 
 .card:hover:not(.disabled) {
@@ -679,7 +750,7 @@
   position: fixed;
   bottom: 24px;
   right: 24px;
-  background: rgba(0,0,0,0.8);
+  background: rgba(0, 0, 0, 0.8);
   color: #fff;
   padding: 10px 14px;
   border-radius: 8px;
@@ -695,14 +766,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0,0,0,0.35);
+  background: rgba(0, 0, 0, 0.35);
   z-index: 1100;
 }
 .countdown-number {
   color: #fff;
   font-size: 96px;
   font-weight: 800;
-  text-shadow: 0 0 12px rgba(255,255,255,0.7), 0 0 30px rgba(0,0,0,0.6);
+  text-shadow:
+    0 0 12px rgba(255, 255, 255, 0.7),
+    0 0 30px rgba(0, 0, 0, 0.6);
 }
 
 .game-over-content {
@@ -852,4 +925,38 @@
   .player-hand {
     min-height: clamp(68px, 30svh, 128px);
   }
+}
+
+.discard-notice,
+.discard-result-notice {
+  align-self: center;
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-size: 0.86rem;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
+}
+
+.discard-notice {
+  background: rgba(247, 70, 95, 0.25);
+  border: 1px solid rgba(247, 70, 95, 0.7);
+}
+
+.discard-result-notice {
+  background: rgba(49, 153, 255, 0.2);
+  border: 1px solid rgba(49, 153, 255, 0.65);
+}
+
+.discard-tag {
+  position: absolute;
+  top: -10px;
+  right: -6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  color: #c73145;
+  border: 1px solid rgba(199, 49, 69, 0.4);
+  font-size: 0.6rem;
+  font-weight: 800;
+  padding: 1px 6px;
 }

--- a/apps/hub/app/globals.css
+++ b/apps/hub/app/globals.css
@@ -3,16 +3,16 @@
 
 /* === アンティーク調カラーパレット === */
 :root {
-  --antique-paper: #F5F0E6;
-  --antique-ink: #2B2B2B;
-  --antique-forest: #2E7D32;
-  --antique-forest-hover: #27692B;
-  --antique-brass: #C8A85A;
-  --antique-brass-hover: #B89A4A;
-  --antique-muted: #6B6B6B;
-  --antique-border: #D4C4A8;
+  --antique-paper: #f5f0e6;
+  --antique-ink: #2b2b2b;
+  --antique-forest: #2e7d32;
+  --antique-forest-hover: #27692b;
+  --antique-brass: #c8a85a;
+  --antique-brass-hover: #b89a4a;
+  --antique-muted: #6b6b6b;
+  --antique-border: #d4c4a8;
   --antique-shadow: rgba(43, 43, 43, 0.1);
-  
+
   /* ゲーム専用カラーパレット */
   --ivy-green: #2e5031;
   --gold: #c8b27a;
@@ -22,8 +22,18 @@
 }
 
 /* Home hero specific font override */
-.home-hero-fonts, .home-hero-fonts * {
-  font-family: 'Shippori Mincho', 'Noto Sans JP', system-ui, -apple-system, Segoe UI, Roboto, "Hiragino Kaku Gothic ProN", "Noto Sans JP", sans-serif;
+.home-hero-fonts,
+.home-hero-fonts * {
+  font-family:
+    'Shippori Mincho',
+    'Noto Sans JP',
+    system-ui,
+    -apple-system,
+    Segoe UI,
+    Roboto,
+    'Hiragino Kaku Gothic ProN',
+    'Noto Sans JP',
+    sans-serif;
 }
 
 /* === アンティーク調フォント === */
@@ -59,7 +69,10 @@
   letter-spacing: 0.06em;
   text-decoration: none;
   cursor: pointer;
-  transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.18s ease,
+    filter 0.18s ease;
   min-height: 48px;
   min-width: 48px;
 }
@@ -156,7 +169,9 @@
   text-decoration: none;
   width: 100%;
   min-height: 48px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .layout-footer__button:active {
@@ -409,7 +424,9 @@
 .page-enter-active {
   opacity: 1;
   transform: translateY(0);
-  transition: opacity 300ms, transform 300ms;
+  transition:
+    opacity 300ms,
+    transform 300ms;
 }
 
 .page-exit {
@@ -420,7 +437,9 @@
 .page-exit-active {
   opacity: 0;
   transform: translateY(-20px);
-  transition: opacity 300ms, transform 300ms;
+  transition:
+    opacity 300ms,
+    transform 300ms;
 }
 
 /* Loading states */
@@ -442,8 +461,12 @@
 }
 
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 /* Error states */
@@ -468,27 +491,28 @@
   .app {
     padding: 0;
   }
-  
+
   .main {
     padding: var(--space-sm);
   }
-  
+
   /* モバイルでの背景調整 */
   body {
     background-size: cover;
     background-position: center center;
   }
-  
-  .page-game, .page-arena {
+
+  .page-game,
+  .page-arena {
     background-size: cover;
     background-position: center center;
   }
-  
+
   /* モバイルでのテキスト可読性向上 */
   .bg-black\/30 {
     background-color: rgba(0, 0, 0, 0.4) !important;
   }
-  
+
   /* 手札のサイズ調整 */
   .hand .card {
     font-size: 0.9rem;
@@ -552,8 +576,13 @@
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.7; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
 }
 
 /* Focus styles */
@@ -562,17 +591,23 @@
   outline-offset: 2px;
 }
 
-
 /* ===== Link 下線の一括無効化（カードやナビ用） ===== */
-.link-reset, .link-reset * { text-decoration: none !important; }
+.link-reset,
+.link-reset * {
+  text-decoration: none !important;
+}
 
 /* 万一、古い <header> 帯が残っていても強制で透明化（保険） */
-header{ background: transparent !important; box-shadow: none !important; backdrop-filter: none !important; }
+header {
+  background: transparent !important;
+  box-shadow: none !important;
+  backdrop-filter: none !important;
+}
 
 /* 行頭三角（必要ならクラス化して使う想定） */
-.tri::before{
-  content:'▶';
-  margin-right:.5rem;
+.tri::before {
+  content: '▶';
+  margin-right: 0.5rem;
 }
 
 /* Print styles */
@@ -583,7 +618,9 @@ header{ background: transparent !important; box-shadow: none !important; backdro
 }
 
 /* === 固定背景レイヤシステム === */
-html, body, #__next { 
+html,
+body,
+#__next {
   height: 100%;
   margin: 0;
   padding: 0;
@@ -608,19 +645,19 @@ body::before {
   background-attachment: fixed;
 }
 
-body[data-page="home"]::before {
+body[data-page='home']::before {
   display: none;
 }
 
 /* ホーム背景 */
-body[data-bg="home"]::before {
-  background-image: url("/images/home1.png");
+body[data-bg='home']::before {
+  background-image: url('/images/home1.png');
   background-position: center top;
 }
 
 /* 対戦背景 */
-body[data-bg="battle"]::before {
-  background-image: url("/images/battle1.png");
+body[data-bg='battle']::before {
+  background-image: url('/images/battle1.png');
   background-position: center center;
 }
 
@@ -630,12 +667,24 @@ body[data-bg="battle"]::before {
 }
 
 /* レイヤー管理 */
-.layer-bg { z-index: 0; }
-.layer-seats { z-index: 10; }
-.layer-grave { z-index: 15; }
-.layer-field { z-index: 20; }
-.layer-hud { z-index: 30; }
-.layer-modal { z-index: 1000; }
+.layer-bg {
+  z-index: 0;
+}
+.layer-seats {
+  z-index: 10;
+}
+.layer-grave {
+  z-index: 15;
+}
+.layer-field {
+  z-index: 20;
+}
+.layer-hud {
+  z-index: 30;
+}
+.layer-modal {
+  z-index: 1000;
+}
 
 .layer-seats,
 .layer-field,
@@ -653,8 +702,10 @@ body[data-bg="battle"]::before {
 }
 
 /* ページ背景（背景はbody::beforeに集約） */
-.page-game, .page-home, .page-arena { 
-  min-height: 100dvh; 
+.page-game,
+.page-home,
+.page-arena {
+  min-height: 100dvh;
   position: relative;
   background: none !important;
 }
@@ -674,8 +725,15 @@ body[data-bg="battle"]::before {
   position: relative;
   z-index: 1;
 }
-.overlay-title { font-family: 'Shippori Mincho', serif; color: #fff; text-shadow: 0 4px 20px rgba(0,0,0,0.55); }
-.overlay-lead { color: rgba(255,255,255,0.88); text-shadow: 0 2px 12px rgba(0,0,0,0.45); }
+.overlay-title {
+  font-family: 'Shippori Mincho', serif;
+  color: #fff;
+  text-shadow: 0 4px 20px rgba(0, 0, 0, 0.55);
+}
+.overlay-lead {
+  color: rgba(255, 255, 255, 0.88);
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.45);
+}
 
 /* 対戦用レイアウト */
 .battle-root {
@@ -740,7 +798,9 @@ body[data-bg="battle"]::before {
   background: linear-gradient(135deg, #2f6b46, #1e5b3f);
   color: #fff;
   border: 3px solid var(--gold);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.2);
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2);
   font-weight: 700;
   transform: scale(1.05);
 }
@@ -821,14 +881,14 @@ body[data-bg="battle"]::before {
 }
 
 .settings-radio-btn:focus-visible {
-  outline: 2px solid #B59A6B;
+  outline: 2px solid #b59a6b;
   outline-offset: 2px;
 }
 
 .settings-radio-btn.selected {
   background: #25533e;
   color: white;
-  border: 2px solid #B59A6B;
+  border: 2px solid #b59a6b;
   font-weight: 600;
   transform: scale(1.02);
   box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
@@ -1011,7 +1071,9 @@ body[data-bg="battle"]::before {
   border-radius: 12px;
   font-weight: 600;
   font-size: clamp(14px, 2vw, 16px);
-  transition: transform 150ms ease, box-shadow 150ms ease;
+  transition:
+    transform 150ms ease,
+    box-shadow 150ms ease;
   border: none;
 }
 
@@ -1068,9 +1130,9 @@ body[data-bg="battle"]::before {
 }
 
 .friend-sticky-secondary {
-  background: rgba(0,0,0,0.04);
+  background: rgba(0, 0, 0, 0.04);
   color: #111827;
-  border: 1px solid rgba(0,0,0,0.08);
+  border: 1px solid rgba(0, 0, 0, 0.08);
 }
 
 @media (max-width: 1024px) {
@@ -1096,9 +1158,9 @@ body[data-bg="battle"]::before {
   right: 0;
   bottom: 0;
   z-index: 40;
-  background: rgba(255,255,255,0.96);
+  background: rgba(255, 255, 255, 0.96);
   backdrop-filter: saturate(1.1) blur(6px);
-  border-top: 1px solid rgba(0,0,0,0.08);
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
   display: grid;
   grid-template-columns: 1fr;
   gap: 8px;
@@ -1116,14 +1178,14 @@ body[data-bg="battle"]::before {
 }
 
 .friend-cta__primary {
-  background: linear-gradient(135deg,#34a853,#1e7c3a);
+  background: linear-gradient(135deg, #34a853, #1e7c3a);
   color: #fff;
 }
 
 .friend-cta__secondary {
-  background: rgba(0,0,0,0.04);
+  background: rgba(0, 0, 0, 0.04);
   color: #111827;
-  border: 1px solid rgba(0,0,0,0.08);
+  border: 1px solid rgba(0, 0, 0, 0.08);
 }
 
 /* createページ下段CTAも同一スタイルを利用 */
@@ -1318,7 +1380,10 @@ body[data-bg="battle"]::before {
   color: #ffffff;
   background: linear-gradient(135deg, #2fb15f, #1a7841);
   cursor: pointer;
-  transition: transform 150ms ease, box-shadow 150ms ease, opacity 150ms ease;
+  transition:
+    transform 150ms ease,
+    box-shadow 150ms ease,
+    opacity 150ms ease;
 }
 
 .friend-room-card__submit:hover {
@@ -1341,7 +1406,9 @@ body[data-bg="battle"]::before {
   background: transparent;
   color: #ffffff;
   font-weight: 600;
-  transition: background 150ms ease, border 150ms ease;
+  transition:
+    background 150ms ease,
+    border 150ms ease;
 }
 
 .friend-room-card__secondary:hover {
@@ -1478,15 +1545,28 @@ body[data-bg="battle"]::before {
 }
 
 @media (max-height: 780px) {
-  .friend-page__title { font-size: clamp(20px, 3.2vw, 36px); }
-  .friend-page__lead { font-size: clamp(14px, 2vw, 16px); }
+  .friend-page__title {
+    font-size: clamp(20px, 3.2vw, 36px);
+  }
+  .friend-page__lead {
+    font-size: clamp(14px, 2vw, 16px);
+  }
 }
 
 @media (max-height: 720px) {
-  .friend-action-card__button { height: 42px; }
-  .friend-cta__primary, .friend-cta__secondary { height: 40px; }
-  .friend-action-card { padding: clamp(10px, 2vh, 16px); }
-  .friend-actions { gap: clamp(6px, 0.8vh, 12px); }
+  .friend-action-card__button {
+    height: 42px;
+  }
+  .friend-cta__primary,
+  .friend-cta__secondary {
+    height: 40px;
+  }
+  .friend-action-card {
+    padding: clamp(10px, 2vh, 16px);
+  }
+  .friend-actions {
+    gap: clamp(6px, 0.8vh, 12px);
+  }
 }
 
 @media (max-width: 640px) {
@@ -1532,7 +1612,7 @@ body[data-bg="battle"]::before {
   color: #92400e;
 }
 
-.debug-checkbox input[type="checkbox"] {
+.debug-checkbox input[type='checkbox'] {
   width: 1rem;
   height: 1rem;
 }
@@ -1542,17 +1622,17 @@ body[data-bg="battle"]::before {
   .settings-container {
     padding: 1rem 0.75rem;
   }
-  
+
   .settings-buttons {
     gap: 0.25rem;
   }
-  
+
   .settings-radio-btn {
     min-width: 42px;
     padding: 0.25rem 0.375rem;
     font-size: 0.75rem;
   }
-  
+
   .settings-start-btn {
     width: 140px;
     height: 40px;
@@ -1565,13 +1645,13 @@ body[data-bg="battle"]::before {
   .settings-page {
     padding: 0.25rem;
   }
-  
+
   .settings-radio-btn {
     min-width: 38px;
     padding: 0.25rem;
     font-size: 0.6875rem;
   }
-  
+
   .settings-start-btn {
     width: 120px;
     height: 36px;
@@ -1587,7 +1667,11 @@ body[data-bg="battle"]::before {
 }
 
 /* レイヤー順序を固定 */
-#oval-inner { position: absolute; inset: 0; z-index: 20; }
+#oval-inner {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+}
 #seats {
   position: absolute;
   inset: 0;
@@ -1635,19 +1719,42 @@ body[data-bg="battle"]::before {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.35rem 0.5rem;
+  gap: 0.45rem;
+  min-width: clamp(112px, 12vw, 168px);
+  padding: 0.5rem 0.65rem;
+  border-radius: 12px;
   color: #fff;
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.75);
+  background: rgba(0, 0, 0, 0.2);
+}
+
+#seats .seat .player-name {
+  font-size: clamp(0.9rem, 1.3vw, 1.05rem);
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+#seats .seat .player-stats {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-size: clamp(0.7rem, 1vw, 0.82rem);
 }
 
 /* 5/6人で軽く縮小して重なり回避 */
-#seats.players-5 .seat { transform: translate(-50%, -50%) scale(0.92); }
-#seats.players-6 .seat { transform: translate(-50%, -50%) scale(0.88); }
+#seats.players-5 .seat {
+  transform: translate(-50%, -50%) scale(0.92);
+}
+#seats.players-6 .seat {
+  transform: translate(-50%, -50%) scale(0.88);
+}
 
 /* 手番ハイライト（枠を光らせる） */
-#seats .seat[data-active="true"] .content {
-  text-shadow: 0 0 14px rgba(255, 190, 59, 0.9), 0 2px 8px rgba(0, 0, 0, 0.9);
+#seats .seat[data-active='true'] .content {
+  text-shadow:
+    0 0 14px rgba(255, 190, 59, 0.9),
+    0 2px 8px rgba(0, 0, 0, 0.9);
 }
 
 /* 手札ドック（下辺中央） */
@@ -1669,9 +1776,15 @@ body[data-bg="battle"]::before {
 
 /* 画面幅が狭い時は全体的に軸を小さく */
 @media (max-width: 640px) {
-  #seats .seat { width: 42vw; }
-  #field { width: 38vw; }
-  #grave { width: 20vw; }
+  #seats .seat {
+    width: 42vw;
+  }
+  #field {
+    width: 38vw;
+  }
+  #grave {
+    width: 20vw;
+  }
 }
 
 /* ルーム情報表示 */
@@ -2177,29 +2290,29 @@ body[data-bg="battle"]::before {
 }
 
 /* === ホームランディング（画像デザイン準拠） === */
-.home-landing{
+.home-landing {
   min-height: 100svh;
   display: grid;
   grid-template-rows: auto auto 1fr;
   justify-items: center;
   align-content: start;
-  padding: clamp(16px,4vw,32px);
+  padding: clamp(16px, 4vw, 32px);
 }
 
-.home-landing__meta{
+.home-landing__meta {
   width: min(1100px, 100%);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-top: clamp(12px,2vh,20px);
+  margin-top: clamp(12px, 2vh, 20px);
 }
 
-.home-landing__links{
+.home-landing__links {
   display: flex;
   gap: clamp(10px, 2vw, 20px);
 }
 
-.home-landing__link{
+.home-landing__link {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -2208,78 +2321,81 @@ body[data-bg="battle"]::before {
   color: var(--antique-ink);
   text-decoration: none;
   border: 1px solid transparent;
-  background: rgba(245,240,230,0.65);
+  background: rgba(245, 240, 230, 0.65);
 }
 
-.home-landing__link:hover{
+.home-landing__link:hover {
   border-color: var(--antique-border);
-  background: rgba(245,240,230,0.9);
+  background: rgba(245, 240, 230, 0.9);
 }
 
-.home-landing__username{
+.home-landing__username {
   color: var(--antique-ink);
   font-weight: 700;
-  background: rgba(245,240,230,0.75);
+  background: rgba(245, 240, 230, 0.75);
   padding: 8px 14px;
   border-radius: 9999px;
   border: 1px solid var(--antique-border);
 }
 
-.home-landing__title{
+.home-landing__title {
   font-family: 'Shippori Mincho', serif;
   font-weight: 700;
-  font-size: clamp(28px,5vw,56px);
+  font-size: clamp(28px, 5vw, 56px);
   color: var(--antique-ink);
-  margin: clamp(12px,2vh,20px) 0;
+  margin: clamp(12px, 2vh, 20px) 0;
   text-align: center;
 }
 
-.home-landing__cta{
+.home-landing__cta {
   width: min(1100px, 100%);
   display: grid;
   grid-template-columns: 1fr;
   justify-items: center;
-  gap: clamp(12px,2vh,16px);
-  margin-top: clamp(8px,2vh,16px);
+  gap: clamp(12px, 2vh, 16px);
+  margin-top: clamp(8px, 2vh, 16px);
 }
 
-.home-landing__button{
+.home-landing__button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   min-width: 260px;
   height: 72px;
   border-radius: 16px;
-  font-size: clamp(18px,2.2vw,24px);
+  font-size: clamp(18px, 2.2vw, 24px);
   font-weight: 800;
   letter-spacing: 0.04em;
   text-decoration: none;
   color: #fff;
-  border: 2px solid rgba(0,0,0,0.15);
-  box-shadow: 0 10px 24px rgba(0,0,0,0.18);
-  transition: transform .15s ease, box-shadow .15s ease, filter .15s ease;
+  border: 2px solid rgba(0, 0, 0, 0.15);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease,
+    filter 0.15s ease;
   padding: 0 24px;
 }
 
-.home-landing__button--cpu{
+.home-landing__button--cpu {
   background: linear-gradient(180deg, #62b14f 0%, #2e7d32 100%);
-  border-color: rgba(46,125,50,0.35);
+  border-color: rgba(46, 125, 50, 0.35);
 }
 
-.home-landing__button--friend{
+.home-landing__button--friend {
   background: linear-gradient(180deg, #5aa74a 0%, #256d2a 100%);
-  border-color: rgba(37,109,42,0.35);
+  border-color: rgba(37, 109, 42, 0.35);
 }
 
-.home-landing__button:hover{
+.home-landing__button:hover {
   transform: translateY(-2px);
-  box-shadow: 0 14px 28px rgba(0,0,0,0.25);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25);
   filter: saturate(1.05);
 }
 
-.home-landing__hint{
+.home-landing__hint {
   color: var(--antique-ink);
-  font-size: clamp(12px,1.6vw,16px);
+  font-size: clamp(12px, 1.6vw, 16px);
   text-align: center;
   margin: -6px 0 6px;
 }
@@ -2551,7 +2667,9 @@ body[data-bg="battle"]::before {
 
 /* 手番ハイライト */
 .seat.turn {
-  box-shadow: 0 0 0 3px #ffe08a, 0 0 12px #ffdf70;
+  box-shadow:
+    0 0 0 3px #ffe08a,
+    0 0 12px #ffdf70;
   transition: box-shadow 0.15s ease;
 }
 

--- a/apps/hub/components/ui/EllipseTable.tsx
+++ b/apps/hub/components/ui/EllipseTable.tsx
@@ -21,9 +21,24 @@ interface EllipseTableProps {
   trickWinnerText?: string | null;
 }
 
-export function EllipseTable({ state, config, currentPlayerIndex, onCardClick, className = '', showAllHands = false, isSubmitting = false, lockedCardId = null, names, mySeatIndex = 0, trickCards = [], latestPlayedCardKey = null, trickWinner = null, trickWinnerText = null }: EllipseTableProps) {
+export function EllipseTable({
+  state,
+  config,
+  currentPlayerIndex,
+  onCardClick,
+  className = '',
+  showAllHands = false,
+  isSubmitting = false,
+  lockedCardId = null,
+  names,
+  mySeatIndex = 0,
+  trickCards = [],
+  latestPlayedCardKey = null,
+  trickWinner = null,
+  trickWinnerText = null,
+}: EllipseTableProps) {
   const playerNames = ['あなた', 'CPU-A', 'CPU-B', 'CPU-C', 'CPU-D', 'CPU-E'];
-  
+
   // デバッグログ（開発時のみ）
   useEffect(() => {
     if (process.env.NODE_ENV === 'development') {
@@ -32,11 +47,11 @@ export function EllipseTable({ state, config, currentPlayerIndex, onCardClick, c
         stateCurrentPlayer: state.currentPlayer,
         phase: state.phase,
         mySeatIndex,
-        isMyTurn: currentPlayerIndex === mySeatIndex
+        isMyTurn: currentPlayerIndex === mySeatIndex,
       });
     }
   }, [currentPlayerIndex, state.currentPlayer, state.phase]);
-  
+
   // フレンド対戦の場合は mySeatIndex を基準に自分の表示名を決める
   const getPlayerName = (index: number) => {
     if (names && names[index]) return names[index];
@@ -46,7 +61,7 @@ export function EllipseTable({ state, config, currentPlayerIndex, onCardClick, c
 
   // 楕円配置の更新
   useEffect(() => {
-    const seatsEl = document.getElementById("seats");
+    const seatsEl = document.getElementById('seats');
     if (!seatsEl) return;
 
     const update = () => layoutSeatsEllipse(seatsEl, config.players, mySeatIndex);
@@ -54,11 +69,11 @@ export function EllipseTable({ state, config, currentPlayerIndex, onCardClick, c
 
     const ro = new ResizeObserver(update);
     ro.observe(seatsEl);
-    window.addEventListener("orientationchange", update);
-    
+    window.addEventListener('orientationchange', update);
+
     return () => {
       ro.disconnect();
-      window.removeEventListener("orientationchange", update);
+      window.removeEventListener('orientationchange', update);
     };
   }, [config.players, mySeatIndex]);
 
@@ -69,36 +84,40 @@ export function EllipseTable({ state, config, currentPlayerIndex, onCardClick, c
       {/* 中央の場と墓地 */}
       <div className="ellipse-table__center">
         <div id="field" className="ellipse-table__field" aria-label="場のカード">
-          {trickCards.length > 0 ? (
+          {trickCards.filter(move => !move.isDiscard).length > 0 ? (
             <div className="trick-cards-queue" aria-live="polite">
-              {trickCards.map((trickCard) => {
-                const cardKey = `${trickCard.player}-${trickCard.timestamp}`;
-                const isLatestPlayed = latestPlayedCardKey === cardKey;
-                const isWinnerCard = trickWinner !== null && trickCard.player === trickWinner;
+              {trickCards
+                .filter(move => !move.isDiscard)
+                .map(trickCard => {
+                  const cardKey = `${trickCard.player}-${trickCard.timestamp}`;
+                  const isLatestPlayed = latestPlayedCardKey === cardKey;
+                  const isWinnerCard = trickWinner !== null && trickCard.player === trickWinner;
 
-                return (
-                  <div
-                    key={cardKey}
-                    className={[
-                      'trick-card-entry',
-                      isLatestPlayed ? 'card-play' : '',
-                      isWinnerCard ? 'winner' : ''
-                    ].filter(Boolean).join(' ')}
-                  >
-                    <div className="trick-card-player">{getPlayerName(trickCard.player)}</div>
-                    <div className="card current-card">
-                      <div className="card-number">{trickCard.card}</div>
-                      <div className="cucumber-icons">
-                        {trickCard.card >= 2 && trickCard.card <= 5 && '🥒'}
-                        {trickCard.card >= 6 && trickCard.card <= 9 && '🥒🥒'}
-                        {trickCard.card >= 10 && trickCard.card <= 11 && '🥒🥒🥒'}
-                        {trickCard.card >= 12 && trickCard.card <= 14 && '🥒🥒🥒🥒'}
-                        {trickCard.card === 15 && '🥒🥒🥒🥒🥒'}
+                  return (
+                    <div
+                      key={cardKey}
+                      className={[
+                        'trick-card-entry',
+                        isLatestPlayed ? 'card-play' : '',
+                        isWinnerCard ? 'winner' : '',
+                      ]
+                        .filter(Boolean)
+                        .join(' ')}
+                    >
+                      <div className="trick-card-player">{getPlayerName(trickCard.player)}</div>
+                      <div className="card current-card">
+                        <div className="card-number">{trickCard.card}</div>
+                        <div className="cucumber-icons">
+                          {trickCard.card >= 2 && trickCard.card <= 5 && '🥒'}
+                          {trickCard.card >= 6 && trickCard.card <= 9 && '🥒🥒'}
+                          {trickCard.card >= 10 && trickCard.card <= 11 && '🥒🥒🥒'}
+                          {trickCard.card >= 12 && trickCard.card <= 14 && '🥒🥒🥒🥒'}
+                          {trickCard.card === 15 && '🥒🥒🥒🥒🥒'}
+                        </div>
                       </div>
                     </div>
-                  </div>
-                );
-              })}
+                  );
+                })}
             </div>
           ) : state.fieldCard !== null ? (
             <div className="card current-card">
@@ -138,34 +157,32 @@ export function EllipseTable({ state, config, currentPlayerIndex, onCardClick, c
               className={`seat ${isTurn ? 'turn' : ''}`}
               data-active={state.currentPlayer === i}
             >
-            <div className="content">
-              <div className="player-name">{getPlayerName(i)}</div>
-              <div className="player-stats">
-                <div className="cucumber-count">
-                  🥒 <span>{player.cucumbers}</span>
+              <div className="content">
+                <div className="player-name">{getPlayerName(i)}</div>
+                <div className="player-stats">
+                  <div className="cucumber-count">
+                    🥒 <span>{player.cucumbers}</span>
+                  </div>
+                  <div className="cards-count">
+                    🃏 <span>{player.hand.length}</span>
+                  </div>
                 </div>
-                <div className="cards-count">
-                  🃏 <span>{player.hand.length}</span>
-                </div>
+                {i !== mySeatIndex && (
+                  <div className="player-hand-visual">
+                    {showAllHands
+                      ? // デバッグモード：実際のカード値を表示
+                        player.hand.map((card, cardIndex) => (
+                          <div key={cardIndex} className="debug-card" title={`カード${card}`}>
+                            {card}
+                          </div>
+                        ))
+                      : // 通常モード：裏面のカードを表示
+                        player.hand.map((_, cardIndex) => (
+                          <div key={cardIndex} className="mini-card" />
+                        ))}
+                  </div>
+                )}
               </div>
-              {i !== mySeatIndex && (
-                <div className="player-hand-visual">
-                  {showAllHands ? (
-                    // デバッグモード：実際のカード値を表示
-                    player.hand.map((card, cardIndex) => (
-                      <div key={cardIndex} className="debug-card" title={`カード${card}`}>
-                        {card}
-                      </div>
-                    ))
-                  ) : (
-                    // 通常モード：裏面のカードを表示
-                    player.hand.map((_, cardIndex) => (
-                      <div key={cardIndex} className="mini-card" />
-                    ))
-                  )}
-                </div>
-              )}
-            </div>
             </div>
           );
         })}
@@ -180,26 +197,32 @@ export function EllipseTable({ state, config, currentPlayerIndex, onCardClick, c
             const isMinCard = card === Math.min(...state.players[mySeatIndex].hand);
             const isDiscard = !isPlayable && isMinCard;
             const isMyTurn = currentPlayerIndex === mySeatIndex;
-            
+
             // カードが送信中またはロックされているかチェック
             const isCardLocked = lockedCardId === card;
             const isAllLocked = isSubmitting || className?.includes('cards-locked');
-            const isDisabled = !isMyTurn || isAllLocked || isCardLocked || state.phase !== 'AwaitMove';
-            
+            const isDisabled =
+              !isMyTurn || isAllLocked || isCardLocked || state.phase !== 'AwaitMove';
+
             const handleCardClick = (e: React.MouseEvent) => {
               e.preventDefault();
               if (isDisabled || isSubmitting || !isMyTurn) return;
               onCardClick?.(card);
             };
-            
+
             return (
               <div
                 key={`${card}-${index}`}
                 className={`card ${
-                  isCardLocked ? 'disabled locked' :
-                  isDisabled ? 'disabled' :
-                  isPlayable ? 'playable' : 
-                  isDiscard ? 'discard' : 'disabled'
+                  isCardLocked
+                    ? 'disabled locked'
+                    : isDisabled
+                      ? 'disabled'
+                      : isPlayable
+                        ? 'playable'
+                        : isDiscard
+                          ? 'discard'
+                          : 'disabled'
                 }`}
                 onClick={handleCardClick}
                 onPointerDown={handleCardClick}
@@ -214,6 +237,7 @@ export function EllipseTable({ state, config, currentPlayerIndex, onCardClick, c
                   {card >= 12 && card <= 14 && '🥒🥒🥒🥒'}
                   {card === 15 && '🥒🥒🥒🥒🥒'}
                 </div>
+                {isDiscard ? <div className="discard-tag">捨てる</div> : null}
               </div>
             );
           })}

--- a/apps/hub/lib/game-core/engine.ts
+++ b/apps/hub/lib/game-core/engine.ts
@@ -2,20 +2,19 @@
 
 import { SeededRng } from './rng';
 import {
-    calculateFinalTrickPenalty,
-    createDeck,
-    dealCards,
-    determineTrickWinner,
-    getGameOverPlayers,
-    getLegalMoves,
-    initializeCardCounts,
-    isGameOver,
-    isTrickComplete,
-    shouldStartNewRound,
-    updateCardCounts
+  calculateFinalTrickPenalty,
+  createDeck,
+  dealCards,
+  determineTrickWinner,
+  getGameOverPlayers,
+  getLegalMoves,
+  initializeCardCounts,
+  isGameOver,
+  isTrickComplete,
+  shouldStartNewRound,
+  updateCardCounts,
 } from './rules';
 import { ActionResult, GameConfig, GamePhase, GameState, GameView, Move } from './types';
-
 
 function cloneState(state: GameState): GameState {
   return {
@@ -23,28 +22,28 @@ function cloneState(state: GameState): GameState {
     players: state.players.map(player => ({
       ...player,
       hand: [...player.hand],
-      graveyard: [...player.graveyard]
+      graveyard: [...player.graveyard],
     })),
     sharedGraveyard: [...state.sharedGraveyard],
     trickCards: state.trickCards.map(trickCard => ({ ...trickCard })),
     gameOverPlayers: [...state.gameOverPlayers],
     remainingCards: [...state.remainingCards],
-    cardCounts: [...state.cardCounts]
+    cardCounts: [...state.cardCounts],
   };
 }
 
 export function createInitialState(config: GameConfig, rng: SeededRng): GameState {
   const deck = rng.shuffle(createDeck());
   const hands = dealCards(deck, config.players, config.initialCards);
-  
+
   const players = hands.map(hand => ({
     hand,
     cucumbers: 0,
-    graveyard: []
+    graveyard: [],
   }));
-  
+
   const firstPlayer = rng.nextInt(config.players);
-  
+
   return {
     players,
     currentPlayer: firstPlayer,
@@ -58,40 +57,45 @@ export function createInitialState(config: GameConfig, rng: SeededRng): GameStat
     gameOverPlayers: [],
     remainingCards: deck.slice(config.players * config.initialCards),
     cardCounts: initializeCardCounts(),
-    phase: "AwaitMove" as GamePhase
+    phase: 'AwaitMove' as GamePhase,
   };
 }
 
-export function applyMove(state: GameState, move: Move, config: GameConfig, rng: SeededRng): ActionResult {
+export function applyMove(
+  state: GameState,
+  move: Move,
+  config: GameConfig,
+  rng: SeededRng
+): ActionResult {
   const { player, card } = move;
-  
+
   // フェーズチェック
-  if (state.phase !== "AwaitMove") {
+  if (state.phase !== 'AwaitMove') {
     return { success: false, newState: state, message: 'Invalid phase for move' };
   }
-  
+
   // バリデーション
   if (player !== state.currentPlayer) {
     return { success: false, newState: state, message: 'Not your turn' };
   }
-  
+
   const legalMoves = getLegalMoves(state, player);
   if (!legalMoves.includes(card)) {
     return { success: false, newState: state, message: 'Illegal move' };
   }
-  
+
   const playerHand = state.players[player].hand;
   const cardIndex = playerHand.indexOf(card);
   if (cardIndex === -1) {
     return { success: false, newState: state, message: 'Card not in hand' };
   }
-  
+
   // 新しい状態を作成
   const players = state.players.map((p, i) => {
     const base = {
       ...p,
       hand: [...p.hand],
-      graveyard: [...p.graveyard]
+      graveyard: [...p.graveyard],
     };
 
     if (i === player) {
@@ -101,18 +105,23 @@ export function applyMove(state: GameState, move: Move, config: GameConfig, rng:
     return base;
   });
 
-  const trickCards = [...state.trickCards, move];
   const sharedGraveyard = [...state.sharedGraveyard];
 
   let fieldCard = state.fieldCard;
+  let isDiscard = false;
 
   // カードを場に出すか墓地に送るか
   if (fieldCard === null || card >= fieldCard) {
     fieldCard = card;
   } else {
+    isDiscard = true;
     players[player].graveyard.push(card);
     sharedGraveyard.push(card);
   }
+
+  const trickCards = isDiscard
+    ? [...state.trickCards]
+    : [...state.trickCards, { ...move, isDiscard: false }];
 
   const newState: GameState = {
     ...state,
@@ -121,77 +130,77 @@ export function applyMove(state: GameState, move: Move, config: GameConfig, rng:
     sharedGraveyard,
     cardCounts: updateCardCounts(state.cardCounts, [card]),
     fieldCard,
-    currentPlayer: (state.currentPlayer + 1) % config.players
+    currentPlayer: (state.currentPlayer + 1) % config.players,
   };
 
   // トリックが完了したかチェック
   if (isTrickComplete(newState.trickCards, config.players, newState.firstPlayer)) {
-    newState.phase = "ResolvingTrick";
+    newState.phase = 'ResolvingTrick';
     return endTrick(newState, config, rng);
   }
-  
+
   return { success: true, newState };
 }
 
 export function endTrick(state: GameState, config: GameConfig, rng: SeededRng): ActionResult {
   const newState = cloneState(state);
-  
+
   // 勝者を決定
   const winner = determineTrickWinner(newState.trickCards);
   newState.currentPlayer = winner;
   newState.firstPlayer = winner;
-  
+
   // 最終トリックかチェック
   if (shouldStartNewRound(newState)) {
-    newState.phase = "RoundEnd";
+    newState.phase = 'RoundEnd';
     return finalRound(newState, config, rng);
   }
-  
+
   // 次のトリックに進む
   newState.currentTrick++;
   newState.fieldCard = null;
   newState.trickCards = [];
-  newState.phase = "AwaitMove";
-  
+  newState.phase = 'AwaitMove';
+
   return { success: true, newState };
 }
 
 export function finalRound(state: GameState, config: GameConfig, rng: SeededRng): ActionResult {
   const newState = cloneState(state);
-  
+
   // 最終トリックのペナルティを計算
   const { winner, penalty } = calculateFinalTrickPenalty(newState.trickCards, config);
-  
+
   if (winner >= 0) {
     newState.players[winner].cucumbers += penalty;
   }
-  
+
   // ゲーム終了チェック
   if (isGameOver(newState, config)) {
     newState.isGameOver = true;
     newState.gameOverPlayers = getGameOverPlayers(newState, config);
-    newState.phase = "GameEnd";
+    newState.phase = 'GameEnd';
     return { success: true, newState };
   }
-  
+
   // 次のラウンドに進む
   return startNewRound(newState, config, rng);
 }
 
 export function startNewRound(state: GameState, config: GameConfig, rng: SeededRng): ActionResult {
   const newState = cloneState(state);
-  
+
   // 新しいデッキを作成
   const deck = rng.shuffle(createDeck());
   const hands = dealCards(deck, config.players, config.initialCards);
-  
+
   // プレイヤー状態をリセット
   newState.players = hands.map((hand, i) => ({
     hand,
     cucumbers: newState.players[i].cucumbers,
-    graveyard: []
+    graveyard: [],
   }));
-  
+
   newState.currentRound++;
   newState.currentTrick = 1;
   newState.fieldCard = null;
@@ -201,18 +210,22 @@ export function startNewRound(state: GameState, config: GameConfig, rng: SeededR
   newState.currentPlayer = newState.firstPlayer;
   newState.remainingCards = deck.slice(config.players * config.initialCards);
   newState.cardCounts = initializeCardCounts();
-  newState.phase = "AwaitMove";
-  
+  newState.phase = 'AwaitMove';
+
   return { success: true, newState };
 }
 
-export function createGameView(state: GameState, config: GameConfig, playerIndex: number): GameView {
+export function createGameView(
+  state: GameState,
+  config: GameConfig,
+  playerIndex: number
+): GameView {
   return {
     state,
     config,
     legalMoves: getLegalMoves(state, playerIndex),
     isMyTurn: state.currentPlayer === playerIndex,
-    playerIndex
+    playerIndex,
   };
 }
 
@@ -253,10 +266,10 @@ export function getPlayerGraveyard(state: GameState, playerIndex: number): numbe
  */
 export function getEffectiveTurnSeconds(config: GameConfig): number | null {
   if (config.turnSeconds === null) return null;
-  
+
   const minTurnMs = config.minTurnMs || 500;
   const minTurnSeconds = minTurnMs / 1000;
-  
+
   return Math.max(minTurnSeconds, config.turnSeconds);
 }
 

--- a/apps/hub/lib/game-core/types.ts
+++ b/apps/hub/lib/game-core/types.ts
@@ -9,6 +9,7 @@ export interface Move {
   player: number;
   card: number;
   timestamp: number;
+  isDiscard?: boolean;
 }
 
 export interface Trick {
@@ -23,7 +24,7 @@ export interface PlayerState {
   graveyard: number[];
 }
 
-export type GamePhase = "AwaitMove" | "ResolvingTrick" | "RoundEnd" | "GameEnd";
+export type GamePhase = 'AwaitMove' | 'ResolvingTrick' | 'RoundEnd' | 'GameEnd';
 
 export interface GameState {
   players: PlayerState[];
@@ -85,7 +86,6 @@ export interface PlayerController {
   onGameEnd?(result: SimulationResult): void;
   onTrickEnd?(trick: Trick): void;
 }
-
 
 export interface GameSnapshot {
   state: GameState;

--- a/games/cucumber5/index.ts
+++ b/games/cucumber5/index.ts
@@ -1,4 +1,13 @@
-import { Cucumber5Card, Cucumber5Player, Cucumber5State, GameEvent, GameHandle, GameMeta, GameModule, GameOptions } from '@five-cucumber/sdk';
+import {
+  Cucumber5Card,
+  Cucumber5Player,
+  Cucumber5State,
+  GameEvent,
+  GameHandle,
+  GameMeta,
+  GameModule,
+  GameOptions,
+} from '@five-cucumber/sdk';
 import { cpuManager, Difficulty } from './cpu';
 import { Cucumber5Rules } from './rules';
 import { Cucumber5View, Cucumber5ViewAction } from './view';
@@ -17,7 +26,7 @@ export class Cucumber5GameModule implements GameModule {
     icon: '🥒',
     theme: 'antique',
     description: 'きゅうりを5本集めないようにするカードゲーム',
-    rules: '数字の大きいカードがトリックを取ります。最終トリックで最大値を出すときゅうり2本！'
+    rules: '数字の大きいカードがトリックを取ります。最終トリックで最大値を出すときゅうり2本！',
   };
 
   private gameState: Cucumber5State | null = null;
@@ -49,11 +58,7 @@ class Cucumber5GameHandle implements GameHandle {
   private humanPlayerIndex = 0;
   private view: Cucumber5View | null = null;
 
-  constructor(
-    element: HTMLElement,
-    options: GameOptions,
-    onEvent: (event: GameEvent) => void
-  ) {
+  constructor(element: HTMLElement, options: GameOptions, onEvent: (event: GameEvent) => void) {
     this.element = element;
     this.options = options;
     this.onEvent = onEvent;
@@ -76,8 +81,8 @@ class Cucumber5GameHandle implements GameHandle {
       gameId: 'cucumber5',
       data: {
         players: this.state.players.map(p => p.id),
-        options: this.options
-      }
+        options: this.options,
+      },
     });
 
     // Start first turn
@@ -138,7 +143,7 @@ class Cucumber5GameHandle implements GameHandle {
       hand: hands[index] || [],
       cucumbers: 0,
       graveyard: [],
-      isCPU: player.isCPU
+      isCPU: player.isCPU,
     }));
 
     return {
@@ -152,7 +157,7 @@ class Cucumber5GameHandle implements GameHandle {
       timeLeft: 15,
       phase: 'playing',
       turn: 1,
-      data: {}
+      data: {},
     };
   }
 
@@ -161,7 +166,7 @@ class Cucumber5GameHandle implements GameHandle {
       state: this.state,
       locale: this.options.locale,
       onEvent: this.onEvent,
-      onRequestAction: this.handleViewAction
+      onRequestAction: this.handleViewAction,
     });
   }
 
@@ -209,7 +214,10 @@ class Cucumber5GameHandle implements GameHandle {
 
     const selectedCard = player.hand[cardIndex];
 
-    if (this.state.fieldCard === null || selectedCard.number >= (this.state.fieldCard?.number ?? 0)) {
+    if (
+      this.state.fieldCard === null ||
+      selectedCard.number >= (this.state.fieldCard?.number ?? 0)
+    ) {
       this.playCard(selectedCard, cardIndex);
     } else {
       this.discardCard(selectedCard, cardIndex);
@@ -222,14 +230,17 @@ class Cucumber5GameHandle implements GameHandle {
     const player = this.state.players[this.state.currentPlayer];
     if (!player) return;
 
-    const index = typeof handIndex === 'number' ? handIndex : player.hand.findIndex(c => this.isSameCard(c, card));
+    const index =
+      typeof handIndex === 'number'
+        ? handIndex
+        : player.hand.findIndex(c => this.isSameCard(c, card));
     if (index === -1) return;
 
     const [playedCard] = player.hand.splice(index, 1);
 
     this.state.trickCards.push({
       player: this.state.currentPlayer,
-      card: playedCard
+      card: playedCard,
     });
 
     this.state.fieldCard = playedCard;
@@ -250,17 +261,16 @@ class Cucumber5GameHandle implements GameHandle {
     const player = this.state.players[this.state.currentPlayer];
     if (!player) return;
 
-    const index = typeof handIndex === 'number' ? handIndex : player.hand.findIndex(c => this.isSameCard(c, card));
+    const index =
+      typeof handIndex === 'number'
+        ? handIndex
+        : player.hand.findIndex(c => this.isSameCard(c, card));
     if (index === -1) return;
 
     const [discardedCard] = player.hand.splice(index, 1);
 
     player.graveyard.push(discardedCard);
     this.state.sharedGraveyard.push(discardedCard);
-    this.state.trickCards.push({
-      player: this.state.currentPlayer,
-      card: discardedCard
-    });
     this.isAnimating = true;
 
     this.updateView();
@@ -274,7 +284,7 @@ class Cucumber5GameHandle implements GameHandle {
 
   private nextPlayer(): void {
     this.state.currentPlayer = (this.state.currentPlayer + 1) % this.state.players.length;
-    
+
     if (this.state.trickCards.length === this.state.players.length) {
       this.endTrick();
     } else {
@@ -290,7 +300,7 @@ class Cucumber5GameHandle implements GameHandle {
     }
 
     const { winner, maxCard } = Cucumber5Rules.processTrick(this.state.trickCards);
-    
+
     this.state.currentPlayer = winner;
     this.state.trick++;
     this.state.turn++;
@@ -320,7 +330,7 @@ class Cucumber5GameHandle implements GameHandle {
 
     // Check game over
     const { isOver, losers } = Cucumber5Rules.isGameOver(this.state.players);
-    
+
     if (isOver) {
       this.endGame(losers);
     } else {
@@ -340,7 +350,7 @@ class Cucumber5GameHandle implements GameHandle {
     // Deal new cards
     const deck = Cucumber5Rules.createDeck();
     const hands = Cucumber5Rules.dealCards(deck, this.state.players.length);
-    
+
     this.state.players.forEach((player, index) => {
       player.hand = hands[index] || [];
       player.graveyard = [];
@@ -360,30 +370,32 @@ class Cucumber5GameHandle implements GameHandle {
     this.stopTimer();
     this.state.phase = 'game_over';
 
-    const scores = this.state.players.reduce((acc, player, index) => {
-      acc[player.id] = player.cucumbers;
-      return acc;
-    }, {} as Record<string, number>);
+    const scores = this.state.players.reduce(
+      (acc, player, index) => {
+        acc[player.id] = player.cucumbers;
+        return acc;
+      },
+      {} as Record<string, number>
+    );
 
     this.onEvent({
       type: 'match:end',
       timestamp: Date.now(),
       gameId: 'cucumber5',
       data: {
-        winnerIds: this.state.players
-          .filter((_, index) => !losers.includes(index))
-          .map(p => p.id),
+        winnerIds: this.state.players.filter((_, index) => !losers.includes(index)).map(p => p.id),
         scores,
         duration: Date.now() - (this.state as any).startTime || 0,
-        reason: 'completed'
-      }
+        reason: 'completed',
+      },
     });
 
     this.updateView();
   }
 
   private scheduleCPUAction(): void {
-    if (!this.isRunning || this.isAnimating || this.state.currentPlayer === this.humanPlayerIndex) return;
+    if (!this.isRunning || this.isAnimating || this.state.currentPlayer === this.humanPlayerIndex)
+      return;
 
     const playerIndex = this.state.currentPlayer;
     const player = this.state.players[playerIndex];
@@ -406,7 +418,10 @@ class Cucumber5GameHandle implements GameHandle {
 
       const targetCard = currentPlayer.hand[handIndex];
 
-      if (this.state.fieldCard === null || targetCard.number >= (this.state.fieldCard?.number ?? 0)) {
+      if (
+        this.state.fieldCard === null ||
+        targetCard.number >= (this.state.fieldCard?.number ?? 0)
+      ) {
         this.playCard(targetCard, handIndex);
       } else {
         this.discardCard(targetCard, handIndex);
@@ -418,13 +433,13 @@ class Cucumber5GameHandle implements GameHandle {
     this.stopTimer();
     this.state.timeLeft = 15;
     this.patchView({ timeLeft: this.state.timeLeft });
-    
+
     this.timer = setInterval(() => {
       if (!this.isRunning) return;
-      
+
       this.state.timeLeft--;
       this.patchView({ timeLeft: this.state.timeLeft });
-      
+
       if (this.state.timeLeft <= 0) {
         this.stopTimer();
         this.autoPlay();
@@ -449,7 +464,7 @@ class Cucumber5GameHandle implements GameHandle {
     const player = this.state.players[this.humanPlayerIndex];
     if (!player) return;
     const playableCards = Cucumber5Rules.getPlayableCards(player, this.state.fieldCard);
-    
+
     if (playableCards.length > 0) {
       const card = playableCards[0];
       const handIndex = player.hand.findIndex(c => this.isSameCard(c, card));
@@ -457,7 +472,10 @@ class Cucumber5GameHandle implements GameHandle {
 
       const targetCard = player.hand[handIndex];
 
-      if (this.state.fieldCard === null || targetCard.number >= (this.state.fieldCard?.number ?? 0)) {
+      if (
+        this.state.fieldCard === null ||
+        targetCard.number >= (this.state.fieldCard?.number ?? 0)
+      ) {
         this.playCard(targetCard, handIndex);
       } else {
         this.discardCard(targetCard, handIndex);
@@ -476,7 +494,7 @@ class Cucumber5GameHandle implements GameHandle {
     const indexCandidates = [
       rawOptions.humanPlayerIndex,
       rawOptions.playerIndex,
-      rawOptions.localPlayerIndex
+      rawOptions.localPlayerIndex,
     ];
 
     for (const candidate of indexCandidates) {
@@ -486,7 +504,9 @@ class Cucumber5GameHandle implements GameHandle {
     }
 
     if (typeof rawOptions.localPlayerId === 'string') {
-      const playerIndex = options.players.findIndex(player => player.id === rawOptions.localPlayerId);
+      const playerIndex = options.players.findIndex(
+        player => player.id === rawOptions.localPlayerId
+      );
       if (playerIndex >= 0) return playerIndex;
     }
 
@@ -499,7 +519,7 @@ class Cucumber5GameHandle implements GameHandle {
       type: 'game_action',
       timestamp: Date.now(),
       gameId: 'cucumber5',
-      data: { action: type, ...data }
+      data: { action: type, ...data },
     });
   }
 


### PR DESCRIPTION
### Motivation
- Fix critical game logic where players (human/CPU) could not discard their minimum card when no legal plays existed, causing invalid play flow. 
- Ensure discarded cards do not appear as normal trick cards on the field to avoid confusing the player view. 
- Improve player info layout and the ellipse table visuals to avoid overlapping text and heavy border outlines.

### Description
- Add an `isDiscard?: boolean` flag to the `Move` type and update `applyMove()` to detect discard moves, put discarded cards into graveyards, and avoid pushing discard moves into `trickCards`. (`apps/hub/lib/game-core/types.ts`, `apps/hub/lib/game-core/engine.ts`).
- Update the CPU/human play flow to set and show a short notice when the min-card discard occurs and to generate `Move` objects with `isDiscard` for visibility/notifications. (`apps/hub/app/cucumber/cpu/play/page.tsx`).
- Change the table UI to filter out discard moves from the trick display and add an explicit `捨てる` badge on the player's min-card in hand when it is a discard candidate. (`apps/hub/components/ui/EllipseTable.tsx`).
- Stop adding discard cards to `trickCards` in the standalone game module implementation as well. (`games/cucumber5/index.ts`).
- UI/CSS tweaks: reduce border/outline prominence and move to shadow/gradient styling, increase seat content padding and font sizing to avoid overlap, and add notice/banner styles for discard messages. (`apps/hub/app/cucumber/cpu/play/game.css`, `apps/hub/app/globals.css`).

### Testing
- Ran lint for the hub app with `pnpm -C apps/hub lint`; it completed successfully with a single existing ESLint warning reported. (passed)
- Ran TypeScript checks for hub with `pnpm -C apps/hub type-check`; it completed successfully. (passed)
- Ran TypeScript checks for the game package with `pnpm -C games/cucumber5 type-check`; this failed due to workspace dependency/type resolution issues (existing `@five-cucumber/sdk` references and project-local TS errors), unrelated to the applied changes. (failed)
- Attempted an automated UI smoke run by starting the dev server (`pnpm -C apps/hub dev`) and a Playwright script to capture a screenshot; the server started but Playwright's Chromium crashed (SIGSEGV) in the container so screenshot could not be captured. (failed)
- Ran formatting (`prettier --write`) over changed files as part of validation. (completed)

If you want I can (1) narrow the TypeScript failures in `games/cucumber5` separately, or (2) extract a minimal unit test for the discard behavior in the `game-core` engine to be run under the hub workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b446f0448832f9ddd69e816b125a1)