### PR TITLE
fix(hub): respect discard flag during move validation

### DIFF
--- a/apps/hub/lib/game-core/engine.ts
+++ b/apps/hub/lib/game-core/engine.ts
@@ -90,6 +90,34 @@ export function applyMove(
     return { success: false, newState: state, message: 'Card not in hand' };
   }
 
+  const minCard = Math.min(...playerHand);
+  const hasLegalPlay =
+    state.fieldCard === null ? true : playerHand.some(handCard => handCard >= state.fieldCard!);
+
+  if (move.isDiscard) {
+    if (state.fieldCard === null) {
+      return { success: false, newState: state, message: 'Cannot discard on empty field' };
+    }
+
+    if (hasLegalPlay) {
+      return {
+        success: false,
+        newState: state,
+        message: 'Player has legal cards to play, cannot discard',
+      };
+    }
+
+    if (card !== minCard) {
+      return {
+        success: false,
+        newState: state,
+        message: 'Discard must be the minimum card in hand',
+      };
+    }
+  } else if (state.fieldCard !== null && card < state.fieldCard) {
+    return { success: false, newState: state, message: `Card ${card} is not legal` };
+  }
+
   // 新しい状態を作成
   const players = state.players.map((p, i) => {
     const base = {
@@ -108,13 +136,12 @@ export function applyMove(
   const sharedGraveyard = [...state.sharedGraveyard];
 
   let fieldCard = state.fieldCard;
-  let isDiscard = false;
+  const isDiscard = move.isDiscard === true;
 
   // カードを場に出すか墓地に送るか
-  if (fieldCard === null || card >= fieldCard) {
+  if (!isDiscard) {
     fieldCard = card;
   } else {
-    isDiscard = true;
     players[player].graveyard.push(card);
     sharedGraveyard.push(card);
   }


### PR DESCRIPTION
### Motivation
- Discard moves were being validated using the same rules as normal plays, causing the minimum-card discard action to be rejected with "Card X is not legal".
- The engine must treat `isDiscard` moves differently so players may discard only when they truly have no legal play and the discarded card is the hand minimum.

### Description
- Update `applyMove` in `apps/hub/lib/game-core/engine.ts` to branch validation based on `move.isDiscard` and enforce discard-specific rules.
- For discard moves, require the field to be non-empty, ensure the player has no legal play (`>= fieldCard`), and require the discarded card equals the hand minimum (`minCard`).
- For non-discard moves, explicitly reject attempts to play a card lower than `fieldCard`.
- Make state mutation follow `move.isDiscard` so discard moves are sent to the graveyard and not appended to `trickCards`.

### Testing
- Ran workspace type checks with `pnpm -w type-check` and the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e9cbf462c832fb192fa17ed6041b2)