### PR TITLE
test(hub): add unit tests for game-core engine and rules

### DIFF
--- a/apps/hub/lib/game-core/__tests__/engine.test.ts
+++ b/apps/hub/lib/game-core/__tests__/engine.test.ts
@@ -1,0 +1,334 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyMove, createInitialState, endTrick } from '../engine';
+import { createDeck, getLegalMoves, initializeCardCounts } from '../rules';
+import { SeededRng } from '../rng';
+import { GameConfig, GameState } from '../types';
+
+const config: GameConfig = {
+  players: 4,
+  turnSeconds: null,
+  maxCucumbers: 30,
+  initialCards: 7,
+  cpuLevel: 'easy',
+};
+
+function createBaseState(partial?: Partial<GameState>): GameState {
+  return {
+    players: [
+      { hand: [1, 7], cucumbers: 0, graveyard: [] },
+      { hand: [2, 8], cucumbers: 0, graveyard: [] },
+      { hand: [3, 9], cucumbers: 0, graveyard: [] },
+      { hand: [4, 10], cucumbers: 0, graveyard: [] },
+    ],
+    currentPlayer: 0,
+    currentRound: 1,
+    currentTrick: 1,
+    fieldCard: null,
+    sharedGraveyard: [],
+    trickCards: [],
+    actionCount: 0,
+    firstPlayer: 0,
+    isGameOver: false,
+    gameOverPlayers: [],
+    remainingCards: createDeck(),
+    cardCounts: initializeCardCounts(),
+    phase: 'AwaitMove',
+    isFinalTrick: false,
+    ...partial,
+  };
+}
+
+describe('applyMove - 通常プレイ', () => {
+  it('場の最高値以上のカードを出せる', () => {
+    const rng = new SeededRng(1);
+    const state = createBaseState({
+      fieldCard: 5,
+      players: [
+        { hand: [3, 7], cucumbers: 0, graveyard: [] },
+        { hand: [2], cucumbers: 0, graveyard: [] },
+        { hand: [3], cucumbers: 0, graveyard: [] },
+        { hand: [4], cucumbers: 0, graveyard: [] },
+      ],
+    });
+
+    const result = applyMove(state, { player: 0, card: 7, timestamp: 1 }, config, rng);
+
+    expect(result.success).toBe(true);
+    expect(result.newState.fieldCard).toBe(7);
+    expect(result.newState.players[0].hand).toEqual([3]);
+    expect(result.newState.trickCards).toHaveLength(1);
+  });
+
+  it('場の最高値未満のカードは出せない', () => {
+    const rng = new SeededRng(2);
+    const state = createBaseState({
+      fieldCard: 10,
+      players: [
+        { hand: [5, 12], cucumbers: 0, graveyard: [] },
+        { hand: [2], cucumbers: 0, graveyard: [] },
+        { hand: [3], cucumbers: 0, graveyard: [] },
+        { hand: [4], cucumbers: 0, graveyard: [] },
+      ],
+    });
+
+    const result = applyMove(state, { player: 0, card: 5, timestamp: 1 }, config, rng);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('Illegal move');
+  });
+
+  it('リードプレイヤーは任意のカードを出せる', () => {
+    const rng = new SeededRng(3);
+    const state = createBaseState({
+      fieldCard: null,
+      players: [
+        { hand: [2, 9], cucumbers: 0, graveyard: [] },
+        { hand: [2], cucumbers: 0, graveyard: [] },
+        { hand: [3], cucumbers: 0, graveyard: [] },
+        { hand: [4], cucumbers: 0, graveyard: [] },
+      ],
+    });
+
+    const result = applyMove(state, { player: 0, card: 2, timestamp: 1 }, config, rng);
+
+    expect(result.success).toBe(true);
+    expect(result.newState.fieldCard).toBe(2);
+    expect(result.newState.players[0].hand).toEqual([9]);
+  });
+});
+
+describe('applyMove - 捨てカード', () => {
+  it('出せるカードがない場合に最小カードを捨てられる', () => {
+    const rng = new SeededRng(4);
+    const state = createBaseState({
+      fieldCard: 14,
+      players: [
+        { hand: [1, 3, 5], cucumbers: 0, graveyard: [] },
+        { hand: [2], cucumbers: 0, graveyard: [] },
+        { hand: [3], cucumbers: 0, graveyard: [] },
+        { hand: [4], cucumbers: 0, graveyard: [] },
+      ],
+    });
+
+    const result = applyMove(state, { player: 0, card: 1, timestamp: 1, isDiscard: true }, config, rng);
+
+    expect(result.success).toBe(true);
+    expect(result.newState.players[0].graveyard).toEqual([1]);
+    expect(result.newState.trickCards).toHaveLength(0);
+  });
+
+  it('出せるカードがある場合に捨ては不可', () => {
+    const rng = new SeededRng(5);
+    const state = createBaseState({
+      fieldCard: 5,
+      players: [
+        { hand: [3, 7, 10], cucumbers: 0, graveyard: [] },
+        { hand: [2], cucumbers: 0, graveyard: [] },
+        { hand: [3], cucumbers: 0, graveyard: [] },
+        { hand: [4], cucumbers: 0, graveyard: [] },
+      ],
+    });
+
+    const result = applyMove(state, { player: 0, card: 3, timestamp: 1, isDiscard: true }, config, rng);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('cannot discard');
+  });
+
+  it('捨てカードはtrickCardsに追加されない', () => {
+    const rng = new SeededRng(6);
+    const state = createBaseState({
+      fieldCard: 14,
+      trickCards: [{ player: 1, card: 14, timestamp: 0 }],
+      actionCount: 1,
+      currentPlayer: 0,
+      players: [
+        { hand: [1, 3], cucumbers: 0, graveyard: [] },
+        { hand: [2], cucumbers: 0, graveyard: [] },
+        { hand: [3], cucumbers: 0, graveyard: [] },
+        { hand: [4], cucumbers: 0, graveyard: [] },
+      ],
+    });
+
+    const result = applyMove(state, { player: 0, card: 1, timestamp: 1, isDiscard: true }, config, rng);
+
+    expect(result.success).toBe(true);
+    expect(result.newState.trickCards).toEqual([{ player: 1, card: 14, timestamp: 0 }]);
+  });
+});
+
+describe('トリック完了', () => {
+  it('全員が行動したらトリック完了（actionCount）', () => {
+    const rng = new SeededRng(7);
+    let state = createBaseState({
+      players: [
+        { hand: [5], cucumbers: 0, graveyard: [] },
+        { hand: [10], cucumbers: 0, graveyard: [] },
+        { hand: [12], cucumbers: 0, graveyard: [] },
+        { hand: [13], cucumbers: 0, graveyard: [] },
+      ],
+    });
+
+    for (const card of [5, 10, 12, 13]) {
+      const result = applyMove(state, { player: state.currentPlayer, card, timestamp: 1 }, config, rng);
+      expect(result.success).toBe(true);
+      state = result.newState;
+    }
+
+    expect(state.currentTrick).toBe(2);
+    expect(state.actionCount).toBe(0);
+    expect(state.phase).toBe('AwaitMove');
+  });
+
+  it('捨てカードもトリック完了カウントに含まれる', () => {
+    const rng = new SeededRng(8);
+    let state = createBaseState({
+      players: [
+        { hand: [14], cucumbers: 0, graveyard: [] },
+        { hand: [15], cucumbers: 0, graveyard: [] },
+        { hand: [2], cucumbers: 0, graveyard: [] },
+        { hand: [1], cucumbers: 0, graveyard: [] },
+      ],
+    });
+
+    const moves = [
+      { card: 14, isDiscard: false },
+      { card: 15, isDiscard: false },
+      { card: 2, isDiscard: true },
+      { card: 1, isDiscard: true },
+    ];
+
+    for (const move of moves) {
+      const result = applyMove(
+        state,
+        { player: state.currentPlayer, card: move.card, timestamp: 1, isDiscard: move.isDiscard },
+        config,
+        rng
+      );
+      expect(result.success).toBe(true);
+      state = result.newState;
+    }
+
+    expect(state.currentTrick).toBe(2);
+    expect(state.actionCount).toBe(0);
+  });
+
+  it('トリック完了後にactionCountがリセットされる', () => {
+    const rng = new SeededRng(9);
+    const state = createBaseState({
+      players: [
+        { hand: [5], cucumbers: 0, graveyard: [] },
+        { hand: [10], cucumbers: 0, graveyard: [] },
+        { hand: [11], cucumbers: 0, graveyard: [] },
+        { hand: [12], cucumbers: 0, graveyard: [] },
+      ],
+      trickCards: [
+        { player: 0, card: 5, timestamp: 1 },
+        { player: 1, card: 10, timestamp: 2 },
+        { player: 2, card: 11, timestamp: 3 },
+        { player: 3, card: 12, timestamp: 4 },
+      ],
+      actionCount: 4,
+      fieldCard: 12,
+    });
+
+    const result = endTrick(state, config, rng);
+    expect(result.success).toBe(true);
+    expect(result.newState.actionCount).toBe(0);
+  });
+
+  it('勝者が次のリードプレイヤーになる', () => {
+    const rng = new SeededRng(10);
+    const state = createBaseState({
+      players: [
+        { hand: [1], cucumbers: 0, graveyard: [] },
+        { hand: [1], cucumbers: 0, graveyard: [] },
+        { hand: [1], cucumbers: 0, graveyard: [] },
+        { hand: [1], cucumbers: 0, graveyard: [] },
+      ],
+      trickCards: [
+        { player: 0, card: 5, timestamp: 1 },
+        { player: 1, card: 10, timestamp: 2 },
+        { player: 2, card: 3, timestamp: 3 },
+        { player: 3, card: 8, timestamp: 4 },
+      ],
+      actionCount: 4,
+      fieldCard: 8,
+    });
+
+    const result = endTrick(state, config, rng);
+
+    expect(result.success).toBe(true);
+    expect(result.newState.currentPlayer).toBe(1);
+  });
+});
+
+describe('1ゲーム完走', () => {
+  it('7トリック完了後にラウンドが終了する', () => {
+    const rng = new SeededRng(42);
+    const longConfig: GameConfig = { ...config, initialCards: 7, maxCucumbers: 999 };
+    let state = createInitialState(longConfig, rng);
+
+    for (let i = 0; i < longConfig.initialCards * longConfig.players; i++) {
+      const player = state.currentPlayer;
+      const legalMoves = getLegalMoves(state, player);
+      const card = Math.min(...legalMoves);
+      const isDiscard = state.fieldCard !== null && card < state.fieldCard;
+      const result = applyMove(state, { player, card, isDiscard, timestamp: i }, longConfig, rng);
+      expect(result.success).toBe(true);
+      state = result.newState;
+    }
+
+    expect(state.currentRound).toBe(2);
+  });
+
+  it('全トリックで手札が1枚ずつ減る', () => {
+    const rng = new SeededRng(99);
+    let state = createInitialState(config, rng);
+
+    for (let trick = 1; trick <= config.initialCards; trick++) {
+      const before = state.players.map(player => player.hand.length);
+
+      for (let turn = 0; turn < config.players; turn++) {
+        const player = state.currentPlayer;
+        const legalMoves = getLegalMoves(state, player);
+        const card = Math.min(...legalMoves);
+        const isDiscard = state.fieldCard !== null && card < state.fieldCard;
+        const result = applyMove(
+          state,
+          { player, card, isDiscard, timestamp: trick * 10 + turn },
+          config,
+          rng
+        );
+        expect(result.success).toBe(true);
+        state = result.newState;
+      }
+
+      const after = state.players.map(player => player.hand.length);
+      for (let i = 0; i < config.players; i++) {
+        expect(after[i]).toBe(before[i] - 1);
+      }
+    }
+  });
+
+  it('最終トリック後にきゅうりが正しく加算される', () => {
+    const rng = new SeededRng(123);
+    const longConfig: GameConfig = { ...config, maxCucumbers: 999 };
+    let state = createInitialState(longConfig, rng);
+    const beforeCucumbers = state.players.map(player => player.cucumbers);
+
+    for (let i = 0; i < longConfig.initialCards * longConfig.players; i++) {
+      const player = state.currentPlayer;
+      const legalMoves = getLegalMoves(state, player);
+      const card = Math.min(...legalMoves);
+      const isDiscard = state.fieldCard !== null && card < state.fieldCard;
+      const result = applyMove(state, { player, card, isDiscard, timestamp: i }, longConfig, rng);
+      expect(result.success).toBe(true);
+      state = result.newState;
+    }
+
+    const afterCucumbers = state.players.map(player => player.cucumbers);
+    expect(afterCucumbers.some((value, index) => value > beforeCucumbers[index])).toBe(true);
+  });
+});

--- a/apps/hub/lib/game-core/__tests__/rules.test.ts
+++ b/apps/hub/lib/game-core/__tests__/rules.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  calculateFinalTrickPenalty,
+  createDeck,
+  dealCards,
+  determineTrickWinner,
+} from '../rules';
+import { GameConfig, Move } from '../types';
+
+const baseConfig: GameConfig = {
+  players: 4,
+  turnSeconds: null,
+  maxCucumbers: 30,
+  initialCards: 7,
+  cpuLevel: 'easy',
+};
+
+describe('createDeck', () => {
+  it('105枚のデッキを生成する（15種類 × 7枚）', () => {
+    const deck = createDeck();
+    expect(deck).toHaveLength(105);
+  });
+
+  it('各数字が7枚ずつある', () => {
+    const deck = createDeck();
+
+    for (let i = 1; i <= 15; i++) {
+      expect(deck.filter(card => card === i)).toHaveLength(7);
+    }
+  });
+});
+
+describe('dealCards', () => {
+  it('各プレイヤーに7枚配る', () => {
+    const hands = dealCards(createDeck(), 4, 7);
+
+    expect(hands).toHaveLength(4);
+    hands.forEach(hand => expect(hand).toHaveLength(7));
+  });
+});
+
+describe('determineTrickWinner', () => {
+  it('最高値カードのプレイヤーが勝者', () => {
+    const trick: Move[] = [
+      { player: 0, card: 5, timestamp: 1 },
+      { player: 1, card: 10, timestamp: 2 },
+      { player: 2, card: 3, timestamp: 3 },
+      { player: 3, card: 8, timestamp: 4 },
+    ];
+
+    expect(determineTrickWinner(trick)).toBe(1);
+  });
+
+  it('同値の場合は最後に出した方が勝者', () => {
+    const trick: Move[] = [
+      { player: 0, card: 8, timestamp: 1 },
+      { player: 1, card: 4, timestamp: 2 },
+      { player: 2, card: 8, timestamp: 3 },
+      { player: 3, card: 8, timestamp: 4 },
+    ];
+
+    expect(determineTrickWinner(trick)).toBe(3);
+  });
+});
+
+describe('最終トリックペナルティ', () => {
+  it('勝者のカード数字分のきゅうりを獲得', () => {
+    const trick: Move[] = [
+      { player: 0, card: 7, timestamp: 1 },
+      { player: 1, card: 12, timestamp: 2 },
+      { player: 2, card: 9, timestamp: 3 },
+      { player: 3, card: 3, timestamp: 4 },
+    ];
+
+    const result = calculateFinalTrickPenalty(trick, baseConfig);
+    expect(result).toEqual({ winner: 1, penalty: 12 });
+  });
+
+  it('場に1がある場合はペナルティ2倍', () => {
+    const trick: Move[] = [
+      { player: 0, card: 1, timestamp: 1 },
+      { player: 1, card: 5, timestamp: 2 },
+      { player: 2, card: 10, timestamp: 3 },
+      { player: 3, card: 8, timestamp: 4 },
+    ];
+
+    const result = calculateFinalTrickPenalty(trick, baseConfig);
+    expect(result).toEqual({ winner: 2, penalty: 20 });
+  });
+
+  it('全員が1を出した場合はペナルティ0', () => {
+    const trick: Move[] = [
+      { player: 0, card: 1, timestamp: 1 },
+      { player: 1, card: 1, timestamp: 2 },
+      { player: 2, card: 1, timestamp: 3 },
+      { player: 3, card: 1, timestamp: 4 },
+    ];
+
+    const result = calculateFinalTrickPenalty(trick, baseConfig);
+    expect(result).toEqual({ winner: 3, penalty: 0 });
+  });
+
+  it('勝者自身が1を出して勝った場合もペナルティ0', () => {
+    const trick: Move[] = [
+      { player: 0, card: 1, timestamp: 1 },
+      { player: 1, card: 1, timestamp: 2 },
+      { player: 2, card: 1, timestamp: 3 },
+      { player: 3, card: 1, timestamp: 4 },
+    ];
+
+    const result = calculateFinalTrickPenalty(trick, baseConfig);
+    expect(result.winner).toBe(3);
+    expect(result.penalty).toBe(0);
+  });
+});

--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -10,7 +10,8 @@
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
-    "clean": "rm -rf .next dist"
+    "clean": "rm -rf .next dist",
+    "test": "vitest run"
   },
   "dependencies": {
     "@five-cucumber/metrics": "workspace:*",
@@ -38,6 +39,7 @@
     "@typescript-eslint/parser": "^7.0.0",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.0.0",
-    "typescript": "~5.3.3"
+    "typescript": "~5.3.3",
+    "vitest": "^2.1.9"
   }
 }


### PR DESCRIPTION
### Motivation

- ゲームエンジンの主要ロジック（`engine.ts` / `rules.ts`）に対して回帰検知用のユニットテストを追加し、将来の改修での破壊を早期発見できるようにする。 

### Description

- 新規に `apps/hub/lib/game-core/__tests__/rules.test.ts` を追加し、`createDeck` / `dealCards` / `determineTrickWinner` / `calculateFinalTrickPenalty` の振る舞いを検証するテストを実装した。 
- 新規に `apps/hub/lib/game-core/__tests__/engine.test.ts` を追加し、`applyMove` の合法手チェック・捨て札の制約・`trickCards` への反映・トリック完了処理（`endTrick`）・1ラウンド分のシミュレーションを検証するテストを実装した。 
- `apps/hub/package.json` に `test` スクリプトを追加し（`"test": "vitest run"`）、`vitest` を `devDependencies` に追記してローカルでのテスト実行準備を行った。 

### Testing

- 型チェックで `pnpm --filter @five-cucumber/hub type-check` を実行して `tsc --noEmit` が通ることを確認した（成功）。
- `vitest` のインストールは環境側の npm レジストリ認証エラー（403）により `pnpm add -D vitest` が失敗したため依存バイナリは未インストールである（失敗）。
- そのため `pnpm --filter @five-cucumber/hub test` を実行すると `vitest: not found` となりテスト実行は環境内では未実行だが、依存をインストールすれば追加したテストは `vitest run` で実行可能でありエンジン／ルールの主要ロジックをカバーする内容になっている。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f242aeb3c832f89565a9e6096b413)