### PR TITLE
A-4: ラウンド/トリック表示を左上固定で視認性改善

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/game.css
+++ b/apps/hub/app/cucumber/cpu/play/game.css
@@ -121,6 +121,21 @@
   background: rgba(217, 119, 6, 0.25);
 }
 
+.trick-indicator-update {
+  animation: trick-pulse 0.5s ease-out;
+}
+
+@keyframes trick-pulse {
+  0% {
+    transform: scale(1.2);
+    opacity: 0.7;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
 .card-back {
   font-size: 0.7rem;
   font-weight: 700;

--- a/apps/hub/app/cucumber/cpu/play/page.tsx
+++ b/apps/hub/app/cucumber/cpu/play/page.tsx
@@ -589,7 +589,26 @@ function CpuPlayContent() {
 
   return (
     <BattleLayout showOrientationHint>
-      <div className="flex-1 flex flex-col gap-6 p-4">
+      <div className="relative flex-1 flex flex-col gap-6 p-4">
+        <div
+          key={`${gameState.currentRound}-${gameState.currentTrick}`}
+          className="trick-indicator-update"
+          style={{
+            position: 'absolute',
+            top: '1rem',
+            left: '1.5rem',
+            zIndex: 10,
+            backgroundColor: 'rgba(0, 0, 0, 0.6)',
+            color: 'white',
+            padding: '0.5rem 1.2rem',
+            borderRadius: '8px',
+            fontSize: '1.1rem',
+            fontWeight: 'bold',
+            letterSpacing: '0.05em',
+          }}
+        >
+          第{gameState.currentRound}ラウンド / 第{gameState.currentTrick}トリック
+        </div>
         <BattleHud
           round={gameState.currentRound}
           trick={gameState.currentTrick}


### PR DESCRIPTION
### Motivation
- ラウンド/トリックの表示が小さく見づらいため、常時目立つ位置・サイズで表示して視認性を改善する必要があった。 
- トリック更新時にユーザーの注意を促すため、軽いアニメーションで変化を分かりやすくしたい。 

### Description
- `apps/hub/app/cucumber/cpu/play/page.tsx` のルートコンテナを `relative` に変更し、左上に絶対配置されたラウンド/トリック表示を追加して常時見えるようにしました。 
- 追加した表示は上書きを避けるためにインラインスタイルで `position`, `fontSize`, `backgroundColor` 等を指定し、`key` に ``${gameState.currentRound}-${gameState.currentTrick}`` を使ってトリック更新時に再描画が走るようにしています。 
- `apps/hub/app/cucumber/cpu/play/game.css` に `.trick-indicator-update` と `@keyframes trick-pulse` を追加して、トリック変更時のフェード/スケールアニメーションを実装しました。 

### Testing
- `pnpm -C apps/hub lint` を実行して ESLint を確認しており、実行自体は成功しつつ別ファイルに関する `no-explicit-any` 警告が1件表示されました（変更対象外）。 
- `pnpm -C apps/hub dev -p 3000` で開発サーバーを起動して対象ページのビルド/ブラウズを確認できました。 
- Playwright を使って `http://127.0.0.1:3000/cucumber/cpu/play?...` を開きスクリーンショットを取得して表示位置・見た目とアニメーションが適用されることを目視で確認しました（スクリーンショット: `artifacts/cpu-round-trick-indicator.png`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f1222f454832f838c7767ed6e9aa9)