### PR TITLE
Fix trick completion to count discard actions

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/page.tsx
+++ b/apps/hub/app/cucumber/cpu/play/page.tsx
@@ -351,7 +351,8 @@ function CpuPlayContent() {
         const trickCardsAfterPlay = isDiscardMove
           ? [...state.trickCards]
           : [...state.trickCards, move];
-        const isTrickCompleteAfterPlay = trickCardsAfterPlay.length === config.players;
+        const actionCountAfterPlay = (state.actionCount ?? 0) + 1;
+        const isTrickCompleteAfterPlay = actionCountAfterPlay === config.players;
         const playersAfterPlay = state.players.map((p, idx) => {
           if (idx !== player) {
             return p;
@@ -376,6 +377,7 @@ function CpuPlayContent() {
           fieldCard: isCardOnField ? card : state.fieldCard,
           sharedGraveyard: isCardOnField ? state.sharedGraveyard : [...state.sharedGraveyard, card],
           trickCards: trickCardsAfterPlay,
+          actionCount: actionCountAfterPlay,
           phase: isTrickCompleteAfterPlay ? 'ResolvingTrick' : 'AwaitMove',
         };
 

--- a/apps/hub/lib/game-core/rules.ts
+++ b/apps/hub/lib/game-core/rules.ts
@@ -149,8 +149,8 @@ export function getPlayerName(playerIndex: number): string {
 }
 
 // トリックが完了しているかチェック
-export function isTrickComplete(trickCards: Move[], players: number, _firstPlayer: number): boolean {
-  return trickCards.length === players;
+export function isTrickComplete(actionCount: number, players: number): boolean {
+  return actionCount === players;
 }
 
 // 次のラウンドに進むかチェック

--- a/apps/hub/lib/game-core/types.ts
+++ b/apps/hub/lib/game-core/types.ts
@@ -34,6 +34,7 @@ export interface GameState {
   fieldCard: number | null;
   sharedGraveyard: number[];
   trickCards: Move[];
+  actionCount: number; // このトリックで行動（出す/捨てる）した人数
   firstPlayer: number;
   isGameOver: boolean;
   gameOverPlayers: number[];


### PR DESCRIPTION
### Motivation
- トリックが全員行動（出す or 捨てる）したときに終了せずループする不具合を修正するため、公式ルールどおり「全員が行動したか」を基準にする必要がありました。 

### Description
- `GameState` に `actionCount: number` を追加してトリック中の行動済みカウントを保持するようにしました。 
- `applyMove` で全ての手（出す／捨てる）で `actionCount` をインクリメントし、`endTrick`／ラウンド開始時にリセットするよう実装しました。 
- ルールの `isTrickComplete` を `trickCards.length` 比較から `actionCount === players` に変更して完了判定を行うようにしました。 
- UI 側の CPU 対戦ページ (`apps/hub/app/cucumber/cpu/play/page.tsx`) のプレビュー処理でも `actionCountAfterPlay` を計算してトリック完了判定／プレビュー状態に反映するよう合わせました。 
- `cloneState`／`createInitialState`／`startNewRound` 等で `actionCount` の初期化や安全な既定値 (`state.actionCount ?? 0`) を扱う調整を行いました。 

### Testing
- 型検査として `pnpm --filter @five-cucumber/hub type-check` を実行して成功しました。 
- リントとして `pnpm --filter @five-cucumber/hub lint` を実行して成功し、今回の変更箇所に起因するエラーは発生しませんでした（既存の無関係な lint 警告が一件残存します）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ea2e25580832f8e417f118b04082b)