### PR TITLE
2026-05-15 15:05 JST: docs add AI workflow policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Agent Instructions for Five_Cucumber
+
+These instructions are the entry point for AI coding agents working in this repository.
+
+## Required Reading Order
+
+Before changing files, read these documents when they exist:
+
+1. `AGENTS.md`
+2. `AI_RULES.md`
+3. `WORKFLOW.md`
+4. `PLAN.md`
+5. `README.md`
+6. Relevant documents under `docs/`
+
+If the work affects gameplay, room flow, deployment, realtime state, or UI behavior, read the matching local docs and nearby source files before editing.
+
+## Current Direction
+
+Five_Cucumber is a Web-first project. The active implementation target is the Next.js / TypeScript / Firebase web application in this repository.
+
+Unity and Blender are not part of the active implementation workflow until the Web version is complete or the user explicitly changes direction. They may be discussed as future tools for higher-fidelity visuals, 3D assets, animation, or a separate Unity edition, but do not introduce Unity or Blender files, scripts, exports, or project setup during normal Web work.
+
+## Collaboration Mode
+
+If the user says `議論のみ`, `相談のみ`, or clearly asks only to discuss, do not edit files, commit, push, create pull requests, or merge. In that mode, inspect only what is needed, summarize findings, and ask or answer questions.
+
+When the user says `作業開始` or otherwise asks for implementation, follow `WORKFLOW.md` and `AI_RULES.md`.
+
+## Default Work Style
+
+- Keep changes focused and reviewable.
+- Prefer existing project patterns over new abstractions.
+- Do not touch unrelated files.
+- Preserve rollback points with commits.
+- Use dated branches and dated pull request titles.
+- Merge completed phases into `main` unless the user explicitly asks to stop before merge.
+- Stop after each completed phase and wait for the user's confirmation before starting the next phase.

--- a/AI_RULES.md
+++ b/AI_RULES.md
@@ -1,0 +1,195 @@
+# AI Rules for Five_Cucumber
+
+These rules define the mandatory operating contract for any AI coding agent working in this repository.
+
+## Canonical Repository
+
+The canonical repository is:
+
+```text
+https://github.com/Terumasa0218/Five_Cucumber
+```
+
+Treat the GitHub repository, especially `origin/main`, as the most accurate source of truth. Local working copies should be checked against the remote before important planning, implementation, or documentation changes when network access is available.
+
+## Current Technical Direction
+
+- Primary target: Web version.
+- Framework: Next.js.
+- Primary language: TypeScript / TSX.
+- Package manager: pnpm.
+- Monorepo tooling: Turborepo.
+- Main app area: `apps/hub/`.
+- Shared packages: `packages/`.
+- Game module area: `games/cucumber5/`.
+- Backend and integration areas: `functions/`, Firebase configuration, Ably / shared-store diagnostics where already present.
+
+Unity and Blender are deferred. Do not use, add, or configure Unity or Blender until the Web version is complete or the user explicitly requests a direction change. If future quality goals suggest Unity or Blender, discuss the tradeoff first and record the decision before implementation.
+
+## 1. Scope Boundary
+
+Repository work should stay inside this repository and its subdirectories. Runtime-provided assistant instructions or connector metadata may be read only when required by the active tool environment, but project inspection and file edits should be limited to this repository.
+
+Allowed repository areas include:
+
+- `AGENTS.md`
+- `AI_RULES.md`
+- `WORKFLOW.md`
+- `PLAN.md`
+- `README.md`
+- `DEPLOYMENT.md`
+- `docs/`
+- `.github/workflows/`
+- `app/`
+- `apps/`
+- `assets/`
+- `games/`
+- `packages/`
+- `functions/`
+- `homeUI/`
+- `homeUI_v0/`
+- `scripts/`
+- `tests/`
+- `tooling/`
+- package and build configuration files at the repository root
+- Git metadata for normal non-destructive status, diff, add, commit, branch, fetch, pull, and push operations
+
+The AI agent must not inspect or modify unrelated projects, user home content outside this repository, credential stores, browser profiles, SSH keys, system directories, OS settings, registry entries, global package manager settings, or global editor settings.
+
+## 2. Required Startup Checklist
+
+Before making changes, the AI agent must:
+
+1. Read `AGENTS.md` if present.
+2. Read `AI_RULES.md`.
+3. Read `WORKFLOW.md` if present.
+4. Read `PLAN.md` if present.
+5. Read `README.md` and relevant files under `docs/` when the task affects product behavior, implementation direction, deployment, or validation.
+6. Confirm the current working directory is the repository root.
+7. Confirm the canonical remote with `git remote -v`.
+8. Run `git status --short`.
+9. Identify the files it expects to change.
+10. Avoid touching unrelated files.
+
+## 3. Default Delivery Policy
+
+Unless the user explicitly says `議論のみ`, `相談のみ`, says not to commit, or says not to push, repository changes should be completed through:
+
+1. focused edits,
+2. validation,
+3. Git commit,
+4. push to a dated branch,
+5. pull request creation or update with `YYYY-MM-DD HH:mm JST` in the title,
+6. merge into `main`,
+7. local `main` synchronization.
+
+Pull request titles must include date, time, and `JST` in `YYYY-MM-DD HH:mm JST` format so rollback points are easy to identify.
+
+Direct pushes to `main` require explicit user instruction unless a repository intentionally does not use pull requests. Force pushing is prohibited.
+
+Work must follow the phase-based review flow in `WORKFLOW.md`: finish a phase, push it, report it, and wait for user confirmation before starting the next phase.
+
+If authentication, branch protection, CI, or repository permissions prevent push, PR creation, merge, or synchronization, stop at a clean boundary and report the blocker.
+
+## 4. Tool Execution Restrictions
+
+Prefer commands documented in `docs/ai-assisted-development-setup.md` and scripts already defined in `package.json`.
+
+Allowed command categories:
+
+- `git status`, `git diff`, `git diff --check`, `git add`, `git commit`, `git branch`, `git switch`, `git log`, `git fetch`, `git pull`, `git remote`, `git rev-parse`, `git push`
+- `pnpm` scripts already defined by this repository
+- repository-local scripts under `scripts/` and `tooling/`
+- browser checks against local development servers when validating UI work
+- GitHub connector or GitHub CLI operations for repository PR workflows when available
+
+Prohibited command categories:
+
+- `sudo`
+- force pushing
+- destructive history rewriting
+- `git reset --hard` unless explicitly requested by the user
+- `git rebase` unless explicitly requested by the user
+- `git commit --amend` unless explicitly requested by the user
+- deleting untracked repository content without explicit user approval
+- recursive destructive shell commands outside generated build/cache directories
+- network downloads or package installs without explicit user approval
+- commands that read or write outside the repository root, except active tool-environment instruction files required by the assistant runtime
+
+## 5. Web Project Rules
+
+- Keep the Web version as the active product target until the user changes direction.
+- Prefer changes inside `apps/hub/`, `games/cucumber5/`, `packages/`, `functions/`, `assets/`, or `docs/` according to the task.
+- Use existing Next.js, TypeScript, pnpm, and Turborepo patterns.
+- Prefer focused tests or checks that match the touched area.
+- For UI changes, run an appropriate local validation and browser check when dependencies and environment allow it.
+- Do not introduce a separate engine, renderer, or asset pipeline without prior discussion.
+
+## 6. Unity and Blender Rules
+
+Unity and Blender are future options, not current implementation tools.
+
+Do not add Unity projects, Blender files, generated 3D exports, Unity scripts, Blender scripts, or engine-specific build pipelines during Web-version work.
+
+Revisit Unity or Blender only after the Web version is complete or when the user explicitly asks to discuss it. A future proposal should explain:
+
+- what problem Web technologies cannot solve well enough,
+- whether Blender asset generation alone is sufficient,
+- whether Unity is needed as a separate edition or prototype,
+- expected repository layout,
+- validation and rollback plan.
+
+## 7. Git Rules
+
+Branch names must include an ISO date in `YYYY-MM-DD` format.
+
+Recommended branch pattern:
+
+```text
+ai/YYYY-MM-DD-short-description
+```
+
+Commit rules:
+
+- Commit focused, reviewable changes.
+- Include a clear prefix such as `docs:`, `tools:`, `web:`, `gameplay:`, `ui:`, `test:`, `fix:`, or `pipeline:`.
+- Review `git diff` and run `git diff --check` before every commit.
+- Push the dated branch unless the user requested discussion only or asked not to push.
+- Use dated pull request titles, such as `2026-05-15 12:34 JST: docs add workflow policy`.
+- Merge completed phase work into `main` and synchronize local `main`.
+
+Prohibited Git operations:
+
+- `git push --force`
+- `git push --force-with-lease`
+- `git reset --hard` unless explicitly requested by the user
+- `git rebase` unless explicitly requested by the user
+- `git commit --amend` unless explicitly requested by the user
+- filtering or rewriting history
+
+## 8. Rollback Requirements
+
+Every AI task must preserve rollback capability:
+
+- Use Git commits as restore points.
+- Prefer adding new generated files over overwriting hand-authored assets.
+- Document generated asset sources and commands.
+- Keep terminal commands reproducible.
+
+Preferred rollback methods:
+
+```bash
+git status --short
+git log --oneline --max-count=10
+git revert <commit-sha>
+```
+
+## 9. Human Approval Policy
+
+The AI agent should behave conservatively:
+
+- Explain planned changes before large refactors.
+- Prefer small diffs.
+- Never assume destructive cleanup is acceptable.
+- Require user approval before deleting or replacing valuable assets.
+- Treat user-created art, screens, documents, and game logic as protected unless explicitly instructed otherwise.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,43 @@
+# Five_Cucumber Plan
+
+This file records the active project direction for AI-assisted work.
+
+## Active Direction
+
+Five_Cucumber is Web-first.
+
+Until the Web version is complete or the user explicitly changes direction, implementation should focus on the existing Web stack:
+
+- Next.js
+- TypeScript / TSX
+- pnpm
+- Turborepo
+- Firebase-related configuration already present in the repository
+- Ably / shared-store diagnostics already present in the repository
+
+## Deferred Direction: Unity and Blender
+
+Unity and Blender are deferred until after the Web version is complete.
+
+They may become useful later if the project needs:
+
+- higher-fidelity 3D cucumber, card, table, or scene assets,
+- generated animation or visual material that improves the Web version,
+- promotional or cinematic visuals,
+- a separate Unity prototype or edition.
+
+Do not add Unity or Blender files during ordinary Web implementation. If the idea becomes relevant, discuss it first and record the decision before implementation.
+
+## Near-Term Priorities
+
+1. Keep AI collaboration rules explicit and easy to follow.
+2. Stabilize the Web MVP and core Five Cucumbers gameplay.
+3. Improve room flow, realtime state, diagnostics, and deployment confidence.
+4. Polish UI and accessibility after core behavior is reliable.
+5. Reassess Unity / Blender only after the Web version reaches a clear completion point.
+
+## Open Decisions
+
+- Define the exact acceptance criteria for "Web version complete."
+- Decide whether future Blender use is asset-generation only or part of a larger 3D workflow.
+- Decide whether Unity is ever a separate edition, a prototype, or unnecessary.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,159 @@
+# Five_Cucumber Work Flow
+
+This document defines the working flow for Five_Cucumber. It should be used as the default collaboration pattern in this repository unless the user gives different instructions or a stronger local rule applies.
+
+## Core Rule
+
+Work should be divided into phases. A phase is a user-reviewable milestone with a clear outcome.
+
+Do not continue from one phase to the next until:
+
+1. the phase work has been committed and pushed,
+2. a pull request or equivalent merge point has been created with a `YYYY-MM-DD HH:mm JST` title marker,
+3. the work has been merged into `main`,
+4. local `main` has been synchronized with `origin/main`,
+5. the work report has been provided,
+6. the user has checked the result,
+7. the user says the phase is OK or gives the next instruction.
+
+## Discussion-Only Mode
+
+If the user says `議論のみ`, `相談のみ`, or clearly asks only to discuss, do not edit files, commit, push, create pull requests, or merge.
+
+In discussion-only mode:
+
+- inspect only if needed,
+- summarize findings,
+- ask or answer questions,
+- do not change repository state.
+
+## Phase Flow
+
+Each phase should follow this flow:
+
+1. Confirm current Git state and the canonical remote.
+2. Create or use a dated working branch.
+3. Break the phase into smaller tasks.
+4. Implement one task at a time.
+5. Validate the task.
+6. Commit and push at task boundaries when useful.
+7. Finish the full phase.
+8. Validate the phase.
+9. Commit and push the phase result.
+10. Create or update a pull request with date, time, and `JST` in the title.
+11. Merge the pull request into `main`.
+12. Synchronize local `main` with `origin/main`.
+13. Report what changed, what was validated, the PR, and the final `main` commit.
+14. Stop and wait for user confirmation before starting the next phase.
+
+Recommended branch pattern:
+
+```text
+ai/YYYY-MM-DD-short-description
+```
+
+## Task Flow Inside a Phase
+
+Tasks inside a phase do not require user confirmation before continuing, but they should still preserve rollback points.
+
+For each meaningful task:
+
+1. keep the change focused,
+2. validate the change,
+3. commit with a clear message,
+4. push the branch,
+5. include date and time in the commit message, pull request, or update note when it helps identify a rollback point.
+
+This makes it possible to return to a known-good point if the user reviews the final phase result and says it is not acceptable.
+
+## Rollback Requirement
+
+Every phase and meaningful task should leave Git restore points.
+
+Preferred rollback methods:
+
+- revert a commit,
+- return to a previous pushed branch commit,
+- create a corrective commit.
+
+Avoid destructive history operations. Do not force push. Do not use `git reset --hard` unless the user explicitly requests it.
+
+## User Review Gate
+
+After each phase:
+
+- stop work,
+- report the pushed branch and task commit,
+- report the pull request or merge point with `YYYY-MM-DD HH:mm JST` in its title,
+- report the final `main` commit,
+- summarize validation,
+- tell the user what to check,
+- wait for the user's OK or correction request before starting the next phase.
+
+Merging into `main` is part of the default phase completion flow. Do not stop at push or PR creation unless the user explicitly asks you to stop there. Do not start the next phase on your own.
+
+## Specification Uncertainty Gate
+
+The specifications are expected to evolve. If implementation reveals that a spec is missing, ambiguous, contradictory, or likely wrong, stop at a clean boundary.
+
+When this happens:
+
+1. finish or revert any partial task so the repository is coherent,
+2. commit and push useful completed work if any,
+3. report the uncertainty,
+4. ask the user what direction to take,
+5. treat the next step as discussion unless the user explicitly resumes implementation.
+
+This applies even in the middle of a phase.
+
+## Push and Pull Request Policy
+
+Default behavior:
+
+- commit and push unless the user says discussion only or says not to push,
+- push to a dated branch,
+- create or update a pull request,
+- include date, time, and `JST` in the pull request title,
+- merge the work into `main`,
+- synchronize local `main` after merge,
+- do not push directly to `main` unless explicitly asked or unless a repository intentionally does not use pull requests,
+- do not force push.
+
+Pull request titles must include date, time, and `JST` so the user can easily identify rollback points.
+
+Recommended title pattern:
+
+```text
+YYYY-MM-DD HH:mm JST: short description
+```
+
+Example:
+
+```text
+2026-05-15 12:34 JST: docs add workflow policy
+```
+
+Merging into `main` is part of the normal completion flow. If the user wants review before merge for a specific task, they should say so explicitly. After merge, synchronize local `main` and report the final `main` commit.
+
+## Web-First Direction
+
+Five_Cucumber should remain Web-first until the Web version is complete or the user explicitly changes direction.
+
+Default implementation work should use the existing Next.js / TypeScript / Firebase / pnpm / Turborepo stack. Unity and Blender should not be introduced during normal Web work.
+
+Unity and Blender may be revisited later for:
+
+- high-fidelity 3D assets,
+- richer animation or promotional visuals,
+- a separate Unity edition,
+- asset generation where Blender output clearly improves the Web experience.
+
+Before using Unity or Blender, discuss the reason, repository layout, validation plan, and rollback strategy with the user.
+
+## Cross-Chat and Cross-Repository Use
+
+Use this workflow as the default in future chats for this repository when the user is asking for implementation work.
+
+If another repository has its own `AGENTS.md`, `WORKFLOW.md`, `AI_RULES.md`, or stronger local instructions, follow that repository's rules first and adapt this workflow only where it does not conflict.
+
+If a future chat does not include this file in context, the user may point the agent back to this workflow or ask to copy it into that repository.

--- a/docs/ai-assisted-development-setup.md
+++ b/docs/ai-assisted-development-setup.md
@@ -1,0 +1,88 @@
+# AI-Assisted Development Setup
+
+This document lists repository-local commands AI agents may use when validating work in Five_Cucumber.
+
+## Startup Checks
+
+Run these before changing files:
+
+```bash
+git remote -v
+git status --short
+git branch --show-current
+```
+
+Use `git fetch origin main` before important planning or implementation work when network access is available.
+
+## Dependency Policy
+
+Do not install or update dependencies without explicit user approval.
+
+If dependencies are already installed, use the repository scripts below. If dependencies are missing and validation requires them, report that clearly and ask before running package installation.
+
+The CI workflow currently installs dependencies with:
+
+```bash
+pnpm install --no-frozen-lockfile
+```
+
+## General Validation
+
+For documentation-only changes:
+
+```bash
+git diff --check
+```
+
+For code changes, choose the smallest relevant checks first, then broaden when the touched area is shared or risky:
+
+```bash
+pnpm -w run format:check
+pnpm -w run lint
+pnpm -w run type-check
+pnpm -w run test
+pnpm -w run build
+```
+
+For deployment-oriented changes:
+
+```bash
+pnpm -w run vercel:check
+pnpm -w run assets:exists
+```
+
+For Ably or shared-store diagnostics:
+
+```bash
+pnpm -w run check:ably
+pnpm -w run check:store
+```
+
+## Local Web Validation
+
+When dependencies are available and UI work needs browser verification:
+
+```bash
+pnpm -w run dev
+```
+
+Then verify the affected page in a browser. Check for visible layout issues, broken navigation, and console errors.
+
+## Git Validation Before Commit
+
+Before every commit:
+
+```bash
+git diff
+git diff --check
+git status --short
+```
+
+Stage only intended files.
+
+## Safety Notes
+
+- Do not print secrets, tokens, or private environment values.
+- Do not run destructive cleanup unless the user explicitly approves it.
+- Do not force push.
+- Do not rewrite history unless the user explicitly asks for that operation.


### PR DESCRIPTION
## Summary
- Add repository-level AI instructions in `AGENTS.md`.
- Add mandatory operating rules in `AI_RULES.md` for Web-first Five_Cucumber work.
- Add phase-based delivery workflow in `WORKFLOW.md`.
- Add current project direction in `PLAN.md`.
- Add validation command guidance in `docs/ai-assisted-development-setup.md`.

## Direction
- Treat Aqua_Play as reference only.
- Keep Five_Cucumber Web-first until the Web version is complete.
- Defer Unity and Blender until future discussion or explicit direction change.

## Validation
- `git diff --check`
- `git diff --cached --check`