### PR TITLE
Extend Showdown display time and add final-trick diagnostics

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/page.tsx
+++ b/apps/hub/app/cucumber/cpu/play/page.tsx
@@ -577,10 +577,12 @@ function CpuPlayContent() {
 
   useEffect(() => {
     console.log(
-      '[Showdown] useEffect fired, isFinalTrick:',
+      '[Showdown-Check] isFinalTrick:',
       gameState?.isFinalTrick,
       'finalTrickStarted:',
-      finalTrickStarted
+      finalTrickStarted,
+      'hand length:',
+      gameState?.players?.[0]?.hand?.length
     );
     if (!gameState || !gameRef.current) return;
     if (!gameState.isFinalTrick || gameState.phase !== 'AwaitMove') return;
@@ -591,7 +593,7 @@ function CpuPlayContent() {
       const { state, config, rng } = gameRef.current;
       if (!state.isFinalTrick || state.phase !== 'AwaitMove') return;
 
-      console.log('[Showdown] Starting showdown');
+      console.log('[Showdown] === SHOWDOWN STARTING ===');
       let currentState = state;
       let trickCardsAfterShowdown: Move[] = [...state.trickCards];
       const selectedPlayers: number[] = [];
@@ -650,11 +652,13 @@ function CpuPlayContent() {
       setFinalTrickStatusText(null);
 
       const showResultTimer = setTimeout(() => {
+        console.log('[Showdown] Calculating penalty...');
         const winnerName = winner === 0 ? 'あなた' : `CPU ${winner}`;
         const playedCards = trickCardsAfterShowdown.filter(trickCard => !trickCard.isDiscard);
         const allOnes = playedCards.length > 0 && playedCards.every(trickCard => trickCard.card === 1);
         if (allOnes) {
           setTrickWinnerText('全員が1を出したためペナルティなし！');
+          setOverlayText('全員が1を出したためペナルティなし！');
         } else {
           const penaltyResult = calculateFinalTrickPenalty(trickCardsAfterShowdown, config);
           const hasOne = playedCards.some(trickCard => trickCard.card === 1);
@@ -665,8 +669,9 @@ function CpuPlayContent() {
               ? `${penaltyText}（場に1があるため2倍: ${basePenalty}×2=${penaltyResult.penalty}）`
               : penaltyText
           );
+          setOverlayText(`${winnerName}が${penaltyResult.penalty}本のきゅうりを獲得！`);
         }
-      }, 2000);
+      }, 5000);
 
       const nextRoundTimer = setTimeout(() => {
         const afterFinalRoundResult = finalRound(currentState, config, rng);
@@ -694,7 +699,7 @@ function CpuPlayContent() {
         } else if (scheduleCpuTurnRef.current && afterFinalRoundState.currentPlayer !== 0) {
           scheduleCpuTurnRef.current();
         }
-      }, 3600);
+      }, 10000);
 
       finalTrickTimeoutsRef.current.push(showResultTimer, nextRoundTimer);
     };
@@ -717,7 +722,7 @@ function CpuPlayContent() {
     }, 2000);
 
     finalTrickTimeoutsRef.current.push(showdownTimer);
-  }, [gameState, finalTrickStarted, isAnimating]);
+  }, [gameState?.isFinalTrick, gameState?.currentTrick, gameState, finalTrickStarted, isAnimating]);
 
   useEffect(() => {
     return () => {

--- a/apps/hub/lib/game-core/engine.ts
+++ b/apps/hub/lib/game-core/engine.ts
@@ -203,6 +203,14 @@ export function finalRound(state: GameState, config: GameConfig, rng: SeededRng)
   const { winner, penalty } = calculateFinalTrickPenalty(newState.trickCards, config);
 
   if (winner >= 0) {
+    console.log(
+      '[Engine-Cucumber] player:',
+      winner,
+      'adding:',
+      penalty,
+      'total:',
+      newState.players[winner].cucumbers + penalty
+    );
     newState.players[winner].cucumbers += penalty;
   }
 

--- a/apps/hub/lib/game-core/rules.ts
+++ b/apps/hub/lib/game-core/rules.ts
@@ -66,14 +66,20 @@ export function determineTrickWinner(trickCards: Move[]): number {
 
 // 最終トリックのペナルティ計算
 export function calculateFinalTrickPenalty(trickCards: Move[], _config: GameConfig): { winner: number; penalty: number } {
+  console.log('[Penalty] Input trickCards:', JSON.stringify(trickCards));
   const playedCards = trickCards.filter(tc => !tc.isDiscard);
-  if (playedCards.length === 0) return { winner: -1, penalty: 0 };
+  console.log('[Penalty] playedCards (after filter):', JSON.stringify(playedCards));
+  if (playedCards.length === 0) {
+    console.log('[Penalty] Result: winner=', -1, 'penalty=', 0);
+    return { winner: -1, penalty: 0 };
+  }
 
   const winner = determineTrickWinner(playedCards);
   const winnerCard = playedCards.find(tc => tc.player === winner)?.card ?? 0;
 
   const allPlayedOne = playedCards.every(tc => tc.card === 1);
   if (allPlayedOne) {
+    console.log('[Penalty] Result: winner=', winner, 'penalty=', 0);
     return { winner, penalty: 0 };
   }
 
@@ -83,6 +89,7 @@ export function calculateFinalTrickPenalty(trickCards: Move[], _config: GameConf
     penalty *= 2;
   }
 
+  console.log('[Penalty] Result: winner=', winner, 'penalty=', penalty);
   return { winner, penalty };
 }
 


### PR DESCRIPTION
### Motivation
- Showdown UI was disappearing too quickly and Showdown flow lacked observable logs, making it hard to verify whether final-trick processing ran.
- Penalty / cucumber accumulation logic needed extra visibility to investigate anomalous cucumber counts.

### Description
- Added entry and startup diagnostics to the Showdown flow in `apps/hub/app/cucumber/cpu/play/page.tsx` (`[Showdown-Check]` and `[Showdown] === SHOWDOWN STARTING ===`).
- Extended Showdown visibility windows by changing the result reveal delay from `2000ms` to `5000ms` and the transition to next round from `3600ms` to `10000ms`, and set `overlayText` to show penalty/no-penalty messages.
- Made the Showdown `useEffect` dependencies more explicit by including `gameState.isFinalTrick` and `gameState.currentTrick` to ensure the effect fires reliably on final-trick signals.
- Added detailed penalty diagnostics in `apps/hub/lib/game-core/rules.ts` (`[Penalty] Input`, filtered cards, and final result) and an engine log in `apps/hub/lib/game-core/engine.ts` (`[Engine-Cucumber] ...`) when cucumbers are added.

### Testing
- Ran unit tests with `pnpm -C apps/hub test` (Vitest), and all tests passed: "Test Files 2 passed" and "Tests 27 passed".
- Attempted `pnpm -C apps/hub test -- --runInBand` but it failed because Vitest does not accept `--runInBand` (unknown option).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c897d38d70832f86228fea2eaa3c6e)