### PR TITLE
Fix friend match button link: /online → /friend/create

### DIFF
--- a/apps/hub/app/home/_components/DesktopHero.tsx
+++ b/apps/hub/app/home/_components/DesktopHero.tsx
@@ -126,7 +126,7 @@ export default function DesktopHero({ username = 'GUEST' }: Props) {
               </button>
             </Link>
             <Link
-              href="/online"
+              href="/friend/create"
               aria-label="フレンド対戦を始める"
               style={{ textDecoration: 'none' }}
             >


### PR DESCRIPTION
The main "フレンド対戦" button on the home screen was pointing to /online (the "coming soon" random matching page) instead of /friend/create (the actual room creation page).

https://claude.ai/code/session_01LE18niVtxKjY3NDyP6FJTa