### PR TITLE
Fix final-trick showdown penalty display and CPU table viewport fit

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/game.css
+++ b/apps/hub/app/cucumber/cpu/play/game.css
@@ -3,9 +3,10 @@
   position: relative;
   flex: 1;
   width: 100%;
-  min-height: clamp(560px, 82svh, 900px);
-  padding: clamp(16px, 3vw, 32px);
-  padding-bottom: clamp(120px, 26svh, 180px);
+  height: 100%;
+  min-height: 0;
+  padding: clamp(12px, 2.6vw, 24px);
+  padding-bottom: clamp(96px, 22svh, 150px);
   border-radius: clamp(18px, 4vw, 30px);
   display: grid;
   align-items: stretch;
@@ -925,22 +926,24 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: var(--ellipse-card-gap);
-  padding: var(--ellipse-hand-padding);
+  gap: clamp(3px, 0.8vw, 10px);
+  padding: clamp(8px, 2vw, 14px);
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.1));
   border-radius: clamp(16px, 4vw, 24px);
   backdrop-filter: blur(15px);
   box-shadow: 0 -6px 25px rgba(0, 0, 0, 0.4);
   overflow-x: auto;
   border: 3px solid rgba(255, 255, 255, 0.4);
-  min-height: clamp(96px, 24svh, 180px);
-  max-height: clamp(128px, 28svh, 220px);
+  min-height: clamp(82px, 18svh, 128px);
+  max-height: clamp(104px, 22svh, 158px);
   margin-bottom: 0;
   z-index: 24;
 }
 
 .player-hand .card {
   flex-shrink: 0;
+  width: clamp(34px, 4.9vw, 62px);
+  height: clamp(48px, 7.2vw, 88px);
 }
 
 .player-hand .card:hover:not(.disabled) {
@@ -1105,8 +1108,8 @@
   }
 
   .player-hand {
-    min-height: clamp(84px, 24svh, 150px);
-    max-height: clamp(112px, 26svh, 180px);
+    min-height: clamp(72px, 18svh, 120px);
+    max-height: clamp(96px, 20svh, 144px);
   }
 }
 
@@ -1130,8 +1133,8 @@
   }
 
   .player-hand {
-    min-height: clamp(74px, 26svh, 140px);
-    max-height: clamp(96px, 28svh, 160px);
+    min-height: clamp(68px, 18svh, 108px);
+    max-height: clamp(88px, 20svh, 132px);
   }
 
   .card-number {
@@ -1157,7 +1160,7 @@
   }
 
   .player-hand {
-    min-height: clamp(68px, 30svh, 128px);
+    min-height: clamp(60px, 17svh, 98px);
   }
 }
 

--- a/apps/hub/app/cucumber/cpu/play/page.tsx
+++ b/apps/hub/app/cucumber/cpu/play/page.tsx
@@ -638,7 +638,7 @@ function CpuPlayContent() {
 
       console.log('[Showdown] === SHOWDOWN STARTING ===');
       let currentState = state;
-      let trickCardsAfterShowdown: Move[] = [...state.trickCards];
+      const showdownTrickCards: Move[] = [...state.trickCards];
       const selectedPlayers: number[] = [];
       const playerOrder = Array.from(
         { length: config.players },
@@ -655,6 +655,7 @@ function CpuPlayContent() {
           timestamp: Date.now() + playerIndex,
           isDiscard: false,
         };
+        showdownTrickCards.push(move);
         console.log('[Showdown] Player', playerIndex, 'card:', selectedCard, 'isDiscard:', false);
         const result = applyMove(currentState, move, config, rng);
         console.log('[Showdown] applyMove result:', result.success, result.message);
@@ -670,24 +671,23 @@ function CpuPlayContent() {
         selectedPlayers.push(playerIndex);
       }
 
-      trickCardsAfterShowdown = [...currentState.trickCards];
-      console.log('[Showdown] Final trickCards:', trickCardsAfterShowdown);
+      console.log('[Showdown] Final trickCards:', showdownTrickCards);
 
-      const openedPlayers = trickCardsAfterShowdown.map(move => move.player);
-      const winner = determineTrickWinner(trickCardsAfterShowdown);
+      const openedPlayers = showdownTrickCards.map(move => move.player);
+      const winner = determineTrickWinner(showdownTrickCards);
 
       setFinalTrickSelectedPlayers(selectedPlayers);
       setFinalTrickOpenedPlayers(openedPlayers);
-      setTableTrickCards(trickCardsAfterShowdown);
+      setTableTrickCards(showdownTrickCards);
       setLatestPlayedKey(null);
-      console.log('[Showdown] Setting state with', trickCardsAfterShowdown.length, 'cards');
+      console.log('[Showdown] Setting state with', showdownTrickCards.length, 'cards');
       setGameState({
         ...currentState,
-        trickCards: trickCardsAfterShowdown,
+        trickCards: showdownTrickCards,
       });
       gameRef.current.state = {
         ...currentState,
-        trickCards: trickCardsAfterShowdown,
+        trickCards: showdownTrickCards,
       };
       setIsAnimating(true);
       setIsShowdownMode(true);
@@ -697,13 +697,13 @@ function CpuPlayContent() {
       const showResultTimer = setTimeout(() => {
         console.log('[Showdown] Calculating penalty...');
         const winnerName = winner === 0 ? 'あなた' : `CPU ${winner}`;
-        const playedCards = trickCardsAfterShowdown.filter(trickCard => !trickCard.isDiscard);
+        const playedCards = showdownTrickCards.filter(trickCard => !trickCard.isDiscard);
         const allOnes = playedCards.length > 0 && playedCards.every(trickCard => trickCard.card === 1);
         if (allOnes) {
           setTrickWinnerText('全員が1を出したためペナルティなし！');
           setOverlayText('全員が1を出したためペナルティなし！');
         } else {
-          const penaltyResult = calculateFinalTrickPenalty(trickCardsAfterShowdown, config);
+          const penaltyResult = calculateFinalTrickPenalty(showdownTrickCards, config);
           const hasOne = playedCards.some(trickCard => trickCard.card === 1);
           const basePenalty = hasOne ? Math.floor(penaltyResult.penalty / 2) : penaltyResult.penalty;
           const penaltyText = `${winnerName}が${penaltyResult.penalty}本のきゅうりを獲得しました`;
@@ -792,22 +792,23 @@ function CpuPlayContent() {
     fieldCard !== null &&
     !gameState.players[0].hand.some(card => card >= fieldCard);
 
+  const displayRound = gameRef.current?.state.currentRound ?? gameState.currentRound;
+  const displayTrick = gameRef.current?.state.currentTrick ?? gameState.currentTrick;
   const isFinalTrickPhase =
-    gameState.isFinalTrick ||
-    gameState.currentTrick === (gameRef.current?.config?.initialCards || 7);
+    gameState.isFinalTrick || displayTrick === (gameRef.current?.config?.initialCards || 7);
   const currentPlayerIndex = isAnimating || isFinalTrickPhase ? null : gameState.currentPlayer;
 
   return (
     <>
       <PageBackground image={BACKGROUNDS.battle} />
-      <div style={{ position: 'relative', zIndex: 1, minHeight: '100vh' }}>
+      <div style={{ position: 'relative', zIndex: 1, height: '100vh', overflow: 'hidden' }}>
         <BattleLayout showOrientationHint>
           <div
-            className="relative z-10 flex-1 flex flex-col gap-6 p-4"
-            style={{ minHeight: '100vh' }}
+            className="relative z-10 flex-1 flex flex-col gap-3 p-3"
+            style={{ height: '100%', minHeight: 0, overflow: 'hidden' }}
           >
             <div
-              key={`${gameState.currentRound}-${gameState.currentTrick}`}
+              key={`${displayRound}-${displayTrick}`}
               className="trick-indicator-update"
               style={{
                 position: 'absolute',
@@ -823,11 +824,11 @@ function CpuPlayContent() {
                 letterSpacing: '0.05em',
               }}
             >
-              第{gameState.currentRound}ラウンド / 第{gameState.currentTrick}トリック
+              第{displayRound}ラウンド / 第{displayTrick}トリック
             </div>
             <BattleHud
-              round={gameState.currentRound}
-              trick={gameState.currentTrick}
+              round={displayRound}
+              trick={displayTrick}
               timer={
                 <Timer
                   turnSeconds={


### PR DESCRIPTION
### Motivation
- Final-trick `showdown` could end up using an emptied `trickCards` (engine cleared them during `applyMove`/`finalRound`), causing incorrect penalty display (e.g. "0本のきゅうり").
- The round/trick HUD could show stale values when engine state is updated via `gameRef.current` during animations.
- Table and hand layout on CPU play could overlap and produce vertical scroll / off-screen content on many viewports.

### Description
- Preserve the cards played during the final-trick showdown in a separate array `showdownTrickCards` and use it for winner determination, penalty calculation, opened-player list and UI rendering instead of relying on `state.trickCards` which can be cleared by the engine. (updated `apps/hub/app/cucumber/cpu/play/page.tsx`)
- Render the round/trick indicator and HUD using the latest ref-backed state when available by deriving `displayRound`/`displayTrick` from `gameRef.current?.state` to avoid stale UI during transitions. (updated `apps/hub/app/cucumber/cpu/play/page.tsx`)
- Constrain the CPU play page to one viewport by setting the outer container to `height: 100vh; overflow: hidden` and tightening inner layout (`height: 100%`, `minHeight: 0`) to prevent vertical overflow. (updated `apps/hub/app/cucumber/cpu/play/page.tsx`)
- Adjust table/hand CSS to fit the table and 7 cards more reliably by switching `.ellipse-table` to `height: 100%`, reducing paddings/gaps, and shrinking hand card sizes and responsive hand-area heights. (updated `apps/hub/app/cucumber/cpu/play/game.css`)

### Testing
- Ran TypeScript checks with `pnpm -C apps/hub type-check` which completed successfully. 
- Ran linting with `pnpm -C apps/hub lint` which completed successfully but reported one pre-existing `@typescript-eslint/no-explicit-any` warning in `app/api/game/move/route.ts`.
- No new unit tests were added; changes are focused on UI behavior and integration with the existing engine and were validated via the above static checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1dd1974cc832fba85af9a9a2de508)