### PR TITLE
Constrain green felt to .ellipse-table-inner and ensure game fills viewport

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/game.css
+++ b/apps/hub/app/cucumber/cpu/play/game.css
@@ -13,6 +13,7 @@
   gap: clamp(16px, 3vw, 32px);
   overflow: hidden;
   box-sizing: border-box;
+  background: transparent;
   border: 3px solid rgba(101, 67, 33, 0.8);
   outline: none;
   box-shadow:
@@ -41,6 +42,7 @@
 
 .game-container {
   position: relative;
+  width: 100%;
   min-height: 100vh;
   display: flex;
   flex-direction: column;

--- a/apps/hub/app/cucumber/cpu/play/page.tsx
+++ b/apps/hub/app/cucumber/cpu/play/page.tsx
@@ -616,122 +616,125 @@ function CpuPlayContent() {
       <PageBackground image={BACKGROUNDS.battle} />
       <div style={{ position: 'relative', zIndex: 1, minHeight: '100vh' }}>
         <BattleLayout showOrientationHint>
-          <div className="relative z-10 flex-1 flex flex-col gap-6 p-4">
-            <div
-            key={`${gameState.currentRound}-${gameState.currentTrick}`}
-            className="trick-indicator-update"
-            style={{
-              position: 'absolute',
-              top: '1rem',
-              left: '1.5rem',
-              zIndex: 10,
-              backgroundColor: 'rgba(0, 0, 0, 0.6)',
-              color: 'white',
-              padding: '0.5rem 1.2rem',
-              borderRadius: '8px',
-              fontSize: '1.1rem',
-              fontWeight: 'bold',
-              letterSpacing: '0.05em',
-            }}
+          <div
+            className="relative z-10 flex-1 flex flex-col gap-6 p-4"
+            style={{ minHeight: '100vh' }}
           >
-            第{gameState.currentRound}ラウンド / 第{gameState.currentTrick}トリック
-          </div>
-          <BattleHud
-            round={gameState.currentRound}
-            trick={gameState.currentTrick}
-            timer={
-              <Timer
-                turnSeconds={
-                  gameRef.current ? getEffectiveTurnSeconds(gameRef.current.config) : null
-                }
-                isActive={gameState.currentPlayer === 0 && gameState.phase === 'AwaitMove'}
-                onTimeout={handleTimeout}
-              />
-            }
-            onExit={handleBackToHome}
-          />
-
-          {isFinalTrickPhase ? (
-            <div className="final-trick-notice" role="status" aria-live="polite">
-              最終トリック
+            <div
+              key={`${gameState.currentRound}-${gameState.currentTrick}`}
+              className="trick-indicator-update"
+              style={{
+                position: 'absolute',
+                top: '1rem',
+                left: '1.5rem',
+                zIndex: 10,
+                backgroundColor: 'rgba(0, 0, 0, 0.6)',
+                color: 'white',
+                padding: '0.5rem 1.2rem',
+                borderRadius: '8px',
+                fontSize: '1.1rem',
+                fontWeight: 'bold',
+                letterSpacing: '0.05em',
+              }}
+            >
+              第{gameState.currentRound}ラウンド / 第{gameState.currentTrick}トリック
             </div>
-          ) : null}
+            <BattleHud
+              round={gameState.currentRound}
+              trick={gameState.currentTrick}
+              timer={
+                <Timer
+                  turnSeconds={
+                    gameRef.current ? getEffectiveTurnSeconds(gameRef.current.config) : null
+                  }
+                  isActive={gameState.currentPlayer === 0 && gameState.phase === 'AwaitMove'}
+                  onTimeout={handleTimeout}
+                />
+              }
+              onExit={handleBackToHome}
+            />
 
-          {shouldDiscardMinCard ? (
-            <div className="discard-notice" role="status" aria-live="polite">
-              出せるカードがありません。最小のカードを捨てます。
-            </div>
-          ) : null}
+            {isFinalTrickPhase ? (
+              <div className="final-trick-notice" role="status" aria-live="polite">
+                最終トリック
+              </div>
+            ) : null}
 
-          {turnNotice ? (
-            <div className="discard-result-notice" role="status" aria-live="polite">
-              {turnNotice}
-            </div>
-          ) : null}
-          <EllipseTable
-            state={gameState}
-            config={
-              gameRef.current?.config ||
-              ({
-                players: 4,
-                turnSeconds: 15,
-                maxCucumbers: 6,
-                initialCards: 7,
-                cpuLevel: 'normal',
-              } as GameConfig)
-            }
-            currentPlayerIndex={currentPlayerIndex}
-            onCardClick={(card: number) => handleCardClick(Number(card))}
-            className={['cpu-play-table', isCardLocked ? 'cards-locked' : '']
-              .filter(Boolean)
-              .join(' ')}
-            isSubmitting={isSubmitting}
-            lockedCardId={lockedCardId}
-            names={displayNames}
-            mySeatIndex={0}
-            trickCards={tableTrickCards}
-            latestPlayedCardKey={latestPlayedKey}
-            trickWinner={trickWinner}
-            trickWinnerText={trickWinnerText}
-            isFinalTrickMode={isFinalTrickPhase}
-            finalTrickSelectedPlayers={finalTrickSelectedPlayers}
-            finalTrickOpenedPlayers={finalTrickOpenedPlayers}
-            finalTrickStatusText={finalTrickStatusText}
-          />
+            {shouldDiscardMinCard ? (
+              <div className="discard-notice" role="status" aria-live="polite">
+                出せるカードがありません。最小のカードを捨てます。
+              </div>
+            ) : null}
 
-          {gameOver ? (
-            <GameFooter>
-              <div className="flex flex-wrap items-center gap-3">
-                <h2 className="font-heading text-[clamp(18px,2.2vw,24px)]">ゲーム終了</h2>
-                <div className="flex flex-wrap gap-2 text-white/80 text-sm">
-                  {gameOverData.map((data, index) => (
-                    <span
-                      key={index}
-                      className="inline-flex items-center gap-2 rounded-full bg-white/10 border border-white/20 px-3 py-1"
-                    >
-                      プレイヤー{data.player}: {data.count}個
-                    </span>
-                  ))}
+            {turnNotice ? (
+              <div className="discard-result-notice" role="status" aria-live="polite">
+                {turnNotice}
+              </div>
+            ) : null}
+            <EllipseTable
+              state={gameState}
+              config={
+                gameRef.current?.config ||
+                ({
+                  players: 4,
+                  turnSeconds: 15,
+                  maxCucumbers: 6,
+                  initialCards: 7,
+                  cpuLevel: 'normal',
+                } as GameConfig)
+              }
+              currentPlayerIndex={currentPlayerIndex}
+              onCardClick={(card: number) => handleCardClick(Number(card))}
+              className={['cpu-play-table', isCardLocked ? 'cards-locked' : '']
+                .filter(Boolean)
+                .join(' ')}
+              isSubmitting={isSubmitting}
+              lockedCardId={lockedCardId}
+              names={displayNames}
+              mySeatIndex={0}
+              trickCards={tableTrickCards}
+              latestPlayedCardKey={latestPlayedKey}
+              trickWinner={trickWinner}
+              trickWinnerText={trickWinnerText}
+              isFinalTrickMode={isFinalTrickPhase}
+              finalTrickSelectedPlayers={finalTrickSelectedPlayers}
+              finalTrickOpenedPlayers={finalTrickOpenedPlayers}
+              finalTrickStatusText={finalTrickStatusText}
+            />
+
+            {gameOver ? (
+              <GameFooter>
+                <div className="flex flex-wrap items-center gap-3">
+                  <h2 className="font-heading text-[clamp(18px,2.2vw,24px)]">ゲーム終了</h2>
+                  <div className="flex flex-wrap gap-2 text-white/80 text-sm">
+                    {gameOverData.map((data, index) => (
+                      <span
+                        key={index}
+                        className="inline-flex items-center gap-2 rounded-full bg-white/10 border border-white/20 px-3 py-1"
+                      >
+                        プレイヤー{data.player}: {data.count}個
+                      </span>
+                    ))}
+                  </div>
                 </div>
-              </div>
-              <div className="flex items-center gap-2 ml-auto">
-                <button
-                  type="button"
-                  onClick={handleRestart}
-                  className="fc-button fc-button--primary"
-                >
-                  再戦
-                </button>
-                <button
-                  type="button"
-                  onClick={handleBackToHome}
-                  className="fc-button fc-button--secondary"
-                >
-                  ホーム
-                </button>
-              </div>
-            </GameFooter>
-          ) : null}
+                <div className="flex items-center gap-2 ml-auto">
+                  <button
+                    type="button"
+                    onClick={handleRestart}
+                    className="fc-button fc-button--primary"
+                  >
+                    再戦
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleBackToHome}
+                    className="fc-button fc-button--secondary"
+                  >
+                    ホーム
+                  </button>
+                </div>
+              </GameFooter>
+            ) : null}
           </div>
         </BattleLayout>
       </div>

--- a/apps/hub/app/globals.css
+++ b/apps/hub/app/globals.css
@@ -631,7 +631,6 @@ body {
   background: transparent;
 }
 
-
 /* ホーム背景 */
 body[data-bg='home']::before {
   background-image: url('/images/home1.png');
@@ -2216,7 +2215,7 @@ body[data-bg='battle']::before {
 
 /* === バトルレイアウト === */
 .battle-layout {
-  min-height: 100svh;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   font-family: 'Noto Sans JP', sans-serif;
@@ -2264,7 +2263,7 @@ body[data-bg='battle']::before {
 
 @media (max-height: 720px) {
   .battle-layout__stage {
-    min-height: clamp(480px, 100svh, 760px);
+    min-height: clamp(480px, 100vh, 760px);
     margin: clamp(8px, 2vh, 20px) auto;
     padding: clamp(12px, 2.8vw, 24px);
     padding-bottom: calc(clamp(24px, 5vw, 48px) + env(safe-area-inset-bottom, 0));


### PR DESCRIPTION
### Motivation
- The green "felt" background was bleeding outside the table because `.ellipse-table` or other wrappers had background values, so the intent is to ensure only `.ellipse-table-inner` provides the felt styling.
- The game area sometimes left a grey gap at the bottom because components used `100svh` or lacked a guaranteed `100vh` minimum, so the layout must reliably cover the viewport.

### Description
- Added `background: transparent;` to `.ellipse-table` and kept the green gradient only on `.ellipse-table-inner` in `apps/hub/app/cucumber/cpu/play/game.css` to confine the felt color to the table interior.
- Added `width: 100%` to `.game-container` in `apps/hub/app/cucumber/cpu/play/game.css` to stabilize layout sizing.
- Ensured the CPU play page root container gets `style={{ minHeight: '100vh' }}` in `apps/hub/app/cucumber/cpu/play/page.tsx` so the game content always fills the viewport.
- Replaced fragile `100svh` usages with `100vh` in `apps/hub/app/globals.css` for `.battle-layout` and related stage rules to avoid viewport-height inconsistencies that caused bottom gaps.

### Testing
- Ran the background investigation commands (`rg` / `grep`) as requested and verified only `.ellipse-table-inner` contains the felt gradient in the CPU play styles (commands returned expected locations).
- Ran code formatting and checks (`npx prettier --write ...` and `pnpm --filter @five-cucumber/hub lint`) which completed (lint produced an unrelated existing warning but no new errors).
- Launched the dev server and performed a headless browser check with Playwright visiting `/cucumber/cpu/play?...` and captured a screenshot confirming no green area outside the table; the artifact is `browser:/tmp/codex_browser_invocations/.../cpu-play-no-green-outside.png`.
- Committed the changes with message `Fix CPU play background scope to table inner only` and verified the modified files are `apps/hub/app/cucumber/cpu/play/game.css`, `apps/hub/app/cucumber/cpu/play/page.tsx`, and `apps/hub/app/globals.css`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f2041b218832fa0f094bb6f99a7b4)