### PR TITLE
Fix trick tie-break winner resolution and final-trick penalty notice

### DIFF
--- a/apps/hub/lib/game-core/rules.ts
+++ b/apps/hub/lib/game-core/rules.ts
@@ -44,24 +44,38 @@ export function getLegalMoves(state: GameState, player: number): number[] {
 // トリックの勝者を決定
 export function determineTrickWinner(trickCards: Move[]): number {
   if (trickCards.length === 0) return -1;
-  
-  const maxCard = Math.max(...trickCards.map(tc => tc.card));
-  const maxCardPlayers = trickCards.filter(tc => tc.card === maxCard);
-  
-  // 同値最大が複数の場合、最後に出した人が勝者
-  return maxCardPlayers[maxCardPlayers.length - 1].player;
+
+  let winnerIndex = 0;
+  let highestValue = trickCards[0].card;
+
+  for (let i = 1; i < trickCards.length; i++) {
+    // 同値の場合は後から出したカードを勝者として上書きする
+    if (trickCards[i].card >= highestValue) {
+      highestValue = trickCards[i].card;
+      winnerIndex = i;
+    }
+  }
+
+  return trickCards[winnerIndex].player;
 }
 
 // 最終トリックのペナルティ計算
 export function calculateFinalTrickPenalty(trickCards: Move[], _config: GameConfig): { winner: number; penalty: number } {
   if (trickCards.length === 0) return { winner: -1, penalty: 0 };
-  
-  const maxCard = Math.max(...trickCards.map(tc => tc.card));
+
+  let winnerIndex = 0;
+  let maxCard = trickCards[0].card;
+
+  for (let i = 1; i < trickCards.length; i++) {
+    if (trickCards[i].card >= maxCard) {
+      maxCard = trickCards[i].card;
+      winnerIndex = i;
+    }
+  }
+
   const hasOne = trickCards.some(tc => tc.card === 1);
-  
-  // 最大カードを出したプレイヤーの中で、最後に出した人が勝者
-  const winners = trickCards.filter(tc => tc.card === maxCard);
-  const winner = winners[winners.length - 1].player;
+
+  const winner = trickCards[winnerIndex].player;
   
   let penalty = getCucumberCount(maxCard);
   if (hasOne) penalty *= 2;


### PR DESCRIPTION
### Motivation
- Ensure trick winner selection follows official rule that when multiple players play the same (highest) value, the player who played last wins.  
- Ensure final-trick penalty calculation uses the same tie-break behavior and show penalty messaging only at the final trick.  
- Remove noisy per-trick winner notifications so only the final-trick result (penalty or "ペナルティなし") is shown.  

### Description
- Updated `determineTrickWinner` to scan trick cards and use `>=` so later plays override equal highest values (file: `apps/hub/lib/game-core/rules.ts`).  
- Aligned `calculateFinalTrickPenalty` to pick the winner with the same last-played-on-tie rule and compute penalty as before (file: `apps/hub/lib/game-core/rules.ts`).  
- Modified CPU-play UI to suppress per-trick winner text for tricks 1–6 and only display final-trick results with the following rules: show `ペナルティなし` when all cards are `1`, otherwise show `◯◯が△本のきゅうりを獲得しました` and append `（2倍ペナルティ）` when a `1` is present (file: `apps/hub/app/cucumber/cpu/play/page.tsx`).  

### Testing
- Ran type-check with `npm --prefix apps/hub run type-check` and it succeeded.  
- Ran linter with `npm --prefix apps/hub run lint` and it completed; the run reports an unrelated `no-explicit-any` warning in `app/api/game/move/route.ts`.  
- Started the dev server and exercised the `/cucumber/cpu/play` page and captured a Playwright screenshot to validate the final-trick notice UI (`artifacts/cpu-play-final-trick-notice.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eac77f6c4832fa31c230fbadb32d8)