### PR TITLE
Refactor CPU play layout and update game settings

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/game.css
+++ b/apps/hub/app/cucumber/cpu/play/game.css
@@ -1,25 +1,19 @@
 /* テーブルの基礎レイアウト */
 .ellipse-table {
   position: relative;
-  flex: 1;
+  flex: 1 1 0%;
   width: 100%;
-  height: 100%;
-  min-height: 0;
+  min-height: clamp(340px, 50svh, 600px);
   padding: clamp(12px, 2.6vw, 24px);
   padding-bottom: clamp(96px, 22svh, 150px);
   border-radius: clamp(18px, 4vw, 30px);
-  display: grid;
-  align-items: stretch;
-  justify-items: center;
-  gap: clamp(16px, 3vw, 32px);
   overflow: hidden;
   box-sizing: border-box;
   background: transparent;
-  border: 3px solid rgba(101, 67, 33, 0.8);
-  outline: none;
+  border: 2px solid rgba(101, 67, 33, 0.6);
   box-shadow:
-    inset 0 0 60px rgba(0, 0, 0, 0.3),
-    0 8px 32px rgba(0, 0, 0, 0.4);
+    inset 0 0 40px rgba(0, 0, 0, 0.2),
+    0 4px 20px rgba(0, 0, 0, 0.3);
   --ellipse-card-width: clamp(44px, 6vw, 72px);
   --ellipse-card-height: clamp(60px, 9vw, 108px);
   --ellipse-card-gap: clamp(6px, 2vw, 14px);
@@ -34,45 +28,17 @@
   width: 100%;
   height: 100%;
   border-radius: inherit;
-  display: grid;
-  align-items: stretch;
-  justify-items: center;
-  gap: inherit;
   background: linear-gradient(135deg, #1a5c2a 0%, #1b6b31 50%, #186128 100%);
 }
 
+/* CPU対戦: ステージ内をflex columnで並べる */
 .cpu-play-layout .battle-layout__stage {
-  min-height: clamp(620px, 94svh, 980px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(8px, 1.5vh, 14px);
+  padding: clamp(8px, 2vw, 16px);
+  padding-bottom: calc(clamp(8px, 2vw, 16px) + env(safe-area-inset-bottom, 0));
   overflow: visible;
-  padding: clamp(12px, 2.4vw, 24px);
-  padding-bottom: calc(clamp(20px, 4vw, 40px) + env(safe-area-inset-bottom, 0));
-}
-
-.cpu-play-root {
-  display: flex;
-  flex: 1 1 auto;
-  flex-direction: column;
-  gap: clamp(10px, 2vh, 16px);
-  min-height: 0;
-  padding: clamp(8px, 1.8vw, 14px);
-}
-
-.cpu-play-table-wrap {
-  position: relative;
-  flex: 1 1 auto;
-  min-height: clamp(340px, 52svh, 620px);
-  max-height: clamp(420px, 62svh, 760px);
-  overflow: hidden;
-}
-
-.game-container {
-  position: relative;
-  width: 100%;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  gap: clamp(16px, 2vw, 28px);
-  padding: clamp(16px, 3vw, 32px);
 }
 
 .ellipse-table__center {
@@ -897,24 +863,32 @@
 .card.playable {
   background: linear-gradient(135deg, #50c878, #45b36b);
   color: white;
-  transform: translateY(-8px) scale(1.05);
-  box-shadow: 0 12px 35px rgba(80, 200, 120, 0.5);
+  box-shadow: 0 4px 12px rgba(80, 200, 120, 0.4);
   border-color: rgba(255, 255, 255, 0.6);
+}
+
+.card.playable:hover {
+  transform: translateY(-8px) scale(1.05);
+  box-shadow: 0 12px 28px rgba(80, 200, 120, 0.6);
 }
 
 .card.discard {
   background: linear-gradient(135deg, #f7465f, #e03d4f);
   color: white;
-  transform: translateY(-5px) scale(1.02);
-  box-shadow: 0 10px 30px rgba(247, 70, 95, 0.5);
+  box-shadow: 0 4px 12px rgba(247, 70, 95, 0.4);
   border-color: rgba(255, 255, 255, 0.5);
 }
 
+.card.discard:hover {
+  transform: translateY(-5px) scale(1.02);
+  box-shadow: 0 10px 24px rgba(247, 70, 95, 0.6);
+}
+
 .card.disabled {
-  background: linear-gradient(135deg, #999, #777);
-  color: #555;
+  background: linear-gradient(135deg, #888, #666);
+  color: #aaa;
   opacity: 0.5;
-  filter: grayscale(0.3);
+  filter: grayscale(0.4);
   cursor: not-allowed;
 }
 
@@ -945,36 +919,7 @@
   z-index: 10;
 }
 
-.player-hand {
-  grid-area: player-hand;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: clamp(3px, 0.8vw, 10px);
-  padding: clamp(8px, 2vw, 14px);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.1));
-  border-radius: clamp(16px, 4vw, 24px);
-  backdrop-filter: blur(15px);
-  box-shadow: 0 -6px 25px rgba(0, 0, 0, 0.4);
-  overflow-x: auto;
-  border: 3px solid rgba(255, 255, 255, 0.4);
-  min-height: clamp(82px, 18svh, 128px);
-  max-height: clamp(104px, 22svh, 158px);
-  margin-bottom: 0;
-  z-index: 24;
-}
-
-.player-hand .card {
-  flex-shrink: 0;
-  width: clamp(34px, 4.9vw, 62px);
-  height: clamp(48px, 7.2vw, 88px);
-}
-
-.player-hand .card:hover:not(.disabled) {
-  transform: translateY(-8px) scale(1.05);
-  z-index: 15;
-}
-
+/* Hand dock is styled via #hand-dock in globals.css */
 .player-hand.is-locked {
   pointer-events: none;
   opacity: 0.6;
@@ -1130,21 +1075,6 @@
     --ellipse-hand-padding: clamp(10px, 3vw, 16px);
     --ellipse-seat-width: clamp(150px, 22vw, 210px);
   }
-
-  .player-hand {
-    min-height: clamp(72px, 18svh, 120px);
-    max-height: clamp(96px, 20svh, 144px);
-  }
-
-  .cpu-play-layout .battle-layout__stage {
-    min-height: clamp(580px, 94svh, 920px);
-  }
-}
-
-/* 5/6人時の座席サイズ縮小 */
-.seats-container.players-5 .player-panel,
-.seats-container.players-6 .player-panel {
-  transform: scale(0.88);
 }
 
 @media (max-width: 768px) {
@@ -1158,16 +1088,6 @@
     --ellipse-seat-width: clamp(120px, 36vw, 188px);
     padding: clamp(12px, 4vw, 20px);
     padding-bottom: clamp(96px, 32svh, 160px);
-  }
-
-  .player-hand {
-    min-height: clamp(68px, 18svh, 108px);
-    max-height: clamp(88px, 20svh, 132px);
-  }
-
-  .cpu-play-table-wrap {
-    min-height: clamp(320px, 50svh, 560px);
-    max-height: clamp(400px, 60svh, 660px);
   }
 
   .card-number {
@@ -1190,10 +1110,6 @@
     --ellipse-seat-width: clamp(100px, 48vw, 160px);
     padding: clamp(10px, 5vw, 16px);
     padding-bottom: clamp(90px, 36svh, 150px);
-  }
-
-  .player-hand {
-    min-height: clamp(60px, 17svh, 98px);
   }
 }
 

--- a/apps/hub/app/cucumber/cpu/play/page.tsx
+++ b/apps/hub/app/cucumber/cpu/play/page.tsx
@@ -375,13 +375,14 @@ function CpuPlayContent() {
 
   const checkGameOver = useCallback(
     (state: GameState) => {
-      const hasEliminated = state.players.some(player => player.cucumbers >= 6);
+      const maxCucumbers = gameRef.current?.config.maxCucumbers ?? 6;
+      const hasEliminated = state.players.some(player => player.cucumbers >= maxCucumbers);
       if (hasEliminated) {
         const results = state.players
           .map((player, index) => ({
             name: index === 0 ? 'あなた' : `CPU ${index}`,
             cucumbers: player.cucumbers,
-            eliminated: player.cucumbers >= 6,
+            eliminated: player.cucumbers >= maxCucumbers,
           }))
           .sort((a, b) => a.cucumbers - b.cucumbers);
         setGameResults(results);
@@ -794,13 +795,9 @@ function CpuPlayContent() {
     return (
       <>
         <PageBackground image={BACKGROUNDS.battle} />
-        <div style={{ position: 'relative', zIndex: 1, minHeight: '100vh' }}>
-          <BattleLayout showOrientationHint>
-            <div className="flex-1 flex flex-col p-4">
-              <div className="grid place-items-center h-full text-white/80">Loading...</div>
-            </div>
-          </BattleLayout>
-        </div>
+        <BattleLayout showOrientationHint>
+          <div className="grid place-items-center flex-1 text-white/80">Loading...</div>
+        </BattleLayout>
       </>
     );
   }
@@ -822,135 +819,111 @@ function CpuPlayContent() {
   return (
     <>
       <PageBackground image={BACKGROUNDS.battle} />
-      <div style={{ position: 'relative', zIndex: 1, minHeight: '100vh', width: '100%' }}>
-        <BattleLayout showOrientationHint className="cpu-play-layout">
-          <div className="cpu-play-root relative z-10" style={{ minHeight: 0 }}>
-            <div
-              key={`${displayRound}-${displayTrick}`}
-              className="trick-indicator-update"
-              style={{
-                position: 'absolute',
-                top: '1rem',
-                left: '1.5rem',
-                zIndex: 10,
-                backgroundColor: 'rgba(0, 0, 0, 0.6)',
-                color: 'white',
-                padding: '0.5rem 1.2rem',
-                borderRadius: '8px',
-                fontSize: '1.1rem',
-                fontWeight: 'bold',
-                letterSpacing: '0.05em',
-              }}
-            >
-              第{displayRound}ラウンド / 第{displayTrick}トリック
-            </div>
-            <BattleHud
-              round={displayRound}
-              trick={displayTrick}
-              timer={
-                <Timer
-                  turnSeconds={
-                    gameRef.current ? getEffectiveTurnSeconds(gameRef.current.config) : null
-                  }
-                  isActive={gameState.currentPlayer === 0 && gameState.phase === 'AwaitMove'}
-                  onTimeout={handleTimeout}
-                />
+      <BattleLayout showOrientationHint className="cpu-play-layout">
+        <BattleHud
+          round={displayRound}
+          trick={displayTrick}
+          timer={
+            <Timer
+              turnSeconds={
+                gameRef.current ? getEffectiveTurnSeconds(gameRef.current.config) : null
               }
-              onExit={handleBackToHome}
+              isActive={gameState.currentPlayer === 0 && gameState.phase === 'AwaitMove'}
+              onTimeout={handleTimeout}
             />
+          }
+          onExit={handleBackToHome}
+        />
 
-            {isFinalTrickPhase ? (
-              <div className="final-trick-notice" role="status" aria-live="polite">
-                最終トリック
-              </div>
-            ) : null}
+        {isFinalTrickPhase ? (
+          <div className="final-trick-notice" role="status" aria-live="polite">
+            最終トリック
+          </div>
+        ) : null}
 
-            {overlayText ? (
-              <div className="final-trick-overlay" role="status" aria-live="assertive">
-                <div className="final-trick-overlay__text">{overlayText}</div>
-              </div>
-            ) : null}
+        {shouldDiscardMinCard ? (
+          <div className="discard-notice" role="status" aria-live="polite">
+            出せるカードがありません。最小のカードを捨てます。
+          </div>
+        ) : null}
 
-            {shouldDiscardMinCard ? (
-              <div className="discard-notice" role="status" aria-live="polite">
-                出せるカードがありません。最小のカードを捨てます。
-              </div>
-            ) : null}
+        {turnNotice ? (
+          <div className="discard-result-notice" role="status" aria-live="polite">
+            {turnNotice}
+          </div>
+        ) : null}
 
-            {turnNotice ? (
-              <div className="discard-result-notice" role="status" aria-live="polite">
-                {turnNotice}
-              </div>
-            ) : null}
-            <div className="cpu-play-table-wrap">
-              <EllipseTable
-                state={gameState}
-                config={
-                  gameRef.current?.config ||
-                  ({
-                    players: 4,
-                    turnSeconds: 15,
-                    maxCucumbers: 6,
-                    initialCards: 7,
-                    cpuLevel: 'normal',
-                  } as GameConfig)
-                }
-                currentPlayerIndex={currentPlayerIndex}
-                onCardClick={(card: number) => handleCardClick(Number(card))}
-                className={['cpu-play-table', isCardLocked ? 'cards-locked' : '']
-                  .filter(Boolean)
-                  .join(' ')}
-                isSubmitting={isSubmitting}
-                lockedCardId={lockedCardId}
-                names={displayNames}
-                mySeatIndex={0}
-                trickCards={tableTrickCards}
-                latestPlayedCardKey={latestPlayedKey}
-                trickWinner={trickWinner}
-                trickWinnerText={trickWinnerText}
-                isFinalTrickMode={isFinalTrickPhase}
-                finalTrickSelectedPlayers={finalTrickSelectedPlayers}
-                finalTrickOpenedPlayers={finalTrickOpenedPlayers}
-                finalTrickStatusText={finalTrickStatusText}
-                showdownMode={isShowdownMode}
-              />
+        <EllipseTable
+          state={gameState}
+          config={
+            gameRef.current?.config ||
+            ({
+              players: 4,
+              turnSeconds: 15,
+              maxCucumbers: 6,
+              initialCards: 7,
+              cpuLevel: 'normal',
+            } as GameConfig)
+          }
+          currentPlayerIndex={currentPlayerIndex}
+          onCardClick={(card: number) => handleCardClick(Number(card))}
+          className={['cpu-play-table', isCardLocked ? 'cards-locked' : '']
+            .filter(Boolean)
+            .join(' ')}
+          isSubmitting={isSubmitting}
+          lockedCardId={lockedCardId}
+          names={displayNames}
+          mySeatIndex={0}
+          trickCards={tableTrickCards}
+          latestPlayedCardKey={latestPlayedKey}
+          trickWinner={trickWinner}
+          trickWinnerText={trickWinnerText}
+          isFinalTrickMode={isFinalTrickPhase}
+          finalTrickSelectedPlayers={finalTrickSelectedPlayers}
+          finalTrickOpenedPlayers={finalTrickOpenedPlayers}
+          finalTrickStatusText={finalTrickStatusText}
+          showdownMode={isShowdownMode}
+        />
+
+        {overlayText ? (
+          <div className="final-trick-overlay" role="status" aria-live="assertive">
+            <div className="final-trick-overlay__text">{overlayText}</div>
+          </div>
+        ) : null}
+
+        {gameOver ? (
+          <div className="game-over-overlay">
+            <div className="game-over-overlay__title">
+              {gameResults
+                .filter(result => result.eliminated)
+                .map(result => result.name)
+                .join('、')}{' '}
+              お漬物！！！
             </div>
 
-            {gameOver ? (
-              <div className="game-over-overlay">
-                <div className="game-over-overlay__title">
-                  {gameResults
-                    .filter(result => result.eliminated)
-                    .map(result => result.name)
-                    .join('、')}{' '}
-                  お漬物！！！
+            <div className="game-over-overlay__result">
+              <h2>結果</h2>
+              {gameResults.map((result, index) => (
+                <div
+                  key={`${result.name}-${index}`}
+                  className={`game-over-overlay__rank ${result.eliminated ? 'is-eliminated' : ''}`}
+                >
+                  <span>
+                    {index + 1}位 {result.name}
+                  </span>
+                  <span>
+                    🥒 {result.cucumbers}本 {result.eliminated ? '💀' : ''}
+                  </span>
                 </div>
+              ))}
+            </div>
 
-                <div className="game-over-overlay__result">
-                  <h2>結果</h2>
-                  {gameResults.map((result, index) => (
-                    <div
-                      key={`${result.name}-${index}`}
-                      className={`game-over-overlay__rank ${result.eliminated ? 'is-eliminated' : ''}`}
-                    >
-                      <span>
-                        {index + 1}位 {result.name}
-                      </span>
-                      <span>
-                        🥒 {result.cucumbers}本 {result.eliminated ? '💀' : ''}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-
-                <a className="game-over-overlay__home" href="/home" onClick={handleBackToHome}>
-                  ホームへ戻る
-                </a>
-              </div>
-            ) : null}
+            <a className="game-over-overlay__home" href="/home" onClick={handleBackToHome}>
+              ホームへ戻る
+            </a>
           </div>
-        </BattleLayout>
-      </div>
+        ) : null}
+      </BattleLayout>
     </>
   );
 }

--- a/apps/hub/app/cucumber/cpu/settings/page.tsx
+++ b/apps/hub/app/cucumber/cpu/settings/page.tsx
@@ -38,9 +38,9 @@ export default function CpuSettings() {
     // アクセシビリティ用の音声通知
     const labels: Record<SettingKey, Record<OptionValue, string>> = {
       players: { 2: '2人', 3: '3人', 4: '4人', 5: '5人', 6: '6人' },
-      turnSeconds: { 5: '5秒', 10: '10秒', 15: '15秒', 20: '20秒', 30: '30秒', 0: '無制限' },
-      maxCucumbers: { 4: '4本', 5: '5本', 6: '6本', 7: '7本' },
-      cpuLevel: { easy: '簡単', normal: '普通', hard: '難しい' },
+      turnSeconds: { 10: '10秒', 15: '15秒', 20: '20秒', 30: '30秒', 0: '無制限' },
+      maxCucumbers: { 5: '5本', 6: '6本', 7: '7本', 10: '10本' },
+      cpuLevel: { easy: 'やさしい', normal: 'ふつう', hard: 'つよい' },
       showAllHands: {}
     };
     
@@ -114,11 +114,17 @@ export default function CpuSettings() {
 
         <section className="flex flex-col gap-3">
           <h2 className="font-heading text-[clamp(18px,2.6vw,24px)]">制限時間</h2>
-          <p className="text-white/80 text-[clamp(13px,1.6vw,16px)]">5, 10, 15, 20, 30秒から選択</p>
+          <p className="text-white/80 text-[clamp(13px,1.6vw,16px)]">10〜30秒、または無制限</p>
           <OptionToggleGroup
             id="turnSeconds"
             label="制限時間"
-            options={[5,10,15,20,30].map(n=>({ value: n, label: `${n}秒` }))}
+            options={[
+              { value: 10, label: '10秒' },
+              { value: 15, label: '15秒' },
+              { value: 20, label: '20秒' },
+              { value: 30, label: '30秒' },
+              { value: 0, label: 'なし' },
+            ]}
             value={settings.turnSeconds}
             onChange={(v)=>handleSettingChange('turnSeconds', Number(v))}
           />
@@ -126,11 +132,11 @@ export default function CpuSettings() {
 
         <section className="flex flex-col gap-3">
           <h2 className="font-heading text-[clamp(18px,2.6vw,24px)]">きゅうり数</h2>
-          <p className="text-white/80 text-[clamp(13px,1.6vw,16px)]">4〜7本から選択</p>
+          <p className="text-white/80 text-[clamp(13px,1.6vw,16px)]">5〜10本から選択</p>
           <OptionToggleGroup
             id="maxCucumbers"
             label="きゅうり数"
-            options={[4,5,6,7].map(n=>({ value: n, label: `${n}本` }))}
+            options={[5,6,7,10].map(n=>({ value: n, label: `${n}本` }))}
             value={settings.maxCucumbers}
             onChange={(v)=>handleSettingChange('maxCucumbers', Number(v))}
           />
@@ -138,14 +144,14 @@ export default function CpuSettings() {
 
         <section className="flex flex-col gap-3">
           <h2 className="font-heading text-[clamp(18px,2.6vw,24px)]">CPU難易度</h2>
-          <p className="text-white/80 text-[clamp(13px,1.6vw,16px)]">簡単 / 普通 / 難しい</p>
+          <p className="text-white/80 text-[clamp(13px,1.6vw,16px)]">やさしい / ふつう / つよい</p>
           <OptionToggleGroup
             id="cpuLevel"
             label="CPU難易度"
             options={[
-              { value: 'easy', label: '簡単' },
-              { value: 'normal', label: '普通' },
-              { value: 'hard', label: '難しい' }
+              { value: 'easy', label: 'やさしい' },
+              { value: 'normal', label: 'ふつう' },
+              { value: 'hard', label: 'つよい' }
             ]}
             value={settings.cpuLevel}
             onChange={(v)=>handleSettingChange('cpuLevel', v)}

--- a/apps/hub/lib/backgrounds.ts
+++ b/apps/hub/lib/backgrounds.ts
@@ -1,5 +1,6 @@
 export const BACKGROUNDS = {
-  home: '/images/home_f.png',
+  home: '/images/home13.png',
   battle: '/images/battle1.png',
+  settings: '/images/bg-home-04.png',
 } as const;
 


### PR DESCRIPTION
## Summary
This PR refactors the CPU play game layout to simplify the DOM structure and improve styling consistency, while also updating game settings options and UI labels.

## Key Changes

### Layout Refactoring (page.tsx)
- Removed unnecessary nested wrapper divs with inline styles from the main game render
- Simplified the loading state to use cleaner flex layout without extra positioning wrappers
- Flattened the component hierarchy by removing `cpu-play-root` and `cpu-play-table-wrap` wrapper divs
- Moved game state overlays (final trick notice, discard notice, game over) to be direct children of `BattleLayout`
- Reordered overlay elements for better z-index layering (game over overlay moved to end)

### Game Logic Updates (page.tsx)
- Made the game-over elimination threshold configurable by using `maxCucumbers` from game config instead of hardcoded value of 6
- Updated both the elimination check and results calculation to use the dynamic threshold

### CSS Improvements (game.css)
- Simplified `.ellipse-table` layout from grid to flex-based with proper flex-grow behavior
- Updated table sizing to use `clamp()` for responsive `min-height` instead of fixed `height: 100%`
- Reduced border thickness and shadow intensity for a more refined appearance
- Moved card hover effects (transform and shadow) from default state to `:hover` pseudo-class for better performance
- Removed grid layout properties from `.ellipse-table__inner` and `.cpu-play-layout .battle-layout__stage`
- Simplified `.cpu-play-layout .battle-layout__stage` to use flex column with consistent gap and padding
- Removed obsolete `.cpu-play-root`, `.cpu-play-table-wrap`, and `.game-container` styles
- Cleaned up responsive breakpoint styles by removing redundant player-hand sizing rules
- Updated card disabled state styling with adjusted grayscale filter

### Settings Updates (settings/page.tsx)
- Removed 5-second option from turn seconds (now 10, 15, 20, 30, or unlimited)
- Expanded max cucumbers range from 4-7 to 5-10 (added 10 as new option)
- Updated CPU difficulty labels from Japanese formal style to hiragana casual style:
  - "簡単" → "やさしい"
  - "普通" → "ふつう"
  - "難しい" → "つよい"
- Updated settings descriptions to reflect new option ranges

### Background Assets (backgrounds.ts)
- Changed home background from `home_f.png` to `home13.png`
- Added new settings background: `bg-home-04.png`

## Implementation Details
- The layout refactoring maintains all functionality while reducing DOM complexity
- CSS changes prioritize performance by deferring transform/shadow effects to hover states
- Game config flexibility now allows different cucumber thresholds for different game modes
- Settings UI now uses more casual/friendly Japanese terminology

https://claude.ai/code/session_01LE18niVtxKjY3NDyP6FJTa