### PR TITLE
fix(hub): prevent invalid discard UI interactions when legal plays exist

### DIFF
--- a/apps/hub/components/ui/EllipseTable.tsx
+++ b/apps/hub/components/ui/EllipseTable.tsx
@@ -107,7 +107,7 @@ export function EllipseTable({
                       <div className="trick-card-player">{getPlayerName(trickCard.player)}</div>
                       <div className="card current-card">
                         <div className="card-number">{trickCard.card}</div>
-                        <div className="cucumber-icons">
+                          <div className="cucumber-icons">
                           {trickCard.card >= 2 && trickCard.card <= 5 && '🥒'}
                           {trickCard.card >= 6 && trickCard.card <= 9 && '🥒🥒'}
                           {trickCard.card >= 10 && trickCard.card <= 11 && '🥒🥒🥒'}
@@ -192,55 +192,68 @@ export function EllipseTable({
       <section id="hand-dock" className="ellipse-table__hand" aria-label="自分の手札">
         <div className="me-name">{getPlayerName(mySeatIndex)}</div>
         <div className="hand">
-          {state.players[mySeatIndex]?.hand.map((card, index) => {
-            const isPlayable = state.fieldCard === null || card >= state.fieldCard;
-            const isMinCard = card === Math.min(...state.players[mySeatIndex].hand);
-            const isDiscard = !isPlayable && isMinCard;
-            const isMyTurn = currentPlayerIndex === mySeatIndex;
-
-            // カードが送信中またはロックされているかチェック
-            const isCardLocked = lockedCardId === card;
-            const isAllLocked = isSubmitting || className?.includes('cards-locked');
-            const isDisabled =
-              !isMyTurn || isAllLocked || isCardLocked || state.phase !== 'AwaitMove';
-
-            const handleCardClick = (e: React.MouseEvent) => {
-              e.preventDefault();
-              if (isDisabled || isSubmitting || !isMyTurn) return;
-              onCardClick?.(card);
-            };
-
-            return (
-              <div
-                key={`${card}-${index}`}
-                className={`card ${
-                  isCardLocked
-                    ? 'disabled locked'
-                    : isDisabled
-                      ? 'disabled'
-                      : isPlayable
-                        ? 'playable'
-                        : isDiscard
-                          ? 'discard'
-                          : 'disabled'
-                }`}
-                onClick={handleCardClick}
-                onPointerDown={handleCardClick}
-                style={{ pointerEvents: isDisabled ? 'none' : 'auto' }}
-                aria-disabled={isDisabled}
-              >
-                <div className="card-number">{card}</div>
-                <div className="cucumber-icons">
-                  {card >= 2 && card <= 5 && '🥒'}
-                  {card >= 6 && card <= 9 && '🥒🥒'}
-                  {card >= 10 && card <= 11 && '🥒🥒🥒'}
-                  {card >= 12 && card <= 14 && '🥒🥒🥒🥒'}
-                  {card === 15 && '🥒🥒🥒🥒🥒'}
-                </div>
-                {isDiscard ? <div className="discard-tag">捨てる</div> : null}
-              </div>
+          {(() => {
+            const myHand = state.players[mySeatIndex]?.hand ?? [];
+            const highestOnTable = state.fieldCard;
+            const hasLegalPlay = myHand.some(
+              handCard => highestOnTable === null || handCard >= highestOnTable
             );
-          })}
+            const minCard = myHand.length > 0 ? Math.min(...myHand) : null;
+
+            return myHand.map((card, index) => {
+              const isPlayable = highestOnTable === null || card >= highestOnTable;
+              const isDiscard = !hasLegalPlay && minCard !== null && card === minCard;
+              const isIllegalWhileLegalExists = hasLegalPlay && !isPlayable;
+              const isMyTurn = currentPlayerIndex === mySeatIndex;
+
+              // カードが送信中またはロックされているかチェック
+              const isCardLocked = lockedCardId === card;
+              const isAllLocked = isSubmitting || className?.includes('cards-locked');
+              const isDisabled =
+                !isMyTurn ||
+                isAllLocked ||
+                isCardLocked ||
+                state.phase !== 'AwaitMove' ||
+                isIllegalWhileLegalExists;
+
+              const handleCardClick = (e: React.MouseEvent) => {
+                e.preventDefault();
+                if (isDisabled || isSubmitting || !isMyTurn) return;
+                onCardClick?.(card);
+              };
+
+              return (
+                <div
+                  key={`${card}-${index}`}
+                  className={`card ${
+                    isCardLocked
+                      ? 'disabled locked'
+                      : isDisabled
+                        ? 'disabled'
+                        : isPlayable
+                          ? 'playable'
+                          : isDiscard
+                            ? 'discard'
+                            : 'disabled'
+                  }`}
+                  onClick={handleCardClick}
+                  onPointerDown={handleCardClick}
+                  style={{ pointerEvents: isDisabled ? 'none' : 'auto' }}
+                  aria-disabled={isDisabled}
+                >
+                  <div className="card-number">{card}</div>
+                  <div className="cucumber-icons">
+                    {card >= 2 && card <= 5 && '🥒'}
+                    {card >= 6 && card <= 9 && '🥒🥒'}
+                    {card >= 10 && card <= 11 && '🥒🥒🥒'}
+                    {card >= 12 && card <= 14 && '🥒🥒🥒🥒'}
+                    {card === 15 && '🥒🥒🥒🥒🥒'}
+                  </div>
+                  {isDiscard ? <div className="discard-tag">捨てる</div> : null}
+                </div>
+              );
+            });
+          })()}
         </div>
       </section>
     </div>


### PR DESCRIPTION
### Motivation
- プレイヤーの手札に「出せるカード」と「出せないカード」が混在する場合に、出せないカードの「捨てる」ラベルが誤表示されてエラー（`Card X is not legal`）が発生する問題を修正するため。
- UI側でクリック可能/不可の振る舞いをルール（場の最高値以上のカードが出せるなら捨て不可）に合わせて明示するため。

### Description
- `apps/hub/components/ui/EllipseTable.tsx` の手札描画を変更し、先に `hasLegalPlay`（場に出せるカードが1枚でもあるか）を判定するようにした。 
- `捨てる` バッジは `hasLegalPlay === false` のときのみ手札の最小値カードに表示するようにした。 
- `hasLegalPlay === true` の場合は場の最高値未満のカードを `isIllegalWhileLegalExists` として無効化し、グレーアウトおよびクリック不可（`pointer-events: none`）にしてクライアントから不正なムーブが送信されないようにした。 
- エンジン側の `applyMove` 等のバリデーションは変更しておらず、サーバ/エンジンのルールはそのまま維持している。 

### Testing
- 型チェックを実行して `pnpm -C apps/hub type-check` は成功した。 
- リントを実行して `pnpm -C apps/hub lint` は成功（既存の unrelated lint 警告が1件あるが今回の変更箇所とは無関係）。 
- 開発サーバを起動して該当画面にブラウザでアクセスし（`/cucumber/cpu/play`）、UIが期待通りに動作することを手動確認およびページのスクリーンショットを取得した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ea660ebf4832f9b2350bb53b26528)