### PR TITLE
A-3: トリック間のターン表示遷移をスムーズ化

### DIFF
--- a/apps/hub/components/ui/EllipseTable.tsx
+++ b/apps/hub/components/ui/EllipseTable.tsx
@@ -7,7 +7,7 @@ import { useEffect } from 'react';
 interface EllipseTableProps {
   state: GameState;
   config: GameConfig;
-  currentPlayerIndex: number;
+  currentPlayerIndex: number | null;
   onCardClick?: (card: number) => void;
   className?: string;
   showAllHands?: boolean; // デバッグ用：全員の手札を表示
@@ -176,7 +176,7 @@ export function EllipseTable({
       {/* 楕円座席（外枠と内枠の間の帯） */}
       <section id="seats" className={`players-${config.players}`}>
         {state.players.map((player, i) => {
-          const isTurn = i === currentPlayerIndex;
+          const isTurn = currentPlayerIndex !== null && i === currentPlayerIndex;
 
           return (
             <div


### PR DESCRIPTION
### Motivation
- トリック終了後に無意味な一周ハイライト（A→B→C→D→...）が発生しており、次トリックの勝者への遷移が不自然だったため、場の表示→場クリア→勝者ハイライトの流れを明確にしてスムーズ化する。 

### Description
- 追加で `isAnimating` フラグを導入して、トリック間アニメーション中はCPUスケジューリング・入力・タイムアウト処理を抑止するようにした（`apps/hub/app/cucumber/cpu/play/page.tsx`）。
- トリック完了のプレビュー状態で表示用 `currentPlayer` を `-1` にし、表示側には `currentPlayerIndex` を `null` と渡して「誰もハイライトしない」状態にしてから結果表示→場クリア→勝者ハイライトへ遷移するように変更した（`play/page.tsx` のプレビュー状態と `currentPlayer` 更新のタイミングを調整）。
- `EllipseTable` の `currentPlayerIndex` を `number | null` に変更し、`null` 時は座席に `turn` ハイライトを付けないように対応した（`apps/hub/components/ui/EllipseTable.tsx`）。

### Testing
- 型チェックを `pnpm -C apps/hub type-check` で実行して成功。 
- リントを `pnpm -C apps/hub lint` で実行して成功（1件の軽微な警告あり）。
- 開発サーバを `pnpm -C apps/hub dev --port 3000` で起動して画面を表示できることを確認。 
- Playwright スクリプトで `/cucumber/cpu/play` を開いて遷移キャプチャを取得し、期待どおりトリック間に不要なハイライト巡回が発生しないことを確認した（スクリーンショットを取得）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f0e64bee4832faf378e5425e628ab)