### PR TITLE
Refactor(hub): unify CPU battle background to PageBackground

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/game.css
+++ b/apps/hub/app/cucumber/cpu/play/game.css
@@ -36,9 +36,7 @@
   align-items: stretch;
   justify-items: center;
   gap: inherit;
-  background:
-    radial-gradient(ellipse at center, rgba(255, 255, 255, 0.05) 0%, transparent 70%),
-    linear-gradient(135deg, #1a5c2a 0%, #1b6b31 50%, #186128 100%);
+  background: linear-gradient(135deg, #1a5c2a 0%, #1b6b31 50%, #186128 100%);
 }
 
 .game-container {

--- a/apps/hub/app/cucumber/cpu/play/page.tsx
+++ b/apps/hub/app/cucumber/cpu/play/page.tsx
@@ -584,11 +584,16 @@ function CpuPlayContent() {
 
   if (!gameState) {
     return (
-      <BattleLayout showOrientationHint useFrameBackground={false}>
-        <div className="flex-1 flex flex-col p-4">
-          <div className="grid place-items-center h-full text-white/80">Loading...</div>
+      <>
+        <PageBackground image={BACKGROUNDS.battle} />
+        <div style={{ position: 'relative', zIndex: 1, minHeight: '100vh' }}>
+          <BattleLayout showOrientationHint>
+            <div className="flex-1 flex flex-col p-4">
+              <div className="grid place-items-center h-full text-white/80">Loading...</div>
+            </div>
+          </BattleLayout>
         </div>
-      </BattleLayout>
+      </>
     );
   }
 
@@ -609,9 +614,10 @@ function CpuPlayContent() {
   return (
     <>
       <PageBackground image={BACKGROUNDS.battle} />
-      <BattleLayout showOrientationHint useFrameBackground={false}>
-        <div className="relative z-10 flex-1 flex flex-col gap-6 p-4">
-          <div
+      <div style={{ position: 'relative', zIndex: 1, minHeight: '100vh' }}>
+        <BattleLayout showOrientationHint>
+          <div className="relative z-10 flex-1 flex flex-col gap-6 p-4">
+            <div
             key={`${gameState.currentRound}-${gameState.currentTrick}`}
             className="trick-indicator-update"
             style={{
@@ -726,8 +732,9 @@ function CpuPlayContent() {
               </div>
             </GameFooter>
           ) : null}
-        </div>
-      </BattleLayout>
+          </div>
+        </BattleLayout>
+      </div>
     </>
   );
 }

--- a/apps/hub/app/globals.css
+++ b/apps/hub/app/globals.css
@@ -631,23 +631,6 @@ body {
   background: transparent;
 }
 
-/* 固定背景レイヤ（最背面） */
-body::before {
-  content: '';
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  z-index: -1;
-  background-size: cover;
-  background-repeat: no-repeat;
-  background-attachment: fixed;
-}
-
-body[data-page='custom-bg']::before {
-  display: none;
-}
 
 /* ホーム背景 */
 body[data-bg='home']::before {
@@ -701,7 +684,7 @@ body[data-bg='battle']::before {
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
 }
 
-/* ページ背景（背景はbody::beforeに集約） */
+/* ページ背景 */
 .page-game,
 .page-home,
 .page-arena {

--- a/apps/hub/app/layout.tsx
+++ b/apps/hub/app/layout.tsx
@@ -59,12 +59,9 @@ function resolveLocale(): 'ja' | 'en' {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   const locale = resolveLocale();
-  const pathname = headers().get('x-pathname') || '';
-  const isCustomBg = pathname.startsWith('/home') || pathname.includes('/play') || pathname.includes('/cucumber');
-
   return (
     <html lang={locale} data-theme="light">
-      <body data-page={isCustomBg ? 'custom-bg' : ''}>
+      <body>
         <Script id="suppress-extension-noise" strategy="beforeInteractive">
           {`
             (function(){

--- a/apps/hub/components/BattleLayout.tsx
+++ b/apps/hub/components/BattleLayout.tsx
@@ -1,20 +1,17 @@
 'use client';
 
-import { BackgroundFrame } from '@/components/ui';
 import { useEffect, useState } from 'react';
 
 interface BattleLayoutProps {
   children: React.ReactNode;
   className?: string;
   showOrientationHint?: boolean;
-  useFrameBackground?: boolean;
 }
 
 export default function BattleLayout({
   children,
   className,
   showOrientationHint,
-  useFrameBackground = true,
 }: BattleLayoutProps) {
   const [isPortrait, setIsPortrait] = useState(false);
 
@@ -41,7 +38,7 @@ export default function BattleLayout({
     };
   }, []);
 
-  const content = (
+  return (
     <div className={['battle-layout', className].filter(Boolean).join(' ')}>
       {/* 縦向き時の回転案内オーバーレイ（必要時のみ） */}
       {showOrientationHint && isPortrait && (
@@ -59,20 +56,5 @@ export default function BattleLayout({
       {/* ステージ */}
       <div className="battle-layout__stage">{children}</div>
     </div>
-  );
-
-  if (!useFrameBackground) {
-    return content;
-  }
-
-  return (
-    <BackgroundFrame
-      src="/images/battle1.png"
-      objectPosition="center"
-      priority
-      className={className}
-    >
-      {content}
-    </BackgroundFrame>
   );
 }


### PR DESCRIPTION
### Motivation
- Consolidate all background rendering so only `PageBackground` provides the fullscreen background for CPU battle pages, removing competing layers and visual artifacts.

### Description
- Remove the global `body::before` pseudo-element and the `body[data-page='custom-bg']::before` switching logic from `apps/hub/app/globals.css`, leaving `body { background: transparent; }` only.
- Simplify `RootLayout` in `apps/hub/app/layout.tsx` by removing the `data-page` attribute on `<body>` so page-level data attributes no longer control a global background layer.
- Make `BattleLayout` a pure layout component in `apps/hub/components/BattleLayout.tsx` by removing `BackgroundFrame` usage and the `useFrameBackground` prop so it only handles orientation overlay and stage layout.
- Force CPU play page to own its background in `apps/hub/app/cucumber/cpu/play/page.tsx` by explicitly rendering `PageBackground` and wrapping the foreground game content in a `div` with `style={{ position: 'relative', zIndex: 1, minHeight: '100vh' }}` so the page background is the single bottom layer.
- Restrict table visuals in `apps/hub/app/cucumber/cpu/play/game.css` so `.ellipse-table-inner` uses the felt green gradient only (removed the additional radial overlay), leaving table-internal styling intact.

### Testing
- Ran `pnpm -C apps/hub lint`, which completed successfully with one unrelated lint warning in `app/api/game/move/route.ts` (no new lint failures introduced). ✅
- Launched the dev server with `pnpm -C apps/hub dev` and confirmed the app compiled and served the CPU play page. ✅
- Automated browser check using Playwright visited `/cucumber/cpu/play?...` and produced a screenshot (`artifacts/cpu-play-background-cleanup.png`) demonstrating a single full-screen background layer with the table interior showing the felt gradient only. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f1dc32110832f87131f55abd802a4)