### PR TITLE
Fix final trick showdown display/transition and add optional min-card discard rule

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/game.css
+++ b/apps/hub/app/cucumber/cpu/play/game.css
@@ -75,6 +75,34 @@
   height: calc(var(--ellipse-card-height) + 40px);
 }
 
+.showdown-cards-row {
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  gap: clamp(8px, 2vw, 24px);
+  flex-wrap: nowrap;
+}
+
+.showdown-card-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.showdown-card {
+  min-width: clamp(56px, 6vw, 74px);
+}
+
+.showdown-player-name {
+  margin-top: 0.5rem;
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-align: center;
+  white-space: nowrap;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
+}
+
 .trick-card-entry {
   position: absolute;
   left: 50%;

--- a/apps/hub/app/cucumber/cpu/play/page.tsx
+++ b/apps/hub/app/cucumber/cpu/play/page.tsx
@@ -6,13 +6,14 @@ import { HumanController } from '@/lib/controllers/human';
 import { delay, runAnimation } from '@/lib/animQueue';
 import {
   applyMove,
+  calculateFinalTrickPenalty,
   createGameView,
   createInitialState,
+  finalRound,
   GameConfig,
   GameState,
   getEffectiveTurnSeconds,
   getLegalMoves,
-  calculateFinalTrickPenalty,
   determineTrickWinner,
   Move,
   PlayerController,
@@ -52,6 +53,7 @@ function CpuPlayContent() {
   const [finalTrickStatusText, setFinalTrickStatusText] = useState<string | null>(null);
   const [overlayText, setOverlayText] = useState<string | null>(null);
   const [finalTrickStarted, setFinalTrickStarted] = useState(false);
+  const [isShowdownMode, setIsShowdownMode] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
   const cpuTurnTimerRef = useRef<NodeJS.Timeout | null>(null);
   const finalTrickTimeoutsRef = useRef<NodeJS.Timeout[]>([]);
@@ -137,6 +139,7 @@ function CpuPlayContent() {
       setFinalTrickStatusText(null);
       setOverlayText(null);
       setFinalTrickStarted(false);
+      setIsShowdownMode(false);
       setIsAnimating(false);
 
       console.log('[Game] New game started with', config.players, 'players');
@@ -239,6 +242,7 @@ function CpuPlayContent() {
               setFinalTrickStatusText(null);
               setOverlayText(null);
               setFinalTrickStarted(false);
+              setIsShowdownMode(false);
               setIsAnimating(false);
 
               console.log('[Game] State restored successfully with rebuilt controllers');
@@ -428,8 +432,13 @@ function CpuPlayContent() {
             } else {
               const penaltyResult = calculateFinalTrickPenalty(trickCardsAfterPlay, config);
               const hasOne = trickCardsAfterPlay.some(trickCard => trickCard.card === 1);
+              const basePenalty = hasOne ? Math.floor(penaltyResult.penalty / 2) : penaltyResult.penalty;
               const penaltyText = `${winnerName}が${penaltyResult.penalty}本のきゅうりを獲得しました`;
-              setTrickWinnerText(hasOne ? `${penaltyText}（1が場にあるため2倍！）` : penaltyText);
+              setTrickWinnerText(
+                hasOne
+                  ? `${penaltyText}（場に1があるため2倍: ${basePenalty}×2=${penaltyResult.penalty}）`
+                  : penaltyText
+              );
             }
             setFinalTrickStatusText('最終トリック結果');
           }
@@ -446,6 +455,7 @@ function CpuPlayContent() {
           setFinalTrickSelectedPlayers([]);
           setFinalTrickOpenedPlayers([]);
           setFinalTrickStatusText(null);
+          setIsShowdownMode(false);
           setIsAnimating(false);
         } else {
           gameRef.current.state = newState;
@@ -621,6 +631,7 @@ function CpuPlayContent() {
         trickCards: trickCardsAfterShowdown,
       };
       setIsAnimating(true);
+      setIsShowdownMode(true);
       setTrickWinner(winner);
       setFinalTrickStatusText(null);
 
@@ -632,14 +643,21 @@ function CpuPlayContent() {
         } else {
           const penaltyResult = calculateFinalTrickPenalty(trickCardsAfterShowdown, config);
           const hasOne = trickCardsAfterShowdown.some(trickCard => trickCard.card === 1);
+          const basePenalty = hasOne ? Math.floor(penaltyResult.penalty / 2) : penaltyResult.penalty;
           const penaltyText = `${winnerName}が${penaltyResult.penalty}本のきゅうりを獲得しました`;
-          setTrickWinnerText(hasOne ? `${penaltyText}（1が場にあるため2倍！）` : penaltyText);
+          setTrickWinnerText(
+            hasOne
+              ? `${penaltyText}（場に1があるため2倍: ${basePenalty}×2=${penaltyResult.penalty}）`
+              : penaltyText
+          );
         }
       }, 2000);
 
       const nextRoundTimer = setTimeout(() => {
-        setGameState(currentState);
-        gameRef.current!.state = currentState;
+        const afterFinalRoundResult = finalRound(currentState, config, rng);
+        const afterFinalRoundState = afterFinalRoundResult.newState;
+        setGameState(afterFinalRoundState);
+        gameRef.current!.state = afterFinalRoundState;
         setTableTrickCards([]);
         setLatestPlayedKey(null);
         setTrickWinner(null);
@@ -649,13 +667,17 @@ function CpuPlayContent() {
         setFinalTrickOpenedPlayers([]);
         setFinalTrickStatusText(null);
         setFinalTrickStarted(false);
+        setOverlayText(null);
+        setIsShowdownMode(false);
         setIsAnimating(false);
 
-        if (currentState.phase === 'GameEnd') {
+        if (afterFinalRoundState.phase === 'GameEnd') {
           setGameOver(true);
           setGameOverData(
-            currentState.players.map((p, index) => ({ player: index, count: p.cucumbers }))
+            afterFinalRoundState.players.map((p, index) => ({ player: index, count: p.cucumbers }))
           );
+        } else if (scheduleCpuTurnRef.current && afterFinalRoundState.currentPlayer !== 0) {
+          scheduleCpuTurnRef.current();
         }
       }, 3600);
 
@@ -720,13 +742,11 @@ function CpuPlayContent() {
   }
 
   const displayNames = gameState.players.map((_, idx) => (idx === 0 ? 'あなた' : `CPU ${idx}`));
-  const humanLegalMoves = getLegalMoves(gameState, 0);
   const shouldDiscardMinCard =
     gameState.currentPlayer === 0 &&
     gameState.phase === 'AwaitMove' &&
     gameState.fieldCard !== null &&
-    humanLegalMoves.length === 1 &&
-    humanLegalMoves[0] < gameState.fieldCard;
+    !gameState.players[0].hand.some(card => card >= gameState.fieldCard);
 
   const isFinalTrickPhase =
     gameState.isFinalTrick ||
@@ -828,6 +848,7 @@ function CpuPlayContent() {
               finalTrickSelectedPlayers={finalTrickSelectedPlayers}
               finalTrickOpenedPlayers={finalTrickOpenedPlayers}
               finalTrickStatusText={finalTrickStatusText}
+              showdownMode={isShowdownMode}
             />
 
             {gameOver ? (

--- a/apps/hub/components/ui/EllipseTable.tsx
+++ b/apps/hub/components/ui/EllipseTable.tsx
@@ -20,6 +20,7 @@ interface EllipseTableProps {
   trickWinner?: number | null;
   trickWinnerText?: string | null;
   isFinalTrickMode?: boolean;
+  showdownMode?: boolean;
   finalTrickSelectedPlayers?: number[];
   finalTrickOpenedPlayers?: number[];
   finalTrickStatusText?: string | null;
@@ -41,6 +42,7 @@ export function EllipseTable({
   trickWinner = null,
   trickWinnerText = null,
   isFinalTrickMode = false,
+  showdownMode = false,
   finalTrickSelectedPlayers = [],
   finalTrickOpenedPlayers = [],
   finalTrickStatusText = null,
@@ -88,6 +90,10 @@ export function EllipseTable({
   const rootClassName = ['ellipse-table', 'layer-field', className].filter(Boolean).join(' ');
   const visibleTrickCards = trickCards.filter(move => !move.isDiscard);
   const lastPlayedTrickCard = visibleTrickCards[visibleTrickCards.length - 1] ?? null;
+  const showdownCards = visibleTrickCards.map(trickCard => ({
+    ...trickCard,
+    playerName: getPlayerName(trickCard.player),
+  }));
 
   return (
     <div className={rootClassName}>
@@ -95,7 +101,25 @@ export function EllipseTable({
         {/* 中央の場と墓地 */}
         <div className="ellipse-table__center">
           <div id="field" className="ellipse-table__field" aria-label="場のカード">
-            {visibleTrickCards.length > 0 ? (
+            {showdownMode && showdownCards.length > 0 ? (
+              <div className="showdown-cards-row" aria-live="polite">
+                {showdownCards.map((showdownCard, index) => (
+                  <div key={`${showdownCard.player}-${showdownCard.timestamp}-${index}`} className="showdown-card-item">
+                    <div className="card game-card current-card showdown-card">
+                      <div className="card-number">{showdownCard.card}</div>
+                      <div className="cucumber-icons">
+                        {showdownCard.card >= 2 && showdownCard.card <= 5 && '🥒'}
+                        {showdownCard.card >= 6 && showdownCard.card <= 9 && '🥒🥒'}
+                        {showdownCard.card >= 10 && showdownCard.card <= 11 && '🥒🥒🥒'}
+                        {showdownCard.card >= 12 && showdownCard.card <= 14 && '🥒🥒🥒🥒'}
+                        {showdownCard.card === 15 && '🥒🥒🥒🥒🥒'}
+                      </div>
+                    </div>
+                    <div className="showdown-player-name">{showdownCard.playerName}</div>
+                  </div>
+                ))}
+              </div>
+            ) : visibleTrickCards.length > 0 ? (
               <div className="trick-cards-queue" aria-live="polite">
                 {visibleTrickCards.map((trickCard, index) => {
                   const cardKey = `${trickCard.player}-${trickCard.timestamp}`;
@@ -242,15 +266,13 @@ export function EllipseTable({
             {(() => {
               const myHand = state.players[mySeatIndex]?.hand ?? [];
               const highestOnTable = state.fieldCard;
-              const hasLegalPlay = myHand.some(
-                handCard => highestOnTable === null || handCard >= highestOnTable
-              );
               const minCard = myHand.length > 0 ? Math.min(...myHand) : null;
 
               return myHand.map((card, index) => {
                 const isPlayable = highestOnTable === null || card >= highestOnTable;
-                const isDiscard = !hasLegalPlay && minCard !== null && card === minCard;
-                const isIllegalWhileLegalExists = hasLegalPlay && !isPlayable;
+                const isMinCard = minCard !== null && card === minCard;
+                const isDiscard = highestOnTable !== null && isMinCard && !isPlayable;
+                const isIllegalWhileLegalExists = !isPlayable && !isMinCard;
                 const isMyTurn = currentPlayerIndex === mySeatIndex;
 
                 // カードが送信中またはロックされているかチェック

--- a/apps/hub/lib/game-core/__tests__/engine.test.ts
+++ b/apps/hub/lib/game-core/__tests__/engine.test.ts
@@ -75,7 +75,7 @@ describe('applyMove - 通常プレイ', () => {
     const result = applyMove(state, { player: 0, card: 5, timestamp: 1 }, config, rng);
 
     expect(result.success).toBe(false);
-    expect(result.message).toBe('Illegal move');
+    expect(result.message).toContain('not legal');
   });
 
   it('リードプレイヤーは任意のカードを出せる', () => {
@@ -118,8 +118,27 @@ describe('applyMove - 捨てカード', () => {
     expect(result.newState.trickCards).toHaveLength(0);
   });
 
-  it('出せるカードがある場合に捨ては不可', () => {
+  it('出せるカードがある場合でも最小カードは捨てられる', () => {
     const rng = new SeededRng(5);
+    const state = createBaseState({
+      fieldCard: 5,
+      players: [
+        { hand: [3, 7, 10], cucumbers: 0, graveyard: [] },
+        { hand: [2], cucumbers: 0, graveyard: [] },
+        { hand: [3], cucumbers: 0, graveyard: [] },
+        { hand: [4], cucumbers: 0, graveyard: [] },
+      ],
+    });
+
+    const result = applyMove(state, { player: 0, card: 3, timestamp: 1, isDiscard: true }, config, rng);
+
+    expect(result.success).toBe(true);
+    expect(result.newState.players[0].graveyard).toEqual([3]);
+    expect(result.newState.players[0].hand).toEqual([7, 10]);
+  });
+
+  it('最小カード以外は捨てられない', () => {
+    const rng = new SeededRng(15);
     const state = createBaseState({
       fieldCard: 5,
       players: [
@@ -133,7 +152,7 @@ describe('applyMove - 捨てカード', () => {
     const result = applyMove(state, { player: 0, card: 7, timestamp: 1, isDiscard: true }, config, rng);
 
     expect(result.success).toBe(false);
-    expect(result.message).toContain('cannot discard');
+    expect(result.message).toContain('minimum card');
   });
 
   it('捨てカードはtrickCardsに追加されない', () => {

--- a/apps/hub/lib/game-core/engine.ts
+++ b/apps/hub/lib/game-core/engine.ts
@@ -95,20 +95,10 @@ export function applyMove(
   }
 
   const minCard = Math.min(...playerHand);
-  const hasLegalPlay =
-    state.fieldCard === null ? true : playerHand.some(handCard => handCard >= state.fieldCard!);
 
   if (move.isDiscard) {
     if (state.fieldCard === null) {
       return { success: false, newState: state, message: 'Cannot discard on empty field' };
-    }
-
-    if (hasLegalPlay) {
-      return {
-        success: false,
-        newState: state,
-        message: 'Player has legal cards to play, cannot discard',
-      };
     }
 
     if (card !== minCard) {

--- a/apps/hub/lib/game-core/rules.ts
+++ b/apps/hub/lib/game-core/rules.ts
@@ -26,19 +26,19 @@ export function getLegalMoves(state: GameState, player: number): number[] {
   if (hand.length === 0) return [];
 
   const minCard = Math.min(...hand);
-  
+
   if (state.fieldCard === null) {
     // 最初のカードは何でも出せる
     return [...hand];
   }
-  
-  // 場のカード以上か、最小カードのみ
+
+  // 場のカード以上 + 任意で最小カード（ハウスルール）
   const playableCards = hand.filter(card => card >= state.fieldCard!);
-  if (playableCards.length > 0) {
+  if (playableCards.includes(minCard)) {
     return playableCards;
   }
-  
-  return [minCard];
+
+  return [...playableCards, minCard];
 }
 
 // トリックの勝者を決定


### PR DESCRIPTION
### Motivation

- 最終トリックのShowdownで全員のカードが横並びで表示されず見づらかったため、表示を改善する必要があった。 
- Showdown後にペナルティ表示のあとゲームが遷移せず固まるケースがあり、確実に次ラウンドまたはゲーム終了へ進めるようにした。 
- ペナルティが2倍になる理由の表示が不親切だったため、計算の内訳を明示してプレイヤーに説明する必要があった。 
- ハウスルールで「最小カードを任意で捨てられる」仕様を導入するため、UI/エンジン/テストを調整する必要があった。 

### Description

- `EllipseTable` に `showdownMode` プロップを追加し、Showdown時は場にあるカードを中央で横並びに表示して各カードの下にプレイヤー名を出す新レンダリングパスを追加した。 
- CPU対戦ページの最終トリック処理を修正し、Showdownモードのフラグ管理を追加してペナルティ表示→`finalRound` 実行→次ラウンド/ゲーム終了への遷移を確実に行うようにした（フラグ `isShowdownMode`/`finalTrickStarted`/`overlayText` を適切にリセット）。 
- ペナルティ表示を改善し、場に `1` がある場合の2倍ルールについて `X×2=Y` の形で内訳を表示するようにした。 
- ハウスルールをエンジンに導入して `getLegalMoves` を変更し、場にカードがあるときでも手札の最小カードを選択肢に含めるようにし、`applyMove` は捨て（`isDiscard`）のバリデーションを「最小カードのみ許可」へ更新して“出せるカードがある”制約を撤廃した。 
- UI側で手札判定を更新し、最小カードが場未満であれば赤表示（捨て）としていつでもクリック可能にし、最小だが出せる場合は通常の出す扱い（緑表示）になるようにした。 
- Showdown用のスタイルを `game.css` に追加した。 
- テストを更新して新ルールに合わせ、最小カードを任意で捨てられることと最小以外は捨てられないことを検証するケースを追加・修正した。 

### Testing

- 実行コマンド：`pnpm --filter @five-cucumber/hub test` を実行し、最終的にテストは全件パスしました（`lib/game-core/__tests__/engine.test.ts` と `lib/game-core/__tests__/rules.test.ts` を含む合計 23 テストが成功）。
- テスト中に1件の期待メッセージ差異を確認してテストアサーションを調整し、その後再実行で全テストが通過しています。 
- 自動テストのみを実行して確認しており、変更はユニットテストでカバーされています（UIのスクリーンショットは環境上取得していません）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8835d0e38832f8f6ab6f90bc232af)