### PR TITLE
Game over UI, auto next-round flow, and penalty test coverage

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/game.css
+++ b/apps/hub/app/cucumber/cpu/play/game.css
@@ -253,6 +253,66 @@
   pointer-events: auto;
 }
 
+.game-over-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.8);
+}
+
+.game-over-overlay__title {
+  font-size: clamp(2rem, 6vw, 3rem);
+  font-weight: 800;
+  color: #ff6b6b;
+  margin-bottom: 1rem;
+  text-shadow: 0 0 20px rgba(255, 107, 107, 0.8);
+  animation: scaleIn 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.game-over-overlay__result {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 2rem;
+  margin-top: 2rem;
+  min-width: 300px;
+}
+
+.game-over-overlay__result h2 {
+  color: white;
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.game-over-overlay__rank {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  color: white;
+  font-size: 1.2rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.game-over-overlay__rank.is-eliminated {
+  color: #ff6b6b;
+}
+
+.game-over-overlay__home {
+  margin-top: 2rem;
+  padding: 1rem 3rem;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: white;
+  background: linear-gradient(to bottom, #4ade80, #16a34a);
+  border-radius: 12px;
+  text-decoration: none;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
 /* HUD（上部の情報帯） */
 .hud {
   position: relative;

--- a/apps/hub/app/cucumber/cpu/play/page.tsx
+++ b/apps/hub/app/cucumber/cpu/play/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import BattleLayout from '@/components/BattleLayout';
-import { BattleHud, EllipseTable, GameFooter, Timer } from '@/components/ui';
+import { BattleHud, EllipseTable, Timer } from '@/components/ui';
 import { HumanController } from '@/lib/controllers/human';
 import { delay, runAnimation } from '@/lib/animQueue';
 import {
@@ -38,7 +38,9 @@ function CpuPlayContent() {
   } | null>(null);
   const [gameState, setGameState] = useState<GameState | null>(null);
   const [gameOver, setGameOver] = useState(false);
-  const [gameOverData, setGameOverData] = useState<{ player: number; count: number }[]>([]);
+  const [gameResults, setGameResults] = useState<
+    { name: string; cucumbers: number; eliminated: boolean }[]
+  >([]);
   const [isCardLocked, setIsCardLocked] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [lockedCardId, setLockedCardId] = useState<number | null>(null);
@@ -128,7 +130,7 @@ function CpuPlayContent() {
       gameRef.current = { state, config, controllers, rng, humanController };
       setGameState(state);
       setGameOver(false);
-      setGameOverData([]);
+      setGameResults([]);
       setTableTrickCards([]);
       setLatestPlayedKey(null);
       setTrickWinner(null);
@@ -198,7 +200,7 @@ function CpuPlayContent() {
               rngState?: RngState;
               gameState: GameState;
               gameOver: boolean;
-              gameOverData: { player: number; count: number }[];
+              gameResults?: { name: string; cucumbers: number; eliminated: boolean }[];
               timestamp: number;
             };
             const now = Date.now();
@@ -231,7 +233,7 @@ function CpuPlayContent() {
               gameRef.current = { state, config, controllers, rng: restoredRng, humanController };
               setGameState(state);
               setGameOver(parsed.gameOver || false);
-              setGameOverData(parsed.gameOverData || []);
+              setGameResults(parsed.gameResults || []);
               setTableTrickCards(state.trickCards || []);
               setLatestPlayedKey(null);
               setTrickWinner(null);
@@ -335,6 +337,55 @@ function CpuPlayContent() {
   useEffect(() => {
     playCpuTurnRef.current = playCpuTurn;
   });
+
+  const startNextRound = useCallback((state: GameState) => {
+    const nextRound = state.currentRound;
+    const startTimer = setTimeout(() => {
+      setOverlayText(`第${nextRound}ラウンド 開始！`);
+      const openTimer = setTimeout(() => {
+        setOverlayText(null);
+        setGameState(state);
+        gameRef.current!.state = state;
+        setTableTrickCards([]);
+        setLatestPlayedKey(null);
+        setTrickWinner(null);
+        setTrickWinnerText(null);
+        setTurnNotice(null);
+        setFinalTrickSelectedPlayers([]);
+        setFinalTrickOpenedPlayers([]);
+        setFinalTrickStatusText(null);
+        setFinalTrickStarted(false);
+        setIsShowdownMode(false);
+        setIsAnimating(false);
+
+        if (scheduleCpuTurnRef.current && state.currentPlayer !== 0) {
+          scheduleCpuTurnRef.current();
+        }
+      }, 2000);
+      finalTrickTimeoutsRef.current.push(openTimer);
+    }, 3000);
+    finalTrickTimeoutsRef.current.push(startTimer);
+  }, []);
+
+  const checkGameOver = useCallback((state: GameState) => {
+    const hasEliminated = state.players.some(player => player.cucumbers >= 6);
+    if (hasEliminated) {
+      const results = state.players
+        .map((player, index) => ({
+          name: index === 0 ? 'あなた' : `CPU ${index}`,
+          cucumbers: player.cucumbers,
+          eliminated: player.cucumbers >= 6,
+        }))
+        .sort((a, b) => a.cucumbers - b.cucumbers);
+      setGameResults(results);
+      setGameOver(true);
+      setFinalTrickStarted(false);
+      setIsAnimating(false);
+      return;
+    }
+
+    startNextRound(state);
+  }, [startNextRound]);
 
   const playMove = async (player: number, card: number) => {
     if (!gameRef.current) return;
@@ -460,13 +511,6 @@ function CpuPlayContent() {
         } else {
           gameRef.current.state = newState;
           setGameState(newState);
-        }
-
-        if (newState.phase === 'GameEnd') {
-          setGameOver(true);
-          setGameOverData(
-            newState.players.map((p, index) => ({ player: index, count: p.cucumbers }))
-          );
         }
 
         if (player === 0) {
@@ -673,8 +717,6 @@ function CpuPlayContent() {
       }, 5000);
 
       const nextRoundTimer = setTimeout(() => {
-        setGameState(currentState);
-        gameRef.current!.state = currentState;
         setTableTrickCards([]);
         setLatestPlayedKey(null);
         setTrickWinner(null);
@@ -683,19 +725,9 @@ function CpuPlayContent() {
         setFinalTrickSelectedPlayers([]);
         setFinalTrickOpenedPlayers([]);
         setFinalTrickStatusText(null);
-        setFinalTrickStarted(false);
         setOverlayText(null);
         setIsShowdownMode(false);
-        setIsAnimating(false);
-
-        if (currentState.phase === 'GameEnd') {
-          setGameOver(true);
-          setGameOverData(
-            currentState.players.map((p, index) => ({ player: index, count: p.cucumbers }))
-          );
-        } else if (scheduleCpuTurnRef.current && currentState.currentPlayer !== 0) {
-          scheduleCpuTurnRef.current();
-        }
+        checkGameOver(currentState);
       }, 10000);
 
       finalTrickTimeoutsRef.current.push(showResultTimer, nextRoundTimer);
@@ -719,7 +751,7 @@ function CpuPlayContent() {
     }, 2000);
 
     finalTrickTimeoutsRef.current.push(showdownTimer);
-  }, [gameState?.isFinalTrick, gameState?.currentTrick, gameState, finalTrickStarted, isAnimating]);
+  }, [checkGameOver, gameState?.isFinalTrick, gameState?.currentTrick, gameState, finalTrickStarted, isAnimating]);
 
   useEffect(() => {
     return () => {
@@ -729,12 +761,6 @@ function CpuPlayContent() {
       finalTrickTimeoutsRef.current = [];
     };
   }, []);
-
-  const handleRestart = () => {
-    const gameStateKey = getGameStateKey(searchParams);
-    localStorage.removeItem(gameStateKey);
-    router.push('/cucumber/cpu/settings');
-  };
 
   const handleBackToHome = () => {
     // ゲーム状態をクリア
@@ -870,37 +896,34 @@ function CpuPlayContent() {
             />
 
             {gameOver ? (
-              <GameFooter>
-                <div className="flex flex-wrap items-center gap-3">
-                  <h2 className="font-heading text-[clamp(18px,2.2vw,24px)]">ゲーム終了</h2>
-                  <div className="flex flex-wrap gap-2 text-white/80 text-sm">
-                    {gameOverData.map((data, index) => (
-                      <span
-                        key={index}
-                        className="inline-flex items-center gap-2 rounded-full bg-white/10 border border-white/20 px-3 py-1"
-                      >
-                        プレイヤー{data.player}: {data.count}個
+              <div className="game-over-overlay">
+                <div className="game-over-overlay__title">
+                  {gameResults
+                    .filter(result => result.eliminated)
+                    .map(result => result.name)
+                    .join('、')}{' '}
+                  お漬物！！！
+                </div>
+
+                <div className="game-over-overlay__result">
+                  <h2>結果</h2>
+                  {gameResults.map((result, index) => (
+                    <div
+                      key={`${result.name}-${index}`}
+                      className={`game-over-overlay__rank ${result.eliminated ? 'is-eliminated' : ''}`}
+                    >
+                      <span>{index + 1}位 {result.name}</span>
+                      <span>
+                        🥒 {result.cucumbers}本 {result.eliminated ? '💀' : ''}
                       </span>
-                    ))}
-                  </div>
+                    </div>
+                  ))}
                 </div>
-                <div className="flex items-center gap-2 ml-auto">
-                  <button
-                    type="button"
-                    onClick={handleRestart}
-                    className="fc-button fc-button--primary"
-                  >
-                    再戦
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleBackToHome}
-                    className="fc-button fc-button--secondary"
-                  >
-                    ホーム
-                  </button>
-                </div>
-              </GameFooter>
+
+                <a className="game-over-overlay__home" href="/home" onClick={handleBackToHome}>
+                  ホームへ戻る
+                </a>
+              </div>
             ) : null}
           </div>
         </BattleLayout>

--- a/apps/hub/lib/game-core/__tests__/engine.test.ts
+++ b/apps/hub/lib/game-core/__tests__/engine.test.ts
@@ -394,3 +394,35 @@ describe('1ゲーム完走', () => {
     expect(afterCucumbers.some((value, index) => value > beforeCucumbers[index])).toBe(true);
   });
 });
+
+describe('最終トリックペナルティ適用', () => {
+  it('勝者カードのカード番号ではなくきゅうり数を加算する', () => {
+    const rng = new SeededRng(200);
+    const shortConfig: GameConfig = { ...config, initialCards: 1, maxCucumbers: 999 };
+    let state = createBaseState({
+      players: [
+        { hand: [2], cucumbers: 0, graveyard: [] },
+        { hand: [10], cucumbers: 0, graveyard: [] },
+        { hand: [7], cucumbers: 0, graveyard: [] },
+        { hand: [5], cucumbers: 0, graveyard: [] },
+      ],
+      currentTrick: 1,
+      isFinalTrick: true,
+      phase: 'AwaitMove',
+      fieldCard: null,
+      currentPlayer: 0,
+      firstPlayer: 0,
+    });
+
+    for (let i = 0; i < shortConfig.players; i++) {
+      const player = state.currentPlayer;
+      const card = state.players[player].hand[0];
+      const result = applyMove(state, { player, card, isDiscard: false, timestamp: i }, shortConfig, rng);
+      expect(result.success).toBe(true);
+      state = result.newState;
+    }
+
+    // 勝者はカード10を出したplayer 1。カード番号10ではなく、きゅうり3本のみ加算される。
+    expect(state.players[1].cucumbers).toBe(3);
+  });
+});

--- a/apps/hub/lib/game-core/__tests__/rules.test.ts
+++ b/apps/hub/lib/game-core/__tests__/rules.test.ts
@@ -159,30 +159,15 @@ describe('最終トリックペナルティ', () => {
 });
 
 describe('cardToCucumbers', () => {
-  it('カード1はきゅうり0', () => {
-    expect(cardToCucumbers(1)).toBe(0);
+  it('全カード番号で正しいきゅうり数を返す', () => {
+    const expected = [0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 5];
+    for (let card = 1; card <= 15; card++) {
+      expect(cardToCucumbers(card)).toBe(expected[card]);
+    }
   });
 
-  it('カード2-5はきゅうり1', () => {
-    expect(cardToCucumbers(2)).toBe(1);
-    expect(cardToCucumbers(5)).toBe(1);
-  });
-
-  it('カード6-9はきゅうり2', () => {
-    expect(cardToCucumbers(6)).toBe(2);
-    expect(cardToCucumbers(9)).toBe(2);
-  });
-
-  it('カード10-13はきゅうり3', () => {
-    expect(cardToCucumbers(10)).toBe(3);
-    expect(cardToCucumbers(13)).toBe(3);
-  });
-
-  it('カード14はきゅうり4', () => {
-    expect(cardToCucumbers(14)).toBe(4);
-  });
-
-  it('カード15はきゅうり5', () => {
-    expect(cardToCucumbers(15)).toBe(5);
+  it('範囲外のカード番号は0を返す', () => {
+    expect(cardToCucumbers(0)).toBe(0);
+    expect(cardToCucumbers(16)).toBe(0);
   });
 });


### PR DESCRIPTION
### Motivation
- Enforce the rule that players with 6 or more cucumbers are eliminated and surface that state to players via a clear end-game UI. 
- Make the final-trick flow deterministic for UX: show results, check end condition, and either end the game or automatically transition to the next round with a short overlay animation. 
- Ensure penalty calculation uses cucumber counts (not raw card numbers) and increase test coverage for the mapping from card to cucumbers. 

### Description
- Implement a full-screen game-over overlay in `apps/hub/app/cucumber/cpu/play/page.tsx` and styles in `apps/hub/app/cucumber/cpu/play/game.css` that lists players sorted by `cucumbers` and highlights eliminated players with the “お漬物！！！” phrase. 
- Add `startNextRound` and `checkGameOver` helpers in the CPU play page and wire the final-trick showdown flow to call `checkGameOver` after the result display so that the flow becomes: show penalty (5s) → if anyone has >=6 cucumbers show game-over UI else wait a short delay and run `startNextRound` with an overlay. 
- Replace the previous `GameFooter` end-state UI with the new overlay and adjust state variables to `gameResults` (name/cucumbers/eliminated); remove the unused `GameFooter` import. 
- Expand automated tests: update `apps/hub/lib/game-core/__tests__/rules.test.ts` to verify `cardToCucumbers` for all card numbers (1–15) and out-of-range values, and add an engine test in `apps/hub/lib/game-core/__tests__/engine.test.ts` that asserts the final-trick penalty adds cucumber counts (e.g. card `10` → `3` cucumbers) rather than the raw card number. 

### Testing
- Ran unit tests with `pnpm -C apps/hub test -- lib/game-core/__tests__/rules.test.ts lib/game-core/__tests__/engine.test.ts`, which completed successfully (2 test files, 30 tests passed). 
- Type-checked the project with `pnpm -C apps/hub exec tsc --noEmit`, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbb1050684832fbea2f9e8a5ca4f71)