### PR TITLE
fix(cucumber): avoid double final trick penalty in CPU showdown

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/page.tsx
+++ b/apps/hub/app/cucumber/cpu/play/page.tsx
@@ -9,7 +9,6 @@ import {
   calculateFinalTrickPenalty,
   createGameView,
   createInitialState,
-  finalRound,
   GameConfig,
   GameState,
   getEffectiveTurnSeconds,
@@ -674,10 +673,8 @@ function CpuPlayContent() {
       }, 5000);
 
       const nextRoundTimer = setTimeout(() => {
-        const afterFinalRoundResult = finalRound(currentState, config, rng);
-        const afterFinalRoundState = afterFinalRoundResult.newState;
-        setGameState(afterFinalRoundState);
-        gameRef.current!.state = afterFinalRoundState;
+        setGameState(currentState);
+        gameRef.current!.state = currentState;
         setTableTrickCards([]);
         setLatestPlayedKey(null);
         setTrickWinner(null);
@@ -691,12 +688,12 @@ function CpuPlayContent() {
         setIsShowdownMode(false);
         setIsAnimating(false);
 
-        if (afterFinalRoundState.phase === 'GameEnd') {
+        if (currentState.phase === 'GameEnd') {
           setGameOver(true);
           setGameOverData(
-            afterFinalRoundState.players.map((p, index) => ({ player: index, count: p.cucumbers }))
+            currentState.players.map((p, index) => ({ player: index, count: p.cucumbers }))
           );
-        } else if (scheduleCpuTurnRef.current && afterFinalRoundState.currentPlayer !== 0) {
+        } else if (scheduleCpuTurnRef.current && currentState.currentPlayer !== 0) {
           scheduleCpuTurnRef.current();
         }
       }, 10000);


### PR DESCRIPTION
### Motivation
- The final-trick penalty was being applied twice: once in the engine's `finalRound()` and again in the CPU showdown flow in the page UI, producing duplicated cucumber additions and duplicate engine logs. 
- The intended flow is that the engine performs the penalty application and the UI only displays the result without mutating cucumber counts.

### Description
- Removed the `finalRound` import and eliminated the `finalRound(currentState, ...)` call from the CPU showdown flow in `apps/hub/app/cucumber/cpu/play/page.tsx`. 
- Replaced the UI-side finalization with reusing the `currentState` returned by `applyMove` and setting that state via `setGameState` and `gameRef.current.state`. 
- Adjusted downstream branch checks and game-over data uses to reference `currentState` instead of an `afterFinalRoundState`. 
- Kept `calculateFinalTrickPenalty` in the UI for display-only purposes and ensured no cucumber mutation occurs on the page side.

### Testing
- Ran TypeScript type-check for the hub app with `pnpm -C apps/hub type-check`, which succeeded. 
- Verified there are no remaining `finalRound(` calls in `apps/hub/app/cucumber/cpu/play/page.tsx` using ripgrep, and confirmed the UI no longer re-applies penalty values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c89a817e2c832fb4cd08409c48c590)