### PR TITLE
feat(hub): CPU対戦画面の背景をグローバル背景から独立化

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/page.tsx
+++ b/apps/hub/app/cucumber/cpu/play/page.tsx
@@ -22,6 +22,8 @@ import {
 import { createCpuTableFromUrlParams } from '@/lib/modes';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import PageBackground from '@/components/ui/PageBackground';
+import { BACKGROUNDS } from '@/lib/backgrounds';
 import './game.css';
 
 function CpuPlayContent() {
@@ -588,8 +590,10 @@ function CpuPlayContent() {
   const currentPlayerIndex = isAnimating ? null : gameState.currentPlayer;
 
   return (
-    <BattleLayout showOrientationHint>
-      <div className="relative flex-1 flex flex-col gap-6 p-4">
+    <>
+      <PageBackground image={BACKGROUNDS.battle} />
+      <BattleLayout showOrientationHint>
+        <div className="relative z-10 flex-1 flex flex-col gap-6 p-4">
         <div
           key={`${gameState.currentRound}-${gameState.currentTrick}`}
           className="trick-indicator-update"
@@ -701,8 +705,9 @@ function CpuPlayContent() {
             </div>
           </GameFooter>
         ) : null}
-      </div>
-    </BattleLayout>
+        </div>
+      </BattleLayout>
+    </>
   );
 }
 

--- a/apps/hub/app/globals.css
+++ b/apps/hub/app/globals.css
@@ -645,7 +645,7 @@ body::before {
   background-attachment: fixed;
 }
 
-body[data-page='home']::before {
+body[data-page='custom-bg']::before {
   display: none;
 }
 

--- a/apps/hub/app/layout.tsx
+++ b/apps/hub/app/layout.tsx
@@ -60,11 +60,11 @@ function resolveLocale(): 'ja' | 'en' {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   const locale = resolveLocale();
   const pathname = headers().get('x-pathname') || '';
-  const isHome = pathname.startsWith('/home');
+  const isCustomBg = pathname.startsWith('/home') || pathname.includes('/play') || pathname.includes('/cucumber');
 
   return (
     <html lang={locale} data-theme="light">
-      <body data-page={isHome ? 'home' : ''}>
+      <body data-page={isCustomBg ? 'custom-bg' : ''}>
         <Script id="suppress-extension-noise" strategy="beforeInteractive">
           {`
             (function(){

--- a/apps/hub/components/ui/PageBackground.tsx
+++ b/apps/hub/components/ui/PageBackground.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+interface PageBackgroundProps {
+  image: string;
+}
+
+export default function PageBackground({ image }: PageBackgroundProps) {
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100vw',
+        height: '100vh',
+        backgroundImage: `url('${image}')`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+        backgroundRepeat: 'no-repeat',
+        zIndex: -1,
+      }}
+    />
+  );
+}

--- a/apps/hub/lib/backgrounds.ts
+++ b/apps/hub/lib/backgrounds.ts
@@ -1,0 +1,5 @@
+export const BACKGROUNDS = {
+  home: '/images/home_f.png',
+  battle: '/images/battle1.png',
+} as const;
+


### PR DESCRIPTION
### Motivation
- CPU対戦画面がグローバルな `body::before` 背景に依存しており、ページ単位で背景を差し替えにくかったため独立化する。 
- 背景差し替えを定数化して運用を簡素化し、半透明レイヤやぼかしの競合を防止する。

### Description
- 追加: `apps/hub/lib/backgrounds.ts` に背景パスを一元管理する `BACKGROUNDS` 定数を追加（`home` / `battle`）。
- 追加: `apps/hub/components/ui/PageBackground.tsx` を追加し、`fixed` + `z-index: -1` の共通背景コンポーネントを実装。
- 変更: `apps/hub/app/cucumber/cpu/play/page.tsx` に `PageBackground` と `BACKGROUNDS.battle` を導入してCPU対戦ページで専用背景を描画し、コンテンツを前面に出すためにルートを `relative z-10` に変更。
- 変更: `apps/hub/app/layout.tsx` の `data-page` 判定を `custom-bg` に統一して `/home`・`/play`・`/cucumber` を対象に追加し、`apps/hub/app/globals.css` 側で `body[data-page='custom-bg']::before { display: none; }` を適用してグローバル背景との競合を防止。

### Testing
- 型チェックで `pnpm -C apps/hub type-check` を実行し成功（`tsc --noEmit`）。
- リントで `pnpm -C apps/hub lint` を実行し成功、既存の `app/api/game/move/route.ts` に `no-explicit-any` の警告が出力されたがエラーにはならなかった。 
- 開発サーバを `pnpm -C apps/hub dev -p 3000` で起動し `/cucumber/cpu/play?...` を表示してページが正常にコンパイル・応答（HTTP 200）することを確認した。 
- Playwright を使って `http://127.0.0.1:3000/cucumber/cpu/play?players=4&turnSeconds=15&maxCucumbers=6&cpuLevel=normal` を開きスクリーンショットを取得して背景描画を目視確認した（アーティファクトあり）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f1323ac00832f8b0a9e66f63b9e74)