### PR TITLE
fix: 最終トリックのペナルティをカード数字ではなくきゅうり数で計算

### DIFF
--- a/apps/hub/components/ui/EllipseTable.tsx
+++ b/apps/hub/components/ui/EllipseTable.tsx
@@ -1,6 +1,7 @@
 // 楕円卓レイアウト用テーブルコンポーネント
 
 import { GameConfig, GameState, Move } from '@/lib/game-core/types';
+import { getCucumberIcons } from '@/lib/game-core/rules';
 import { layoutSeatsEllipse } from '@/lib/layoutEllipse';
 import { CSSProperties, useEffect } from 'react';
 
@@ -107,13 +108,7 @@ export function EllipseTable({
                   <div key={`${showdownCard.player}-${showdownCard.timestamp}-${index}`} className="showdown-card-item">
                     <div className="card game-card current-card showdown-card">
                       <div className="card-number">{showdownCard.card}</div>
-                      <div className="cucumber-icons">
-                        {showdownCard.card >= 2 && showdownCard.card <= 5 && '🥒'}
-                        {showdownCard.card >= 6 && showdownCard.card <= 9 && '🥒🥒'}
-                        {showdownCard.card >= 10 && showdownCard.card <= 11 && '🥒🥒🥒'}
-                        {showdownCard.card >= 12 && showdownCard.card <= 14 && '🥒🥒🥒🥒'}
-                        {showdownCard.card === 15 && '🥒🥒🥒🥒🥒'}
-                      </div>
+                      <div className="cucumber-icons">{getCucumberIcons(showdownCard.card)}</div>
                     </div>
                     <div className="showdown-player-name">{showdownCard.playerName}</div>
                   </div>
@@ -164,13 +159,7 @@ export function EllipseTable({
                         ) : (
                           <>
                             <div className="card-number">{trickCard.card}</div>
-                            <div className="cucumber-icons">
-                              {trickCard.card >= 2 && trickCard.card <= 5 && '🥒'}
-                              {trickCard.card >= 6 && trickCard.card <= 9 && '🥒🥒'}
-                              {trickCard.card >= 10 && trickCard.card <= 11 && '🥒🥒🥒'}
-                              {trickCard.card >= 12 && trickCard.card <= 14 && '🥒🥒🥒🥒'}
-                              {trickCard.card === 15 && '🥒🥒🥒🥒🥒'}
-                            </div>
+                            <div className="cucumber-icons">{getCucumberIcons(trickCard.card)}</div>
                           </>
                         )}
                       </div>
@@ -186,13 +175,7 @@ export function EllipseTable({
             ) : state.fieldCard !== null ? (
               <div className="card game-card current-card">
                 <div className="card-number">{state.fieldCard}</div>
-                <div className="cucumber-icons">
-                  {state.fieldCard >= 2 && state.fieldCard <= 5 && '🥒'}
-                  {state.fieldCard >= 6 && state.fieldCard <= 9 && '🥒🥒'}
-                  {state.fieldCard >= 10 && state.fieldCard <= 11 && '🥒🥒🥒'}
-                  {state.fieldCard >= 12 && state.fieldCard <= 14 && '🥒🥒🥒🥒'}
-                  {state.fieldCard === 15 && '🥒🥒🥒🥒🥒'}
-                </div>
+                <div className="cucumber-icons">{getCucumberIcons(state.fieldCard)}</div>
               </div>
             ) : (
               <div className="card game-card disabled">
@@ -315,13 +298,7 @@ export function EllipseTable({
                     aria-disabled={isDisabled}
                   >
                     <div className="card-number">{card}</div>
-                    <div className="cucumber-icons">
-                      {card >= 2 && card <= 5 && '🥒'}
-                      {card >= 6 && card <= 9 && '🥒🥒'}
-                      {card >= 10 && card <= 11 && '🥒🥒🥒'}
-                      {card >= 12 && card <= 14 && '🥒🥒🥒🥒'}
-                      {card === 15 && '🥒🥒🥒🥒🥒'}
-                    </div>
+                    <div className="cucumber-icons">{getCucumberIcons(card)}</div>
                     {isDiscard ? <div className="discard-tag">捨てる</div> : null}
                   </div>
                 );

--- a/apps/hub/lib/game-core/__tests__/rules.test.ts
+++ b/apps/hub/lib/game-core/__tests__/rules.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  cardToCucumbers,
   calculateFinalTrickPenalty,
   createDeck,
   dealCards,
@@ -95,7 +96,7 @@ describe('getLegalMoves', () => {
 });
 
 describe('最終トリックペナルティ', () => {
-  it('勝者のカード数字分のきゅうりを獲得', () => {
+  it('勝者のきゅうり数分のきゅうりを獲得', () => {
     const trick: Move[] = [
       { player: 0, card: 7, timestamp: 1 },
       { player: 1, card: 12, timestamp: 2 },
@@ -104,7 +105,7 @@ describe('最終トリックペナルティ', () => {
     ];
 
     const result = calculateFinalTrickPenalty(trick, baseConfig);
-    expect(result).toEqual({ winner: 1, penalty: 12 });
+    expect(result).toEqual({ winner: 1, penalty: 3 });
   });
 
   it('場に1がある場合はペナルティ2倍', () => {
@@ -116,7 +117,7 @@ describe('最終トリックペナルティ', () => {
     ];
 
     const result = calculateFinalTrickPenalty(trick, baseConfig);
-    expect(result).toEqual({ winner: 2, penalty: 20 });
+    expect(result).toEqual({ winner: 2, penalty: 6 });
   });
 
   it('全員が1を出した場合はペナルティ0', () => {
@@ -153,6 +154,35 @@ describe('最終トリックペナルティ', () => {
     ];
 
     const result = calculateFinalTrickPenalty(trick, baseConfig);
-    expect(result).toEqual({ winner: 0, penalty: 12 });
+    expect(result).toEqual({ winner: 0, penalty: 3 });
+  });
+});
+
+describe('cardToCucumbers', () => {
+  it('カード1はきゅうり0', () => {
+    expect(cardToCucumbers(1)).toBe(0);
+  });
+
+  it('カード2-5はきゅうり1', () => {
+    expect(cardToCucumbers(2)).toBe(1);
+    expect(cardToCucumbers(5)).toBe(1);
+  });
+
+  it('カード6-9はきゅうり2', () => {
+    expect(cardToCucumbers(6)).toBe(2);
+    expect(cardToCucumbers(9)).toBe(2);
+  });
+
+  it('カード10-13はきゅうり3', () => {
+    expect(cardToCucumbers(10)).toBe(3);
+    expect(cardToCucumbers(13)).toBe(3);
+  });
+
+  it('カード14はきゅうり4', () => {
+    expect(cardToCucumbers(14)).toBe(4);
+  });
+
+  it('カード15はきゅうり5', () => {
+    expect(cardToCucumbers(15)).toBe(5);
   });
 });

--- a/apps/hub/lib/game-core/rules.ts
+++ b/apps/hub/lib/game-core/rules.ts
@@ -7,10 +7,15 @@ const MAX_CARD_NUMBER = 15;
 const CARDS_PER_NUMBER = 7;
 
 export function getCucumberCount(cardNumber: number): number {
+  return cardToCucumbers(cardNumber);
+}
+
+export function cardToCucumbers(cardNumber: number): number {
+  if (cardNumber === 1) return 0;
   if (cardNumber >= 2 && cardNumber <= 5) return 1;
   if (cardNumber >= 6 && cardNumber <= 9) return 2;
-  if (cardNumber >= 10 && cardNumber <= 11) return 3;
-  if (cardNumber >= 12 && cardNumber <= 14) return 4;
+  if (cardNumber >= 10 && cardNumber <= 13) return 3;
+  if (cardNumber === 14) return 4;
   if (cardNumber === 15) return 5;
   return 0;
 }
@@ -84,7 +89,7 @@ export function calculateFinalTrickPenalty(trickCards: Move[], _config: GameConf
   }
 
   const hasOneOnTable = playedCards.some(tc => tc.card === 1);
-  let penalty = winnerCard;
+  let penalty = cardToCucumbers(winnerCard);
   if (hasOneOnTable) {
     penalty *= 2;
   }


### PR DESCRIPTION
### Motivation
- 最終トリックで勝者に与えられるペナルティがカードの数字（例: 12）を使って計算されており、公式ルールではカードに描かれたきゅうりの数（例: 12 → 3）を使う必要があるため修正。

### Description
- `cardToCucumbers` を `apps/hub/lib/game-core/rules.ts` に追加し、公式対応（1→0, 2–5→1, 6–9→2, 10–13→3, 14→4, 15→5）を実装した。 
- 既存の `getCucumberCount` を `cardToCucumbers` に委譲し、`calculateFinalTrickPenalty` が勝者カードの数字ではなく `cardToCucumbers(winnerCard)` を使うように修正した。 
- UI のカード表示 (`apps/hub/components/ui/EllipseTable.tsx`) を `getCucumberIcons` に統一して、場／手札／ショーダウンで表示されるきゅうりアイコンがルールと一致するように変更した。 
- テスト (`apps/hub/lib/game-core/__tests__/rules.test.ts`) を更新して、最終トリックの期待値をきゅうり数ベースに修正し、`cardToCucumbers` の単体テストを追加した。 

### Testing
- 実行した自動テスト: `pnpm --filter @five-cucumber/hub test -- lib/game-core/__tests__/rules.test.ts`, 該当テストファイルの実行結果は成功で `Test Files 1 passed`、`Tests 17 passed`。 
- `calculateFinalTrickPenalty` の既存ケース（全員が1、場に1がある場合、捨てカードの除外など）は期待通り動作することを確認済み。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbaf54aa74832f983cd22602746105)