### PR TITLE
fix(hub): narrow fieldCard before discard check

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/page.tsx
+++ b/apps/hub/app/cucumber/cpu/play/page.tsx
@@ -742,11 +742,12 @@ function CpuPlayContent() {
   }
 
   const displayNames = gameState.players.map((_, idx) => (idx === 0 ? 'あなた' : `CPU ${idx}`));
+  const fieldCard = gameState.fieldCard;
   const shouldDiscardMinCard =
     gameState.currentPlayer === 0 &&
     gameState.phase === 'AwaitMove' &&
-    gameState.fieldCard !== null &&
-    !gameState.players[0].hand.some(card => card >= gameState.fieldCard);
+    fieldCard !== null &&
+    !gameState.players[0].hand.some(card => card >= fieldCard);
 
   const isFinalTrickPhase =
     gameState.isFinalTrick ||


### PR DESCRIPTION
### Motivation
- TypeScript が `gameState.fieldCard` の null 絞り込みを認識せず型エラーになるため、参照をローカル変数に切り出して安全に絞り込みを行う必要があった。

### Description
- `apps/hub/app/cucumber/cpu/play/page.tsx` で `gameState.fieldCard` を `const fieldCard = gameState.fieldCard;` に取り出し、`shouldDiscardMinCard` 判定で `fieldCard` を使用するように変更して型エラーを解消した（非 null アサーションは使用していない）。

### Testing
- 実行した自動チェックとして `pnpm --filter @five-cucumber/hub type-check` は成功した。 
- 実行したビルドとして `pnpm --filter @five-cucumber/hub build` は警告を出したがビルドは完了して成功した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c888971ac8832fac43ad72aac6ea44)