### PR TITLE
Fix CPU play layout: ellipse-table-inner height and card class collision

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/game.css
+++ b/apps/hub/app/cucumber/cpu/play/game.css
@@ -39,9 +39,8 @@
 }
 
 .ellipse-table-inner {
-  position: relative;
-  width: 100%;
-  height: 100%;
+  position: absolute;
+  inset: 0;
   border-radius: inherit;
   background: linear-gradient(135deg, #1a5c2a 0%, #1b6b31 50%, #186128 100%);
 }
@@ -320,9 +319,11 @@
 
 /* --- カード --- */
 
-.card {
+.card.game-card {
   width: var(--ellipse-card-width, 65px);
   height: var(--ellipse-card-height, 90px);
+  padding: 0;
+  backdrop-filter: none;
   border-radius: 8px;
   display: flex !important;
   flex-direction: column;


### PR DESCRIPTION
- Change .ellipse-table-inner from position:relative + height:100% to position:absolute + inset:0 so it fills the parent regardless of how the flex layout resolves height. This fixes #seats having zero height which caused all player seats to collapse to a horizontal line at top.
- Scope game card base styles to .card.game-card (higher specificity) to prevent globals.css generic .card (padding:24px, backdrop-filter) from bleeding into game cards.

https://claude.ai/code/session_01LE18niVtxKjY3NDyP6FJTa