### PR TITLE
fix(hub): unify CPU play background layers and scope table background

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/game.css
+++ b/apps/hub/app/cucumber/cpu/play/game.css
@@ -13,9 +13,6 @@
   gap: clamp(16px, 3vw, 32px);
   overflow: hidden;
   box-sizing: border-box;
-  background:
-    radial-gradient(ellipse at center, rgba(255, 255, 255, 0.05) 0%, transparent 70%),
-    linear-gradient(135deg, #1a5c2a 0%, #1b6b31 50%, #186128 100%);
   border: 3px solid rgba(101, 67, 33, 0.8);
   outline: none;
   box-shadow:
@@ -28,6 +25,20 @@
   --ellipse-center-offset: clamp(24px, 6vh, 72px);
   --ellipse-center-gap: clamp(24px, 6vw, 96px);
   --ellipse-seat-width: clamp(160px, 18vw, 240px);
+}
+
+.ellipse-table-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  display: grid;
+  align-items: stretch;
+  justify-items: center;
+  gap: inherit;
+  background:
+    radial-gradient(ellipse at center, rgba(255, 255, 255, 0.05) 0%, transparent 70%),
+    linear-gradient(135deg, #1a5c2a 0%, #1b6b31 50%, #186128 100%);
 }
 
 .game-container {

--- a/apps/hub/app/cucumber/cpu/play/page.tsx
+++ b/apps/hub/app/cucumber/cpu/play/page.tsx
@@ -584,7 +584,7 @@ function CpuPlayContent() {
 
   if (!gameState) {
     return (
-      <BattleLayout showOrientationHint>
+      <BattleLayout showOrientationHint useFrameBackground={false}>
         <div className="flex-1 flex flex-col p-4">
           <div className="grid place-items-center h-full text-white/80">Loading...</div>
         </div>
@@ -609,7 +609,7 @@ function CpuPlayContent() {
   return (
     <>
       <PageBackground image={BACKGROUNDS.battle} />
-      <BattleLayout showOrientationHint>
+      <BattleLayout showOrientationHint useFrameBackground={false}>
         <div className="relative z-10 flex-1 flex flex-col gap-6 p-4">
           <div
             key={`${gameState.currentRound}-${gameState.currentTrick}`}

--- a/apps/hub/app/globals.css
+++ b/apps/hub/app/globals.css
@@ -628,7 +628,7 @@ body,
 }
 
 body {
-  background-color: #2d5a27;
+  background: transparent;
 }
 
 /* 固定背景レイヤ（最背面） */

--- a/apps/hub/components/BattleLayout.tsx
+++ b/apps/hub/components/BattleLayout.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import { BackgroundFrame } from '@/components/ui';
 import { useEffect, useState } from 'react';
@@ -7,9 +7,15 @@ interface BattleLayoutProps {
   children: React.ReactNode;
   className?: string;
   showOrientationHint?: boolean;
+  useFrameBackground?: boolean;
 }
 
-export default function BattleLayout({ children, className, showOrientationHint }: BattleLayoutProps) {
+export default function BattleLayout({
+  children,
+  className,
+  showOrientationHint,
+  useFrameBackground = true,
+}: BattleLayoutProps) {
   const [isPortrait, setIsPortrait] = useState(false);
 
   // 画面向きの監視
@@ -35,8 +41,8 @@ export default function BattleLayout({ children, className, showOrientationHint 
     };
   }, []);
 
-  return (
-    <BackgroundFrame src="/images/battle1.png" objectPosition="center" priority className={className}>
+  const content = (
+    <div className={['battle-layout', className].filter(Boolean).join(' ')}>
       {/* 縦向き時の回転案内オーバーレイ（必要時のみ） */}
       {showOrientationHint && isPortrait && (
         <div className="battle-layout__orientation-overlay">
@@ -51,9 +57,22 @@ export default function BattleLayout({ children, className, showOrientationHint 
       )}
 
       {/* ステージ */}
-      <div className="battle-layout__stage">
-        {children}
-      </div>
+      <div className="battle-layout__stage">{children}</div>
+    </div>
+  );
+
+  if (!useFrameBackground) {
+    return content;
+  }
+
+  return (
+    <BackgroundFrame
+      src="/images/battle1.png"
+      objectPosition="center"
+      priority
+      className={className}
+    >
+      {content}
     </BackgroundFrame>
   );
 }

--- a/apps/hub/components/ui/EllipseTable.tsx
+++ b/apps/hub/components/ui/EllipseTable.tsx
@@ -91,218 +91,220 @@ export function EllipseTable({
 
   return (
     <div className={rootClassName}>
-      {/* 中央の場と墓地 */}
-      <div className="ellipse-table__center">
-        <div id="field" className="ellipse-table__field" aria-label="場のカード">
-          {visibleTrickCards.length > 0 ? (
-            <div className="trick-cards-queue" aria-live="polite">
-              {visibleTrickCards.map((trickCard, index) => {
-                const cardKey = `${trickCard.player}-${trickCard.timestamp}`;
-                const isLatestPlayed = latestPlayedCardKey === cardKey;
-                const isWinnerCard = trickWinner !== null && trickCard.player === trickWinner;
-                const seed = trickCard.card * 7 + index * 13;
-                const rotate = (seed % 11) - 5;
-                const offsetX = (seed % 21) - 10;
-                const offsetY = ((seed * 3) % 15) - 7;
+      <div className="ellipse-table-inner">
+        {/* 中央の場と墓地 */}
+        <div className="ellipse-table__center">
+          <div id="field" className="ellipse-table__field" aria-label="場のカード">
+            {visibleTrickCards.length > 0 ? (
+              <div className="trick-cards-queue" aria-live="polite">
+                {visibleTrickCards.map((trickCard, index) => {
+                  const cardKey = `${trickCard.player}-${trickCard.timestamp}`;
+                  const isLatestPlayed = latestPlayedCardKey === cardKey;
+                  const isWinnerCard = trickWinner !== null && trickCard.player === trickWinner;
+                  const seed = trickCard.card * 7 + index * 13;
+                  const rotate = (seed % 11) - 5;
+                  const offsetX = (seed % 21) - 10;
+                  const offsetY = ((seed * 3) % 15) - 7;
 
-                return (
-                  <div
-                    key={cardKey}
-                    className={[
-                      'trick-card-entry',
-                      isLatestPlayed ? 'card-play-to-center' : '',
-                      isWinnerCard ? 'winner' : '',
-                    ]
-                      .filter(Boolean)
-                      .join(' ')}
-                    style={
-                      {
-                        '--offset-x': `${offsetX}px`,
-                        '--offset-y': `${offsetY}px`,
-                        '--rotate': `${rotate}deg`,
-                        zIndex: index + 1,
-                      } as CSSProperties
-                    }
-                  >
+                  return (
                     <div
+                      key={cardKey}
                       className={[
-                        'card game-card current-card',
-                        isFinalTrickMode && finalTrickOpenedPlayers.includes(trickCard.player)
-                          ? 'card-flip'
-                          : '',
+                        'trick-card-entry',
+                        isLatestPlayed ? 'card-play-to-center' : '',
+                        isWinnerCard ? 'winner' : '',
                       ]
                         .filter(Boolean)
                         .join(' ')}
+                      style={
+                        {
+                          '--offset-x': `${offsetX}px`,
+                          '--offset-y': `${offsetY}px`,
+                          '--rotate': `${rotate}deg`,
+                          zIndex: index + 1,
+                        } as CSSProperties
+                      }
                     >
-                      {isFinalTrickMode && !finalTrickOpenedPlayers.includes(trickCard.player) ? (
-                        <div className="card-back">選択済み</div>
-                      ) : (
-                        <>
-                          <div className="card-number">{trickCard.card}</div>
-                          <div className="cucumber-icons">
-                            {trickCard.card >= 2 && trickCard.card <= 5 && '🥒'}
-                            {trickCard.card >= 6 && trickCard.card <= 9 && '🥒🥒'}
-                            {trickCard.card >= 10 && trickCard.card <= 11 && '🥒🥒🥒'}
-                            {trickCard.card >= 12 && trickCard.card <= 14 && '🥒🥒🥒🥒'}
-                            {trickCard.card === 15 && '🥒🥒🥒🥒🥒'}
-                          </div>
-                        </>
-                      )}
+                      <div
+                        className={[
+                          'card game-card current-card',
+                          isFinalTrickMode && finalTrickOpenedPlayers.includes(trickCard.player)
+                            ? 'card-flip'
+                            : '',
+                        ]
+                          .filter(Boolean)
+                          .join(' ')}
+                      >
+                        {isFinalTrickMode && !finalTrickOpenedPlayers.includes(trickCard.player) ? (
+                          <div className="card-back">選択済み</div>
+                        ) : (
+                          <>
+                            <div className="card-number">{trickCard.card}</div>
+                            <div className="cucumber-icons">
+                              {trickCard.card >= 2 && trickCard.card <= 5 && '🥒'}
+                              {trickCard.card >= 6 && trickCard.card <= 9 && '🥒🥒'}
+                              {trickCard.card >= 10 && trickCard.card <= 11 && '🥒🥒🥒'}
+                              {trickCard.card >= 12 && trickCard.card <= 14 && '🥒🥒🥒🥒'}
+                              {trickCard.card === 15 && '🥒🥒🥒🥒🥒'}
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+                {lastPlayedTrickCard ? (
+                  <div className="trick-last-player-label">
+                    {getPlayerName(lastPlayedTrickCard.player)}
+                  </div>
+                ) : null}
+              </div>
+            ) : state.fieldCard !== null ? (
+              <div className="card game-card current-card">
+                <div className="card-number">{state.fieldCard}</div>
+                <div className="cucumber-icons">
+                  {state.fieldCard >= 2 && state.fieldCard <= 5 && '🥒'}
+                  {state.fieldCard >= 6 && state.fieldCard <= 9 && '🥒🥒'}
+                  {state.fieldCard >= 10 && state.fieldCard <= 11 && '🥒🥒🥒'}
+                  {state.fieldCard >= 12 && state.fieldCard <= 14 && '🥒🥒🥒🥒'}
+                  {state.fieldCard === 15 && '🥒🥒🥒🥒🥒'}
+                </div>
+              </div>
+            ) : (
+              <div className="card game-card disabled">
+                <div className="card-number">?</div>
+              </div>
+            )}
+            {finalTrickStatusText ? (
+              <div className="trick-winner-banner">{finalTrickStatusText}</div>
+            ) : trickWinnerText ? (
+              <div className="trick-winner-banner">{trickWinnerText}</div>
+            ) : null}
+          </div>
+          <div id="grave" className="ellipse-table__grave" aria-label="墓地">
+            {state.sharedGraveyard.length > 0 && (
+              <div className="graveyard-card">
+                {state.sharedGraveyard[state.sharedGraveyard.length - 1]}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* 楕円座席（外枠と内枠の間の帯） */}
+        <section id="seats" className={`players-${config.players}`}>
+          {state.players.map((player, i) => {
+            const isTurn = currentPlayerIndex !== null && i === currentPlayerIndex;
+
+            return (
+              <div
+                key={i}
+                className={`seat player-seat ${isTurn ? 'turn active-turn' : ''}`}
+                data-active={state.currentPlayer === i}
+              >
+                <div className="content player-info">
+                  <div className="player-name">{getPlayerName(i)}</div>
+                  <div className="player-stats">
+                    <div className="cucumber-count">
+                      🥒 <span>{player.cucumbers}</span>
+                    </div>
+                    <div className="cards-count">
+                      🃏 <span>{player.hand.length}</span>
                     </div>
                   </div>
-                );
-              })}
-              {lastPlayedTrickCard ? (
-                <div className="trick-last-player-label">
-                  {getPlayerName(lastPlayedTrickCard.player)}
+                  {isFinalTrickMode && finalTrickSelectedPlayers.includes(i) ? (
+                    <div className="final-selected-badge">選択済み</div>
+                  ) : null}
+                  {i !== mySeatIndex && (
+                    <div className="player-hand-visual">
+                      {showAllHands
+                        ? // デバッグモード：実際のカード値を表示
+                          player.hand.map((card, cardIndex) => (
+                            <div key={cardIndex} className="debug-card" title={`カード${card}`}>
+                              {card}
+                            </div>
+                          ))
+                        : // 通常モード：裏面のカードを表示
+                          player.hand.map((_, cardIndex) => (
+                            <div key={cardIndex} className="mini-card" />
+                          ))}
+                    </div>
+                  )}
                 </div>
-              ) : null}
-            </div>
-          ) : state.fieldCard !== null ? (
-            <div className="card game-card current-card">
-              <div className="card-number">{state.fieldCard}</div>
-              <div className="cucumber-icons">
-                {state.fieldCard >= 2 && state.fieldCard <= 5 && '🥒'}
-                {state.fieldCard >= 6 && state.fieldCard <= 9 && '🥒🥒'}
-                {state.fieldCard >= 10 && state.fieldCard <= 11 && '🥒🥒🥒'}
-                {state.fieldCard >= 12 && state.fieldCard <= 14 && '🥒🥒🥒🥒'}
-                {state.fieldCard === 15 && '🥒🥒🥒🥒🥒'}
               </div>
-            </div>
-          ) : (
-            <div className="card game-card disabled">
-              <div className="card-number">?</div>
-            </div>
-          )}
-          {finalTrickStatusText ? (
-            <div className="trick-winner-banner">{finalTrickStatusText}</div>
-          ) : trickWinnerText ? (
-            <div className="trick-winner-banner">{trickWinnerText}</div>
-          ) : null}
-        </div>
-        <div id="grave" className="ellipse-table__grave" aria-label="墓地">
-          {state.sharedGraveyard.length > 0 && (
-            <div className="graveyard-card">
-              {state.sharedGraveyard[state.sharedGraveyard.length - 1]}
-            </div>
-          )}
-        </div>
-      </div>
-
-      {/* 楕円座席（外枠と内枠の間の帯） */}
-      <section id="seats" className={`players-${config.players}`}>
-        {state.players.map((player, i) => {
-          const isTurn = currentPlayerIndex !== null && i === currentPlayerIndex;
-
-          return (
-            <div
-              key={i}
-              className={`seat player-seat ${isTurn ? 'turn active-turn' : ''}`}
-              data-active={state.currentPlayer === i}
-            >
-              <div className="content player-info">
-                <div className="player-name">{getPlayerName(i)}</div>
-                <div className="player-stats">
-                  <div className="cucumber-count">
-                    🥒 <span>{player.cucumbers}</span>
-                  </div>
-                  <div className="cards-count">
-                    🃏 <span>{player.hand.length}</span>
-                  </div>
-                </div>
-                {isFinalTrickMode && finalTrickSelectedPlayers.includes(i) ? (
-                  <div className="final-selected-badge">選択済み</div>
-                ) : null}
-                {i !== mySeatIndex && (
-                  <div className="player-hand-visual">
-                    {showAllHands
-                      ? // デバッグモード：実際のカード値を表示
-                        player.hand.map((card, cardIndex) => (
-                          <div key={cardIndex} className="debug-card" title={`カード${card}`}>
-                            {card}
-                          </div>
-                        ))
-                      : // 通常モード：裏面のカードを表示
-                        player.hand.map((_, cardIndex) => (
-                          <div key={cardIndex} className="mini-card" />
-                        ))}
-                  </div>
-                )}
-              </div>
-            </div>
-          );
-        })}
-      </section>
-
-      {/* 自分の手札と名前（下辺） */}
-      <section id="hand-dock" className="ellipse-table__hand" aria-label="自分の手札">
-        <div className="me-name">{getPlayerName(mySeatIndex)}</div>
-        <div className="hand">
-          {(() => {
-            const myHand = state.players[mySeatIndex]?.hand ?? [];
-            const highestOnTable = state.fieldCard;
-            const hasLegalPlay = myHand.some(
-              handCard => highestOnTable === null || handCard >= highestOnTable
             );
-            const minCard = myHand.length > 0 ? Math.min(...myHand) : null;
+          })}
+        </section>
 
-            return myHand.map((card, index) => {
-              const isPlayable = highestOnTable === null || card >= highestOnTable;
-              const isDiscard = !hasLegalPlay && minCard !== null && card === minCard;
-              const isIllegalWhileLegalExists = hasLegalPlay && !isPlayable;
-              const isMyTurn = currentPlayerIndex === mySeatIndex;
-
-              // カードが送信中またはロックされているかチェック
-              const isCardLocked = lockedCardId === card;
-              const isAllLocked = isSubmitting || className?.includes('cards-locked');
-              const isDisabled =
-                !isMyTurn ||
-                isAllLocked ||
-                isCardLocked ||
-                state.phase !== 'AwaitMove' ||
-                isIllegalWhileLegalExists;
-
-              const handleCardClick = (e: React.MouseEvent) => {
-                e.preventDefault();
-                if (isDisabled || isSubmitting || !isMyTurn) return;
-                onCardClick?.(card);
-              };
-
-              return (
-                <div
-                  key={`${card}-${index}`}
-                  className={`card game-card ${
-                    isCardLocked
-                      ? 'disabled locked'
-                      : isDisabled
-                        ? 'disabled'
-                        : isPlayable
-                          ? 'playable'
-                          : isDiscard
-                            ? 'discard'
-                            : 'disabled'
-                  }`}
-                  onClick={handleCardClick}
-                  onPointerDown={handleCardClick}
-                  style={{ pointerEvents: isDisabled ? 'none' : 'auto' }}
-                  data-card={card}
-                  aria-disabled={isDisabled}
-                >
-                  <div className="card-number">{card}</div>
-                  <div className="cucumber-icons">
-                    {card >= 2 && card <= 5 && '🥒'}
-                    {card >= 6 && card <= 9 && '🥒🥒'}
-                    {card >= 10 && card <= 11 && '🥒🥒🥒'}
-                    {card >= 12 && card <= 14 && '🥒🥒🥒🥒'}
-                    {card === 15 && '🥒🥒🥒🥒🥒'}
-                  </div>
-                  {isDiscard ? <div className="discard-tag">捨てる</div> : null}
-                </div>
+        {/* 自分の手札と名前（下辺） */}
+        <section id="hand-dock" className="ellipse-table__hand" aria-label="自分の手札">
+          <div className="me-name">{getPlayerName(mySeatIndex)}</div>
+          <div className="hand">
+            {(() => {
+              const myHand = state.players[mySeatIndex]?.hand ?? [];
+              const highestOnTable = state.fieldCard;
+              const hasLegalPlay = myHand.some(
+                handCard => highestOnTable === null || handCard >= highestOnTable
               );
-            });
-          })()}
-        </div>
-      </section>
+              const minCard = myHand.length > 0 ? Math.min(...myHand) : null;
+
+              return myHand.map((card, index) => {
+                const isPlayable = highestOnTable === null || card >= highestOnTable;
+                const isDiscard = !hasLegalPlay && minCard !== null && card === minCard;
+                const isIllegalWhileLegalExists = hasLegalPlay && !isPlayable;
+                const isMyTurn = currentPlayerIndex === mySeatIndex;
+
+                // カードが送信中またはロックされているかチェック
+                const isCardLocked = lockedCardId === card;
+                const isAllLocked = isSubmitting || className?.includes('cards-locked');
+                const isDisabled =
+                  !isMyTurn ||
+                  isAllLocked ||
+                  isCardLocked ||
+                  state.phase !== 'AwaitMove' ||
+                  isIllegalWhileLegalExists;
+
+                const handleCardClick = (e: React.MouseEvent) => {
+                  e.preventDefault();
+                  if (isDisabled || isSubmitting || !isMyTurn) return;
+                  onCardClick?.(card);
+                };
+
+                return (
+                  <div
+                    key={`${card}-${index}`}
+                    className={`card game-card ${
+                      isCardLocked
+                        ? 'disabled locked'
+                        : isDisabled
+                          ? 'disabled'
+                          : isPlayable
+                            ? 'playable'
+                            : isDiscard
+                              ? 'discard'
+                              : 'disabled'
+                    }`}
+                    onClick={handleCardClick}
+                    onPointerDown={handleCardClick}
+                    style={{ pointerEvents: isDisabled ? 'none' : 'auto' }}
+                    data-card={card}
+                    aria-disabled={isDisabled}
+                  >
+                    <div className="card-number">{card}</div>
+                    <div className="cucumber-icons">
+                      {card >= 2 && card <= 5 && '🥒'}
+                      {card >= 6 && card <= 9 && '🥒🥒'}
+                      {card >= 10 && card <= 11 && '🥒🥒🥒'}
+                      {card >= 12 && card <= 14 && '🥒🥒🥒🥒'}
+                      {card === 15 && '🥒🥒🥒🥒🥒'}
+                    </div>
+                    {isDiscard ? <div className="discard-tag">捨てる</div> : null}
+                  </div>
+                );
+              });
+            })()}
+          </div>
+        </section>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- The CPU play screen showed duplicated background layers and a green overlay across the page because both `PageBackground` and `BattleLayout` (via `BackgroundFrame`) were rendering backgrounds and `body` had a global green background color.
- The table felt/green gradient was applied at the `.ellipse-table` root, unintentionally affecting more than the table area.

### Description
- Added an opt-out flag `useFrameBackground?: boolean` to `BattleLayout` and render the `BackgroundFrame` only when `useFrameBackground` is true, allowing callers to choose the background source.
- Updated the CPU play page (`apps/hub/app/cucumber/cpu/play/page.tsx`) to call `<BattleLayout useFrameBackground={false}>` and keep `PageBackground` as the single background provider for that page.
- Scoped the felt-style gradient to a new wrapper `.ellipse-table-inner` inside `EllipseTable` and moved the gradient CSS from `.ellipse-table` into `.ellipse-table-inner` so the green styling is limited to the table area only (`apps/hub/app/cucumber/cpu/play/game.css` and `apps/hub/components/ui/EllipseTable.tsx`).
- Made `body` background transparent in `apps/hub/app/globals.css` so the fixed `body::before` background (used by `PageBackground`/`body::before`) is the single visible page background when `data-page='custom-bg'` is set.

### Testing
- Ran type-check with `pnpm -C apps/hub type-check`, which completed successfully with no errors.
- Ran linter with `pnpm -C apps/hub lint`, which completed successfully but reported one existing warning (`any` usage in `app/api/game/move/route.ts`).
- Started the dev server with `pnpm -C apps/hub dev` and confirmed `GET /cucumber/cpu/play` compiled and served the page successfully.
- Ran a headless Playwright navigation to `http://127.0.0.1:3000/cucumber/cpu/play?...` and captured a screenshot, producing `artifacts/cpu-play-background-hotfix.png` which shows the background unified and the green layer limited to the table area.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f1a3bf3f8832f8cfc5e3b010980c9)