### PR TITLE
feat(hub): B-2/B-3 トリックカードの中央重なり演出と2D UIポリッシュ

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/game.css
+++ b/apps/hub/app/cucumber/cpu/play/game.css
@@ -14,13 +14,13 @@
   overflow: hidden;
   box-sizing: border-box;
   background:
-    radial-gradient(circle at 50% 30%, rgba(255, 255, 255, 0.08), transparent 68%),
-    radial-gradient(120% 80% at 50% 55%, rgba(8, 34, 28, 0.35), rgba(0, 0, 0, 0) 70%);
-  border: none;
+    radial-gradient(ellipse at center, rgba(255, 255, 255, 0.05) 0%, transparent 70%),
+    linear-gradient(135deg, #1a5c2a 0%, #1b6b31 50%, #186128 100%);
+  border: 3px solid rgba(101, 67, 33, 0.8);
   outline: none;
   box-shadow:
-    inset 0 20px 40px rgba(255, 255, 255, 0.04),
-    inset 0 -26px 50px rgba(0, 0, 0, 0.25);
+    inset 0 0 60px rgba(0, 0, 0, 0.3),
+    0 8px 32px rgba(0, 0, 0, 0.4);
   --ellipse-card-width: clamp(44px, 6vw, 72px);
   --ellipse-card-height: clamp(60px, 9vw, 108px);
   --ellipse-card-gap: clamp(6px, 2vw, 14px);
@@ -59,24 +59,28 @@
 }
 
 .trick-cards-queue {
-  display: flex;
-  align-items: flex-end;
-  justify-content: center;
-  gap: clamp(8px, 1.8vw, 16px);
-  min-height: calc(var(--ellipse-card-height) + 28px);
+  position: relative;
+  width: clamp(120px, 18vw, 200px);
+  height: calc(var(--ellipse-card-height) + 40px);
 }
 
 .trick-card-entry {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%) translate(var(--offset-x), var(--offset-y)) rotate(var(--rotate));
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
-.trick-card-player {
+.trick-last-player-label {
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 8px);
+  transform: translateX(-50%);
   color: rgba(255, 255, 255, 0.95);
   font-size: 0.75rem;
   font-weight: 700;
+  white-space: nowrap;
   text-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
 }
 
@@ -147,9 +151,15 @@
 }
 
 @keyframes flip {
-  0% { transform: rotateY(0deg); }
-  50% { transform: rotateY(90deg); }
-  100% { transform: rotateY(0deg); }
+  0% {
+    transform: rotateY(0deg);
+  }
+  50% {
+    transform: rotateY(90deg);
+  }
+  100% {
+    transform: rotateY(0deg);
+  }
 }
 
 .ellipse-table__grave {
@@ -210,18 +220,24 @@
   animation: slideToField 0.3s ease-out forwards;
 }
 
-.card-play {
-  animation: card-appear 0.3s ease-out;
+.card-play-to-center {
+  animation: play-card 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
-@keyframes card-appear {
-  from {
+@keyframes play-card {
+  0% {
     opacity: 0;
-    transform: translateY(20px) scale(0.8);
+    transform: translate(-50%, -50%) translate(0px, 60px) rotate(0deg) scale(0.6);
   }
-  to {
+  60% {
     opacity: 1;
-    transform: translateY(0) scale(1);
+    transform: translate(-50%, -50%) translate(var(--offset-x), var(--offset-y))
+      rotate(var(--rotate)) scale(1.05);
+  }
+  100% {
+    opacity: 1;
+    transform: translate(-50%, -50%) translate(var(--offset-x), var(--offset-y))
+      rotate(var(--rotate)) scale(1);
   }
 }
 
@@ -502,10 +518,24 @@
   }
 }
 
+.player-seat {
+  transition: all 0.4s ease;
+}
+
+.player-seat.active-turn {
+  box-shadow: 0 0 20px rgba(255, 215, 0, 0.5);
+  border-color: rgba(255, 215, 0, 0.8);
+}
+
 .player-info {
   display: flex;
   flex-direction: column;
   gap: 5px;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  border-radius: 12px;
+  padding: 0.5rem 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .player-name {
@@ -665,9 +695,18 @@
     box-shadow 0.2s ease;
   position: relative;
   border: 2px solid rgba(255, 255, 255, 0.4);
-  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.4);
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.2),
+    0 4px 8px rgba(0, 0, 0, 0.1);
   backdrop-filter: blur(5px);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(240, 240, 240, 0.8));
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.15) 0%,
+      transparent 50%,
+      rgba(0, 0, 0, 0.05) 100%
+    ),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(240, 240, 240, 0.8));
   color: #333;
   visibility: visible !important;
   opacity: 1 !important;
@@ -710,8 +749,9 @@
 .card.disabled {
   background: linear-gradient(135deg, #999, #777);
   color: #555;
+  opacity: 0.5;
+  filter: grayscale(0.3);
   cursor: not-allowed;
-  opacity: 0.7;
 }
 
 .card.current-card {
@@ -734,8 +774,10 @@
 }
 
 .card:hover:not(.disabled) {
-  transform: translateY(-12px) scale(1.08);
-  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.4);
+  transform: translateY(-8px);
+  box-shadow:
+    0 8px 16px rgba(0, 0, 0, 0.3),
+    0 12px 24px rgba(0, 0, 0, 0.15);
   z-index: 10;
 }
 
@@ -1012,4 +1054,8 @@
   font-size: 0.6rem;
   font-weight: 800;
   padding: 1px 6px;
+}
+
+.game-card.playable {
+  cursor: pointer;
 }


### PR DESCRIPTION
### Motivation
- CPU対戦画面の場表示とカードUIを強化し、カード出し時の演出（重なり・微回転・アニメ）と雀魂風の2D質感を導入するため。 

### Description
- `EllipseTable.tsx`で場のトリックカード表示を横並びから中央重なり表示へ変更し、カード値＋インデックス由来の決定的なseedで各カードに微回転・微オフセットを付与して重ねる実装を追加した。 
- 最新に出されたカードには中央へ飛び込むアニメーション（`card-play-to-center` / `play-card`）を適用し、重なり上には「最後に出したプレイヤー名」だけを表示するようにした。 
- 手札のカード要素に安定してターゲットできるように `data-card` 属性を追加し、出牌時のアニメーションクラス付与に利用するようにした。 
- `game.css` を更新してテーブル背景をフェルト風＋木枠風ボーダーに変更し、カードの多段シャドウ・光沢グラデ・ホバー浮上などの2Dポリッシュを適用、`player-seat` の滑らかなハイライト遷移と `player-info` の半透明パネルスタイルを追加した。 
- `page.tsx` 側で最終トリック判定を `isFinalTrickPhase` に集約し、`EllipseTable` へ渡すフラグやテーブル用クラス名（`cpu-play-table`）を整理した。 
- 変更したファイル: `apps/hub/components/ui/EllipseTable.tsx`, `apps/hub/app/cucumber/cpu/play/page.tsx`, `apps/hub/app/cucumber/cpu/play/game.css`. 

### Testing
- フォーマッタ実行: `pnpm prettier --write ...` を実行して整形を行い成功した。 
- Lint: `pnpm --filter @five-cucumber/hub lint` を実行してビルドの静的解析を確認し実行は成功（既存箇所で `no-explicit-any` の警告1件を確認）。 
- 型チェック: `pnpm --filter @five-cucumber/hub type-check` を実行して `tsc --noEmit` を通過した。 
- 実動作確認: 開発サーバーを起動して Playwright で `/cucumber/cpu/play` を開きスクリーンショットを取得し（ブラウザ確認）、表示と演出の目視確認を行った（スクリーンショット生成成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f18296ac8832f922f6df7090d20fd)