### PR TITLE
Enforce final-trick play (no discards), fix penalty calc, and hide graveyard during showdown

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/page.tsx
+++ b/apps/hub/app/cucumber/cpu/play/page.tsx
@@ -603,23 +603,14 @@ function CpuPlayContent() {
       for (const playerIndex of playerOrder) {
         const hand = currentState.players[playerIndex]?.hand ?? [];
         if (hand.length === 0) continue;
-        const legalMoves = getLegalMoves(currentState, playerIndex);
-        if (legalMoves.length === 0) {
-          console.warn('[Showdown] No legal moves for player', playerIndex, 'hand:', hand);
-          continue;
-        }
-        const selectedCard = legalMoves[0];
-        const isDiscardMove =
-          currentState.fieldCard !== null &&
-          selectedCard < (currentState.fieldCard ?? 0) &&
-          selectedCard === Math.min(...hand);
+        const selectedCard = hand[0];
         const move: Move = {
           player: playerIndex,
           card: selectedCard,
           timestamp: Date.now() + playerIndex,
-          isDiscard: isDiscardMove,
+          isDiscard: false,
         };
-        console.log('[Showdown] Player', playerIndex, 'card:', selectedCard, 'isDiscard:', isDiscardMove);
+        console.log('[Showdown] Player', playerIndex, 'card:', selectedCard, 'isDiscard:', false);
         const result = applyMove(currentState, move, config, rng);
         console.log('[Showdown] applyMove result:', result.success, result.message);
         if (!result.success) {
@@ -660,12 +651,13 @@ function CpuPlayContent() {
 
       const showResultTimer = setTimeout(() => {
         const winnerName = winner === 0 ? 'あなた' : `CPU ${winner}`;
-        const allOnes = trickCardsAfterShowdown.every(trickCard => trickCard.card === 1);
+        const playedCards = trickCardsAfterShowdown.filter(trickCard => !trickCard.isDiscard);
+        const allOnes = playedCards.length > 0 && playedCards.every(trickCard => trickCard.card === 1);
         if (allOnes) {
           setTrickWinnerText('全員が1を出したためペナルティなし！');
         } else {
           const penaltyResult = calculateFinalTrickPenalty(trickCardsAfterShowdown, config);
-          const hasOne = trickCardsAfterShowdown.some(trickCard => trickCard.card === 1);
+          const hasOne = playedCards.some(trickCard => trickCard.card === 1);
           const basePenalty = hasOne ? Math.floor(penaltyResult.penalty / 2) : penaltyResult.penalty;
           const penaltyText = `${winnerName}が${penaltyResult.penalty}本のきゅうりを獲得しました`;
           setTrickWinnerText(

--- a/apps/hub/components/ui/EllipseTable.tsx
+++ b/apps/hub/components/ui/EllipseTable.tsx
@@ -205,13 +205,15 @@ export function EllipseTable({
               <div className="trick-winner-banner">{trickWinnerText}</div>
             ) : null}
           </div>
-          <div id="grave" className="ellipse-table__grave" aria-label="墓地">
-            {state.sharedGraveyard.length > 0 && (
-              <div className="graveyard-card">
-                {state.sharedGraveyard[state.sharedGraveyard.length - 1]}
-              </div>
-            )}
-          </div>
+          {!showdownMode ? (
+            <div id="grave" className="ellipse-table__grave" aria-label="墓地">
+              {state.sharedGraveyard.length > 0 && (
+                <div className="graveyard-card">
+                  {state.sharedGraveyard[state.sharedGraveyard.length - 1]}
+                </div>
+              )}
+            </div>
+          ) : null}
         </div>
 
         {/* 楕円座席（外枠と内枠の間の帯） */}

--- a/apps/hub/lib/game-core/__tests__/engine.test.ts
+++ b/apps/hub/lib/game-core/__tests__/engine.test.ts
@@ -175,6 +175,47 @@ describe('applyMove - 捨てカード', () => {
     expect(result.success).toBe(true);
     expect(result.newState.trickCards).toEqual([{ player: 1, card: 14, timestamp: 0 }]);
   });
+
+  it('最終トリックでは捨てられない', () => {
+    const rng = new SeededRng(16);
+    const state = createBaseState({
+      isFinalTrick: true,
+      fieldCard: 14,
+      players: [
+        { hand: [1], cucumbers: 0, graveyard: [] },
+        { hand: [2], cucumbers: 0, graveyard: [] },
+        { hand: [3], cucumbers: 0, graveyard: [] },
+        { hand: [4], cucumbers: 0, graveyard: [] },
+      ],
+    });
+
+    const result = applyMove(state, { player: 0, card: 1, timestamp: 1, isDiscard: true }, config, rng);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Final trick');
+  });
+});
+
+describe('applyMove - 最終トリック', () => {
+  it('最終トリックでは場の最高値未満でも出せる', () => {
+    const rng = new SeededRng(17);
+    const state = createBaseState({
+      isFinalTrick: true,
+      fieldCard: 14,
+      players: [
+        { hand: [5], cucumbers: 0, graveyard: [] },
+        { hand: [2], cucumbers: 0, graveyard: [] },
+        { hand: [3], cucumbers: 0, graveyard: [] },
+        { hand: [4], cucumbers: 0, graveyard: [] },
+      ],
+    });
+
+    const result = applyMove(state, { player: 0, card: 5, timestamp: 1, isDiscard: false }, config, rng);
+
+    expect(result.success).toBe(true);
+    expect(result.newState.trickCards).toContainEqual({ player: 0, card: 5, timestamp: 1, isDiscard: false });
+    expect(result.newState.players[0].hand).toEqual([]);
+  });
 });
 
 describe('トリック完了', () => {
@@ -295,7 +336,7 @@ describe('1ゲーム完走', () => {
       const player = state.currentPlayer;
       const legalMoves = getLegalMoves(state, player);
       const card = Math.min(...legalMoves);
-      const isDiscard = state.fieldCard !== null && card < state.fieldCard;
+      const isDiscard = !state.isFinalTrick && state.fieldCard !== null && card < state.fieldCard;
       const result = applyMove(state, { player, card, isDiscard, timestamp: i }, longConfig, rng);
       expect(result.success).toBe(true);
       state = result.newState;
@@ -315,7 +356,7 @@ describe('1ゲーム完走', () => {
         const player = state.currentPlayer;
         const legalMoves = getLegalMoves(state, player);
         const card = Math.min(...legalMoves);
-        const isDiscard = state.fieldCard !== null && card < state.fieldCard;
+        const isDiscard = !state.isFinalTrick && state.fieldCard !== null && card < state.fieldCard;
         const result = applyMove(
           state,
           { player, card, isDiscard, timestamp: trick * 10 + turn },
@@ -343,7 +384,7 @@ describe('1ゲーム完走', () => {
       const player = state.currentPlayer;
       const legalMoves = getLegalMoves(state, player);
       const card = Math.min(...legalMoves);
-      const isDiscard = state.fieldCard !== null && card < state.fieldCard;
+      const isDiscard = !state.isFinalTrick && state.fieldCard !== null && card < state.fieldCard;
       const result = applyMove(state, { player, card, isDiscard, timestamp: i }, longConfig, rng);
       expect(result.success).toBe(true);
       state = result.newState;

--- a/apps/hub/lib/game-core/__tests__/rules.test.ts
+++ b/apps/hub/lib/game-core/__tests__/rules.test.ts
@@ -5,6 +5,7 @@ import {
   createDeck,
   dealCards,
   determineTrickWinner,
+  getLegalMoves,
 } from '../rules';
 import { GameConfig, Move } from '../types';
 
@@ -64,6 +65,35 @@ describe('determineTrickWinner', () => {
   });
 });
 
+describe('getLegalMoves', () => {
+  it('最終トリックでは手札をそのまま返す', () => {
+    const state = {
+      players: [
+        { hand: [2, 5], cucumbers: 0, graveyard: [] },
+        { hand: [3], cucumbers: 0, graveyard: [] },
+        { hand: [4], cucumbers: 0, graveyard: [] },
+        { hand: [6], cucumbers: 0, graveyard: [] },
+      ],
+      currentPlayer: 0,
+      currentRound: 1,
+      currentTrick: 7,
+      fieldCard: 14,
+      sharedGraveyard: [],
+      trickCards: [],
+      actionCount: 0,
+      firstPlayer: 0,
+      isGameOver: false,
+      gameOverPlayers: [],
+      remainingCards: [],
+      cardCounts: [],
+      phase: 'AwaitMove' as const,
+      isFinalTrick: true,
+    };
+
+    expect(getLegalMoves(state, 0)).toEqual([2, 5]);
+  });
+});
+
 describe('最終トリックペナルティ', () => {
   it('勝者のカード数字分のきゅうりを獲得', () => {
     const trick: Move[] = [
@@ -112,5 +142,17 @@ describe('最終トリックペナルティ', () => {
     const result = calculateFinalTrickPenalty(trick, baseConfig);
     expect(result.winner).toBe(3);
     expect(result.penalty).toBe(0);
+  });
+
+  it('捨てカードは最終トリックのペナルティ判定から除外される', () => {
+    const trick: Move[] = [
+      { player: 0, card: 12, timestamp: 1 },
+      { player: 1, card: 10, timestamp: 2 },
+      { player: 2, card: 1, timestamp: 3, isDiscard: true },
+      { player: 3, card: 9, timestamp: 4 },
+    ];
+
+    const result = calculateFinalTrickPenalty(trick, baseConfig);
+    expect(result).toEqual({ winner: 0, penalty: 12 });
   });
 });

--- a/apps/hub/lib/game-core/engine.ts
+++ b/apps/hub/lib/game-core/engine.ts
@@ -95,8 +95,13 @@ export function applyMove(
   }
 
   const minCard = Math.min(...playerHand);
+  const isFinalTrick = state.isFinalTrick;
 
-  if (move.isDiscard) {
+  if (isFinalTrick && move.isDiscard) {
+    return { success: false, newState: state, message: 'Final trick: discard not allowed' };
+  }
+
+  if (!isFinalTrick && move.isDiscard) {
     if (state.fieldCard === null) {
       return { success: false, newState: state, message: 'Cannot discard on empty field' };
     }
@@ -108,7 +113,7 @@ export function applyMove(
         message: 'Discard must be the minimum card in hand',
       };
     }
-  } else if (state.fieldCard !== null && card < state.fieldCard) {
+  } else if (!isFinalTrick && state.fieldCard !== null && card < state.fieldCard) {
     return { success: false, newState: state, message: `Card ${card} is not legal` };
   }
 

--- a/apps/hub/lib/game-core/rules.ts
+++ b/apps/hub/lib/game-core/rules.ts
@@ -25,6 +25,11 @@ export function getLegalMoves(state: GameState, player: number): number[] {
   const hand = state.players[player].hand;
   if (hand.length === 0) return [];
 
+  if (state.isFinalTrick) {
+    // 最終トリックでは手札の最後の1枚を必ず場に出す（捨て不可）
+    return [...hand];
+  }
+
   const minCard = Math.min(...hand);
 
   if (state.fieldCard === null) {
@@ -61,17 +66,18 @@ export function determineTrickWinner(trickCards: Move[]): number {
 
 // 最終トリックのペナルティ計算
 export function calculateFinalTrickPenalty(trickCards: Move[], _config: GameConfig): { winner: number; penalty: number } {
-  if (trickCards.length === 0) return { winner: -1, penalty: 0 };
+  const playedCards = trickCards.filter(tc => !tc.isDiscard);
+  if (playedCards.length === 0) return { winner: -1, penalty: 0 };
 
-  const winner = determineTrickWinner(trickCards);
-  const winnerCard = trickCards.find(tc => tc.player === winner)?.card ?? 0;
+  const winner = determineTrickWinner(playedCards);
+  const winnerCard = playedCards.find(tc => tc.player === winner)?.card ?? 0;
 
-  const allPlayedOne = trickCards.every(tc => tc.card === 1);
+  const allPlayedOne = playedCards.every(tc => tc.card === 1);
   if (allPlayedOne) {
     return { winner, penalty: 0 };
   }
 
-  const hasOneOnTable = trickCards.some(tc => tc.card === 1);
+  const hasOneOnTable = playedCards.some(tc => tc.card === 1);
   let penalty = winnerCard;
   if (hasOneOnTable) {
     penalty *= 2;


### PR DESCRIPTION
### Motivation
- Final trick behavior allowed discards and applied penalty rules including discarded cards, causing incorrect displays (only 3 cards shown) and wrong penalty doubling (e.g. 12→24).
- The showdown UI still showed the graveyard during final trick which is misleading.

### Description
- Engine: `applyMove` now rejects `isDiscard` during final trick and skips the usual "must be >= field" validation when `state.isFinalTrick` is true, allowing any remaining card to be played in final trick (`apps/hub/lib/game-core/engine.ts`).
- Rules: `getLegalMoves` returns the hand directly in final trick to avoid discard choices, and `calculateFinalTrickPenalty` now ignores moves with `isDiscard: true` by filtering to `playedCards` before winner/1-checks (`apps/hub/lib/game-core/rules.ts`).
- CPU showdown: final-trick showdown loop always plays each player's remaining card with `isDiscard: false` and uses filtered `playedCards` for the all-ones/has-one checks (`apps/hub/app/cucumber/cpu/play/page.tsx`).
- UI: hide the shared graveyard during showdown/final-trick display (`EllipseTable.tsx`).
- Tests: added/adjusted unit tests to cover final-trick legal moves, discard prohibition, penalty ignoring discards, and updated long-run tests to not force discard in final trick (`apps/hub/lib/game-core/__tests__/rules.test.ts`, `.../engine.test.ts`).

### Testing
- Ran unit tests with `pnpm --filter @five-cucumber/hub test -- lib/game-core/__tests__/rules.test.ts lib/game-core/__tests__/engine.test.ts` and all tests passed: 27 tests succeeded (both `rules.test.ts` and `engine.test.ts`).
- A non-blocking workspace engine warning about node version (`wanted: node 18`, `current: node 22`) was observed during the test run but did not affect test results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c89146e530832f8c9c5eb2b6edcb3b)