### PR TITLE
Final-trick simultaneous reveal and 1-card double-penalty rule

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/game.css
+++ b/apps/hub/app/cucumber/cpu/play/game.css
@@ -99,6 +99,44 @@
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
 }
 
+.final-trick-notice {
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 0.9rem;
+  font-weight: 800;
+  color: #fff;
+  background: rgba(255, 120, 80, 0.3);
+  border: 1px solid rgba(255, 160, 120, 0.8);
+  width: fit-content;
+}
+
+.final-selected-badge {
+  margin-top: 6px;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #fef3c7;
+  border: 1px solid rgba(251, 191, 36, 0.8);
+  background: rgba(217, 119, 6, 0.25);
+}
+
+.card-back {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.card-flip {
+  animation: flip 0.5s ease-in-out;
+}
+
+@keyframes flip {
+  0% { transform: rotateY(0deg); }
+  50% { transform: rotateY(90deg); }
+  100% { transform: rotateY(0deg); }
+}
+
 .ellipse-table__grave {
   opacity: 0.9;
 }

--- a/apps/hub/components/ui/EllipseTable.tsx
+++ b/apps/hub/components/ui/EllipseTable.tsx
@@ -19,6 +19,10 @@ interface EllipseTableProps {
   latestPlayedCardKey?: string | null;
   trickWinner?: number | null;
   trickWinnerText?: string | null;
+  isFinalTrickMode?: boolean;
+  finalTrickSelectedPlayers?: number[];
+  finalTrickOpenedPlayers?: number[];
+  finalTrickStatusText?: string | null;
 }
 
 export function EllipseTable({
@@ -36,6 +40,10 @@ export function EllipseTable({
   latestPlayedCardKey = null,
   trickWinner = null,
   trickWinnerText = null,
+  isFinalTrickMode = false,
+  finalTrickSelectedPlayers = [],
+  finalTrickOpenedPlayers = [],
+  finalTrickStatusText = null,
 }: EllipseTableProps) {
   const playerNames = ['あなた', 'CPU-A', 'CPU-B', 'CPU-C', 'CPU-D', 'CPU-E'];
 
@@ -105,15 +113,30 @@ export function EllipseTable({
                         .join(' ')}
                     >
                       <div className="trick-card-player">{getPlayerName(trickCard.player)}</div>
-                      <div className="card current-card">
-                        <div className="card-number">{trickCard.card}</div>
-                          <div className="cucumber-icons">
-                          {trickCard.card >= 2 && trickCard.card <= 5 && '🥒'}
-                          {trickCard.card >= 6 && trickCard.card <= 9 && '🥒🥒'}
-                          {trickCard.card >= 10 && trickCard.card <= 11 && '🥒🥒🥒'}
-                          {trickCard.card >= 12 && trickCard.card <= 14 && '🥒🥒🥒🥒'}
-                          {trickCard.card === 15 && '🥒🥒🥒🥒🥒'}
-                        </div>
+                      <div
+                        className={[
+                          'card current-card',
+                          isFinalTrickMode && finalTrickOpenedPlayers.includes(trickCard.player)
+                            ? 'card-flip'
+                            : '',
+                        ]
+                          .filter(Boolean)
+                          .join(' ')}
+                      >
+                        {isFinalTrickMode && !finalTrickOpenedPlayers.includes(trickCard.player) ? (
+                          <div className="card-back">選択済み</div>
+                        ) : (
+                          <>
+                            <div className="card-number">{trickCard.card}</div>
+                            <div className="cucumber-icons">
+                              {trickCard.card >= 2 && trickCard.card <= 5 && '🥒'}
+                              {trickCard.card >= 6 && trickCard.card <= 9 && '🥒🥒'}
+                              {trickCard.card >= 10 && trickCard.card <= 11 && '🥒🥒🥒'}
+                              {trickCard.card >= 12 && trickCard.card <= 14 && '🥒🥒🥒🥒'}
+                              {trickCard.card === 15 && '🥒🥒🥒🥒🥒'}
+                            </div>
+                          </>
+                        )}
                       </div>
                     </div>
                   );
@@ -135,7 +158,11 @@ export function EllipseTable({
               <div className="card-number">?</div>
             </div>
           )}
-          {trickWinnerText ? <div className="trick-winner-banner">{trickWinnerText}</div> : null}
+          {finalTrickStatusText ? (
+            <div className="trick-winner-banner">{finalTrickStatusText}</div>
+          ) : trickWinnerText ? (
+            <div className="trick-winner-banner">{trickWinnerText}</div>
+          ) : null}
         </div>
         <div id="grave" className="ellipse-table__grave" aria-label="墓地">
           {state.sharedGraveyard.length > 0 && (
@@ -167,6 +194,9 @@ export function EllipseTable({
                     🃏 <span>{player.hand.length}</span>
                   </div>
                 </div>
+                {isFinalTrickMode && finalTrickSelectedPlayers.includes(i) ? (
+                  <div className="final-selected-badge">選択済み</div>
+                ) : null}
                 {i !== mySeatIndex && (
                   <div className="player-hand-visual">
                     {showAllHands

--- a/apps/hub/lib/game-core/engine.ts
+++ b/apps/hub/lib/game-core/engine.ts
@@ -30,6 +30,7 @@ function cloneState(state: GameState): GameState {
     gameOverPlayers: [...state.gameOverPlayers],
     remainingCards: [...state.remainingCards],
     cardCounts: [...state.cardCounts],
+    isFinalTrick: state.isFinalTrick,
   };
 }
 
@@ -60,6 +61,7 @@ export function createInitialState(config: GameConfig, rng: SeededRng): GameStat
     remainingCards: deck.slice(config.players * config.initialCards),
     cardCounts: initializeCardCounts(),
     phase: 'AwaitMove' as GamePhase,
+    isFinalTrick: config.initialCards === 1,
   };
 }
 
@@ -190,6 +192,7 @@ export function endTrick(state: GameState, config: GameConfig, rng: SeededRng): 
 
   // 次のトリックに進む
   newState.currentTrick++;
+  newState.isFinalTrick = newState.currentTrick === config.initialCards;
   newState.fieldCard = null;
   newState.trickCards = [];
   newState.actionCount = 0;
@@ -245,6 +248,7 @@ export function startNewRound(state: GameState, config: GameConfig, rng: SeededR
   newState.remainingCards = deck.slice(config.players * config.initialCards);
   newState.cardCounts = initializeCardCounts();
   newState.phase = 'AwaitMove';
+  newState.isFinalTrick = config.initialCards === 1;
 
   return { success: true, newState };
 }

--- a/apps/hub/lib/game-core/rules.ts
+++ b/apps/hub/lib/game-core/rules.ts
@@ -63,23 +63,20 @@ export function determineTrickWinner(trickCards: Move[]): number {
 export function calculateFinalTrickPenalty(trickCards: Move[], _config: GameConfig): { winner: number; penalty: number } {
   if (trickCards.length === 0) return { winner: -1, penalty: 0 };
 
-  let winnerIndex = 0;
-  let maxCard = trickCards[0].card;
+  const winner = determineTrickWinner(trickCards);
+  const winnerCard = trickCards.find(tc => tc.player === winner)?.card ?? 0;
 
-  for (let i = 1; i < trickCards.length; i++) {
-    if (trickCards[i].card >= maxCard) {
-      maxCard = trickCards[i].card;
-      winnerIndex = i;
-    }
+  const allPlayedOne = trickCards.every(tc => tc.card === 1);
+  if (allPlayedOne) {
+    return { winner, penalty: 0 };
   }
 
-  const hasOne = trickCards.some(tc => tc.card === 1);
+  const hasOneOnTable = trickCards.some(tc => tc.card === 1);
+  let penalty = winnerCard;
+  if (hasOneOnTable) {
+    penalty *= 2;
+  }
 
-  const winner = trickCards[winnerIndex].player;
-  
-  let penalty = getCucumberCount(maxCard);
-  if (hasOne) penalty *= 2;
-  
   return { winner, penalty };
 }
 

--- a/apps/hub/lib/game-core/types.ts
+++ b/apps/hub/lib/game-core/types.ts
@@ -41,6 +41,7 @@ export interface GameState {
   remainingCards: number[]; // デッキの残り
   cardCounts: number[]; // 各カードの残り枚数 [0,4,4,4,...,4] (0は未使用)
   phase: GamePhase; // フェーズ制御
+  isFinalTrick: boolean;
 }
 
 export interface GameConfig {


### PR DESCRIPTION
### Motivation
- Implement the official final-trick rule where all players select simultaneously and cards are revealed together with a dramatic reveal animation.
- Update penalty calculation to match the new rule: penalty is based on the winner's played card, doubled if any `1` is on the table, and zero if everyone played `1`.

### Description
- Add `isFinalTrick: boolean` to `GameState` and keep it synchronized in `createInitialState`, `cloneState`, `endTrick`, and `startNewRound` (`apps/hub/lib/game-core/types.ts`, `apps/hub/lib/game-core/engine.ts`).
- Replace final-trick penalty logic with the new rule in `calculateFinalTrickPenalty` so the winner is determined via `determineTrickWinner`, penalty uses the winner's card value, doubles if any `1` exists, and returns `0` when all played `1` (`apps/hub/lib/game-core/rules.ts`).
- Implement final-trick simultaneous selection and staged reveal UX on the CPU play page by tracking selected/opened players, showing a `最終トリック` notice, waiting for all selections, displaying `オープン！`, revealing cards in lead order with delays, and showing updated result messages (`apps/hub/app/cucumber/cpu/play/page.tsx`).
- Enhance `EllipseTable` to render final-trick mode with per-seat `選択済み` badges, back-side card placeholders, and a flip animation when cards are revealed; add supporting styles and keyframes in `game.css` (`apps/hub/components/ui/EllipseTable.tsx`, `apps/hub/app/cucumber/cpu/play/game.css`).

### Testing
- Ran code searches to validate changed logic with `rg "penalty|cucumber|final.*trick" apps/hub/lib/game-core/{rules.ts,engine.ts}` and confirmed updated occurrences (success).
- Performed a TypeScript check with `pnpm -w turbo run type-check --filter=hub` which completed successfully (no type errors).
- Launched the dev server with `pnpm --filter @five-cucumber/hub dev --hostname 0.0.0.0 --port 3100` and executed a Playwright script to capture a visual confirmation screenshot of the final-trick UI (screenshot captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f05b76c98832f9be295c6a2f292ca)