### PR TITLE
Phase 1: Local playability baseline (2026-05-17 12:19 JST)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Use these documents as the current source of truth:
 - `docs/product-spec.md` - current product specification
 - `docs/work-plan.md` - implementation phases and task order
 - `docs/rules/cucumber5.md` - game rule specification
+- `docs/local-playability.md` - local backend fallback and server-sync behavior
 
 Older investigation notes, legacy flow descriptions, and `.docx` proposal files remain as historical reference only. When they conflict with the canonical docs above, follow the canonical docs.
 
@@ -124,6 +125,8 @@ git diff --check
 
 ## Environment Notes
 
+CPU play and local profile setup should work without Firebase Admin, KV, Redis, or Ably. Friend rooms use a localStorage review mode when server sync is disabled, but real multi-device friend matches require authenticated requests and a shared store.
+
 Friend room APIs currently depend on authenticated requests and a shared store for full server-side operation. Relevant environment areas include:
 
 - `NEXT_PUBLIC_FIREBASE_*`
@@ -135,6 +138,7 @@ Friend room APIs currently depend on authenticated requests and a shared store f
 - `NEXT_PUBLIC_USE_SERVER`
 
 See `docs/deploy/` and `docs/ai-assisted-development-setup.md` for operational details.
+See `docs/local-playability.md` for the expected local fallback behavior.
 
 ## Development Policy
 

--- a/apps/hub/app/api/friend/create/route.ts
+++ b/apps/hub/app/api/friend/create/route.ts
@@ -21,13 +21,11 @@ function parseNumberish(value: unknown): number | null {
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const auth = await verifyAuth(req);
   if (!auth) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  console.info('[KV URL in runtime]', process.env.KV_REST_API_URL, process.env.UPSTASH_REDIS_REST_URL);
   try {
     // リクエストボディの取得と検証
     let body: CreateRoomRequest;
     try {
       const text = await req.text();
-      console.log('[API] Raw request body:', text);
       if (!text || text.trim() === '') {
         throw new Error('Empty request body');
       }

--- a/apps/hub/app/api/username/register/route.ts
+++ b/apps/hub/app/api/username/register/route.ts
@@ -73,7 +73,6 @@ export async function POST(req: NextRequest) {
     await kv.set(keyOwner, nickname, { ex: MAX_AGE });
 
 
-    console.log('[username/register] registered', { id, nickname });
     return NextResponse.json({ ok: true, id, nickname });
   } catch (err) {
     console.error('[username/register] error', err);

--- a/apps/hub/app/cucumber/cpu/play/page.tsx
+++ b/apps/hub/app/cucumber/cpu/play/page.tsx
@@ -26,6 +26,14 @@ import PageBackground from '@/components/ui/PageBackground';
 import { BACKGROUNDS } from '@/lib/backgrounds';
 import './game.css';
 
+const DEBUG_CPU_GAME = process.env.NEXT_PUBLIC_DEBUG_GAME === '1';
+
+function debugGameLog(...args: unknown[]): void {
+  if (DEBUG_CPU_GAME) {
+    console.log(...args);
+  }
+}
+
 function CpuPlayContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -76,7 +84,7 @@ function CpuPlayContent() {
     try {
       const gameStateKey = getGameStateKey(searchParams);
       localStorage.removeItem(gameStateKey);
-      console.log('[Game] CPU game state cleared for fresh start');
+      debugGameLog('[Game] CPU game state cleared for fresh start');
     } catch (error) {
       console.warn('[Game] Failed to clear CPU game state:', error);
     }
@@ -110,7 +118,7 @@ function CpuPlayContent() {
       cpuTurnTimerRef.current = null;
     }
 
-    console.log(`[CPU] Scheduling turn for player ${state.currentPlayer}`);
+    debugGameLog(`[CPU] Scheduling turn for player ${state.currentPlayer}`);
 
     // CPUの思考時間
     const thinkingTime = 600 + Math.random() * 400;
@@ -150,7 +158,7 @@ function CpuPlayContent() {
       setIsShowdownMode(false);
       setIsAnimating(false);
 
-      console.log('[Game] New game started with', config.players, 'players');
+      debugGameLog('[Game] New game started with', config.players, 'players');
 
       // 最初のプレイヤーがCPUの場合は自動プレイ
       if (state.currentPlayer !== 0) {
@@ -191,7 +199,7 @@ function CpuPlayContent() {
 
     // ホームから来た場合は常に新規ゲーム開始
     if (isFromHome) {
-      console.log('[Game] Starting fresh game (from home/settings)');
+      debugGameLog('[Game] Starting fresh game (from home/settings)');
       clearCpuGameState();
       // 新規ゲーム開始
       startGame();
@@ -214,7 +222,7 @@ function CpuPlayContent() {
 
             // 5分以内のセーブデータのみ復元
             if (age < 5 * 60 * 1000) {
-              console.log(
+              debugGameLog(
                 '[Game] Restoring from saved state (age:',
                 Math.round(age / 1000),
                 'seconds)'
@@ -253,10 +261,10 @@ function CpuPlayContent() {
               setIsShowdownMode(false);
               setIsAnimating(false);
 
-              console.log('[Game] State restored successfully with rebuilt controllers');
+              debugGameLog('[Game] State restored successfully with rebuilt controllers');
               return;
             } else {
-              console.log('[Game] Saved state too old, starting fresh');
+              debugGameLog('[Game] Saved state too old, starting fresh');
               clearCpuGameState();
               startGame();
             }
@@ -285,13 +293,13 @@ function CpuPlayContent() {
       const currentPlayer = state.currentPlayer;
 
       if (currentPlayer === 0 || gameOver || state.phase !== 'AwaitMove' || isAnimating) {
-        console.log(
+        debugGameLog(
           `[CPU] Skipping turn - Player: ${currentPlayer}, Phase: ${state.phase}, GameOver: ${gameOver}`
         );
         return;
       }
 
-      console.log(`[CPU] Executing turn for player ${currentPlayer}`);
+      debugGameLog(`[CPU] Executing turn for player ${currentPlayer}`);
 
       const controller = controllers[currentPlayer];
       if (!controller) {
@@ -309,23 +317,23 @@ function CpuPlayContent() {
       const move = await controller.onYourTurn(view);
 
       if (move !== null && typeof move === 'number' && legalMoves.includes(move)) {
-        console.log(`[CPU] Playing move: ${move}`);
+        debugGameLog(`[CPU] Playing move: ${move}`);
         await playMove(currentPlayer, move);
       } else {
         // フォールバック: 最初の合法手
         const fallbackMove = legalMoves[0];
-        console.log(`[CPU] Using fallback move: ${fallbackMove}`);
+        debugGameLog(`[CPU] Using fallback move: ${fallbackMove}`);
         await playMove(currentPlayer, fallbackMove);
       }
 
-      console.log(`[CPU] Turn completed for player ${currentPlayer}`);
+      debugGameLog(`[CPU] Turn completed for player ${currentPlayer}`);
 
       // ターン完了後、次のCPUターンをスケジューリング
       setTimeout(() => {
         if (gameRef.current && !gameOver) {
           const { state } = gameRef.current;
           if (state.currentPlayer !== 0 && state.phase === 'AwaitMove') {
-            console.log(`[CPU] Auto-scheduling next turn for player ${state.currentPlayer}`);
+            debugGameLog(`[CPU] Auto-scheduling next turn for player ${state.currentPlayer}`);
             if (scheduleCpuTurnRef.current) {
               scheduleCpuTurnRef.current();
             }
@@ -336,7 +344,7 @@ function CpuPlayContent() {
       console.error('[CPU] Turn error:', error);
     } finally {
       isProcessingRef.current = false;
-      console.log(`[CPU] Processing flag cleared`);
+      debugGameLog(`[CPU] Processing flag cleared`);
     }
   };
 
@@ -400,7 +408,7 @@ function CpuPlayContent() {
   const playMove = async (player: number, card: number) => {
     if (!gameRef.current) return;
 
-    console.log(`[PlayMove] Starting move - Player: ${player}, Card: ${card}`);
+    debugGameLog(`[PlayMove] Starting move - Player: ${player}, Card: ${card}`);
 
     try {
       await runAnimation(async () => {
@@ -549,7 +557,7 @@ function CpuPlayContent() {
     if (gameState && !gameOver && !isProcessingRef.current && !isAnimating && gameRef.current) {
       const { state } = gameRef.current;
       if (state.currentPlayer !== 0 && state.phase === 'AwaitMove' && !state.isFinalTrick) {
-        console.log(`[useEffect] Scheduling CPU turn for player ${state.currentPlayer}`);
+        debugGameLog(`[useEffect] Scheduling CPU turn for player ${state.currentPlayer}`);
         if (scheduleCpuTurnRef.current) {
           scheduleCpuTurnRef.current();
         }
@@ -608,14 +616,14 @@ function CpuPlayContent() {
     )
       return;
 
-    console.log('[Timeout] Handling timeout for player 0');
+    debugGameLog('[Timeout] Handling timeout for player 0');
 
     // 制限時間切れ時のランダムカード選択
     const legalMoves = getLegalMoves(gameState, 0);
     if (legalMoves.length > 0) {
       const randomIndex = Math.floor(Math.random() * legalMoves.length);
       const selectedCard = legalMoves[randomIndex];
-      console.log(
+      debugGameLog(
         `[Timeout] Auto-selecting random card: ${selectedCard} from legal moves:`,
         legalMoves
       );
@@ -624,14 +632,14 @@ function CpuPlayContent() {
       const hand = gameState.players[0].hand;
       if (hand.length > 0) {
         const minCard = Math.min(...hand);
-        console.log(`[Timeout] No legal moves, selecting minimum card: ${minCard}`);
+        debugGameLog(`[Timeout] No legal moves, selecting minimum card: ${minCard}`);
         await handleCardClick(minCard);
       }
     }
   };
 
   useEffect(() => {
-    console.log(
+    debugGameLog(
       '[Showdown-Check] isFinalTrick:',
       gameState?.isFinalTrick,
       'finalTrickStarted:',
@@ -648,7 +656,7 @@ function CpuPlayContent() {
       const { state, config, rng } = gameRef.current;
       if (!state.isFinalTrick || state.phase !== 'AwaitMove') return;
 
-      console.log('[Showdown] === SHOWDOWN STARTING ===');
+      debugGameLog('[Showdown] === SHOWDOWN STARTING ===');
       let currentState = state;
       const showdownTrickCards: Move[] = [...state.trickCards];
       const selectedPlayers: number[] = [];
@@ -668,9 +676,9 @@ function CpuPlayContent() {
           isDiscard: false,
         };
         showdownTrickCards.push(move);
-        console.log('[Showdown] Player', playerIndex, 'card:', selectedCard, 'isDiscard:', false);
+        debugGameLog('[Showdown] Player', playerIndex, 'card:', selectedCard, 'isDiscard:', false);
         const result = applyMove(currentState, move, config, rng);
-        console.log('[Showdown] applyMove result:', result.success, result.message);
+        debugGameLog('[Showdown] applyMove result:', result.success, result.message);
         if (!result.success) {
           console.error('[Showdown] applyMove failed for player', playerIndex, result.message);
           setFinalTrickStatusText('ショーダウン処理に失敗しました。');
@@ -683,7 +691,7 @@ function CpuPlayContent() {
         selectedPlayers.push(playerIndex);
       }
 
-      console.log('[Showdown] Final trickCards:', showdownTrickCards);
+      debugGameLog('[Showdown] Final trickCards:', showdownTrickCards);
 
       const openedPlayers = showdownTrickCards.map(move => move.player);
       const winner = determineTrickWinner(showdownTrickCards);
@@ -692,7 +700,7 @@ function CpuPlayContent() {
       setFinalTrickOpenedPlayers(openedPlayers);
       setTableTrickCards(showdownTrickCards);
       setLatestPlayedKey(null);
-      console.log('[Showdown] Setting state with', showdownTrickCards.length, 'cards');
+      debugGameLog('[Showdown] Setting state with', showdownTrickCards.length, 'cards');
       setGameState({
         ...currentState,
         trickCards: showdownTrickCards,
@@ -707,7 +715,7 @@ function CpuPlayContent() {
       setFinalTrickStatusText(null);
 
       const showResultTimer = setTimeout(() => {
-        console.log('[Showdown] Calculating penalty...');
+        debugGameLog('[Showdown] Calculating penalty...');
         const winnerName = winner === 0 ? 'あなた' : `CPU ${winner}`;
         const playedCards = showdownTrickCards.filter(trickCard => !trickCard.isDiscard);
         const allOnes =

--- a/apps/hub/app/friend/create/page.tsx
+++ b/apps/hub/app/friend/create/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { RoomSettingsForm } from "@/components/ui";
-import { apiJson } from "@/lib/api";
+import { apiJson, ApiRequestError } from "@/lib/api";
 import { getNickname } from "@/lib/profile";
-import { upsertLocalRoom } from "@/lib/roomSystemUnified";
+import { createRoom, getRoom, upsertLocalRoom } from "@/lib/roomSystemUnified";
+import { USE_SERVER_SYNC } from "@/lib/serverSync";
 import type { Room, RoomResponse } from "@/types/room";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -19,6 +20,8 @@ export default function FriendCreatePage() {
   type SettingKey = keyof FriendRoomSettings;
 
   type CreateRoomResponse = RoomResponse & { storage?: string };
+
+  const serverSyncEnabled = USE_SERVER_SYNC;
 
   const [settings, setSettings] = useState<FriendRoomSettings>({
     roomSize: 4,
@@ -55,6 +58,54 @@ export default function FriendCreatePage() {
     document.title = "ルーム作成 | Five Cucumber";
   }, []);
 
+  const roomFailureMessage = (reason?: string, detail?: unknown) => {
+    if (reason === "no-shared-store") {
+      return "フレンド対戦のサーバー同期に必要な共有ストアが未設定です。ローカル確認ではサーバー同期をOFFにしてください。";
+    }
+    if (reason === "bad-request" || reason === "invalid-json") {
+      return "ルーム設定に不正な値があります。設定を見直してください。";
+    }
+    if (reason === "kv-failed") {
+      return "共有ストアへの保存に失敗しました。KV/Redis設定を確認してください。";
+    }
+
+    const suffix = detail ? ` (${String(detail)})` : "";
+    return `ルーム作成に失敗しました${reason ? `: ${reason}` : ""}${suffix}`;
+  };
+
+  const backendFailureMessage = (err: unknown) => {
+    if (err instanceof ApiRequestError) {
+      const body = err.response.data as (RoomResponse & { error?: string }) | undefined;
+      if (err.response.status === 401) {
+        return "サーバー同期に必要な認証設定が不足しています。フレンド対戦を公開環境で使うにはFirebase Admin設定が必要です。";
+      }
+      return roomFailureMessage(body?.reason, body?.detail ?? body?.error);
+    }
+
+    const message = err instanceof Error ? err.message : String(err);
+    return `作成に失敗しました${message ? ` (${message})` : ""}`;
+  };
+
+  const createLocalRoom = (nickname: string) => {
+    const result = createRoom(
+      Number(settings.roomSize),
+      nickname,
+      Number(settings.turnSeconds),
+      Number(settings.maxCucumbers),
+    );
+
+    if (!result.success || !result.roomId) {
+      setError(roomFailureMessage(result.reason));
+      return;
+    }
+
+    const localRoom = getRoom(result.roomId);
+    if (localRoom) {
+      upsertLocalRoom(localRoom);
+    }
+    router.push(`/friend/room/${result.roomId}`);
+  };
+
   const handleCreateRoom = async () => {
     const nickname = getNickname();
     if (!nickname) {
@@ -66,6 +117,11 @@ export default function FriendCreatePage() {
     setError(null);
 
     try {
+      if (!serverSyncEnabled) {
+        createLocalRoom(nickname);
+        return;
+      }
+
       const payload = {
         roomSize: Number(settings.roomSize),
         nickname,
@@ -93,14 +149,10 @@ export default function FriendCreatePage() {
         } catch {}
         router.push(`/friend/room/${data.roomId}`);
       } else {
-        const reason = data?.reason || "unknown-error";
-        const detail = data?.detail ? ` (${data.detail})` : "";
-        setError(`ルーム作成に失敗しました: ${reason}${detail}`);
+        setError(roomFailureMessage(data?.reason, data?.detail));
       }
     } catch (e: unknown) {
-      const message = e instanceof Error ? e.message : String(e);
-      const msg = message ? ` (${message})` : "";
-      setError(`作成に失敗しました${msg}`);
+      setError(backendFailureMessage(e));
     } finally {
       setIsCreating(false);
     }

--- a/apps/hub/app/friend/join/page.tsx
+++ b/apps/hub/app/friend/join/page.tsx
@@ -1,14 +1,16 @@
 'use client';
 
+import { apiJson, ApiRequestError } from "@/lib/api";
 import { getNickname } from "@/lib/profile";
-import { upsertLocalRoom } from "@/lib/roomSystemUnified";
+import { getRoom, joinRoom, upsertLocalRoom } from "@/lib/roomSystemUnified";
+import { USE_SERVER_SYNC } from "@/lib/serverSync";
 import type { Room, RoomResponse } from "@/types/room";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import { apiJson } from "@/lib/api";
 
 export default function FriendJoinPage() {
   const router = useRouter();
+  const serverSyncEnabled = USE_SERVER_SYNC;
   const [roomCode, setRoomCode] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [isJoining, setIsJoining] = useState(false);
@@ -16,6 +18,55 @@ export default function FriendJoinPage() {
   useEffect(() => {
     document.title = 'ルーム参加 | Five Cucumber';
   }, []);
+
+  const joinFailureMessage = (reason?: string) => {
+    switch (reason) {
+      case 'not-found':
+        return serverSyncEnabled
+          ? 'ルーム番号が違います'
+          : 'この端末にローカルルームが見つかりません。別端末の友達と遊ぶにはサーバー同期設定が必要です。';
+      case 'full':
+        return 'この部屋はすでに定員です';
+      case 'locked':
+      case 'busy':
+        return '対戦中のため入室できません';
+      case 'expired':
+        return '部屋の有効期限が切れました';
+      case 'bad-request':
+        return 'ルーム番号の形式が正しくありません';
+      case 'no-shared-store':
+        return 'フレンド対戦のサーバー同期に必要な共有ストアが未設定です。ローカル確認ではサーバー同期をOFFにしてください。';
+      default:
+        return '参加に失敗しました';
+    }
+  };
+
+  const backendFailureMessage = (err: unknown) => {
+    if (err instanceof ApiRequestError) {
+      const body = err.response.data as RoomResponse | { reason?: string } | undefined;
+      if (err.response.status === 401) {
+        return 'サーバー同期に必要な認証設定が不足しています。フレンド対戦を公開環境で使うにはFirebase Admin設定が必要です。';
+      }
+      return joinFailureMessage(body?.reason);
+    }
+
+    const message = err instanceof Error ? err.message : String(err);
+    return `ネットワークエラーが発生しました${message ? ` (${message})` : ''}`;
+  };
+
+  const joinLocalRoom = (trimmedRoomCode: string, nickname: string) => {
+    const result = joinRoom(trimmedRoomCode, nickname);
+    if (!result.success || !result.roomId) {
+      setError(joinFailureMessage(result.reason));
+      return;
+    }
+
+    const localRoom = getRoom(result.roomId);
+    if (localRoom) {
+      upsertLocalRoom(localRoom);
+    }
+    router.push(`/friend/room/${result.roomId}`);
+  };
 
   const handleJoinRoom = async () => {
     const nickname = getNickname();
@@ -29,13 +80,20 @@ export default function FriendJoinPage() {
       return;
     }
 
+    const trimmedRoomCode = roomCode.trim();
+
     setIsJoining(true);
     setError(null);
 
     try {
+      if (!serverSyncEnabled) {
+        joinLocalRoom(trimmedRoomCode, nickname);
+        return;
+      }
+
       const data = await apiJson<RoomResponse>('/friend/join', {
         method: 'POST',
-        json: { roomId: roomCode.trim(), nickname },
+        json: { roomId: trimmedRoomCode, nickname },
       });
       if (data.ok && data.roomId) {
         try {
@@ -62,32 +120,10 @@ export default function FriendJoinPage() {
         } catch {}
         router.push(`/friend/room/${data.roomId}`);
       } else {
-        const reason = data.reason ?? 'unknown';
-        switch (reason) {
-          case 'not-found':
-            setError('ルーム番号が違います');
-            break;
-          case 'full':
-            setError('この部屋はすでに定員です');
-            break;
-          case 'locked':
-          case 'busy':
-            setError('対戦中のため入室できません');
-            break;
-          case 'expired':
-            setError('部屋の有効期限が切れました');
-            break;
-          case 'bad-request':
-            setError('ルーム番号の形式が正しくありません');
-            break;
-          default:
-            setError('参加に失敗しました');
-            break;
-        }
+        setError(joinFailureMessage(data.reason));
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      setError(`ネットワークエラーが発生しました${message ? ` (${message})` : ''}`);
+      setError(backendFailureMessage(err));
     } finally {
       setIsJoining(false);
     }

--- a/apps/hub/app/friend/room/[roomId]/page.tsx
+++ b/apps/hub/app/friend/room/[roomId]/page.tsx
@@ -219,6 +219,13 @@ export default function RoomWaitingPage() {
   const handleLeaveRoom = async () => {
     if (!nickname || !room) return;
     try {
+      if (!useServer) {
+        const { leaveRoom } = await import('@/lib/roomSystemUnified');
+        leaveRoom(roomId, nickname);
+        router.push('/home');
+        return;
+      }
+
       await apiJson<{ ok: boolean; reason?: string }>(`/friend/leave`, {
         method: 'POST',
         json: { roomId, nickname },
@@ -243,6 +250,11 @@ export default function RoomWaitingPage() {
       return;
     }
     try {
+      if (!useServer) {
+        setError('このローカルルームは待機画面の確認用です。別端末のフレンド対戦を開始するにはサーバー同期設定が必要です。');
+        return;
+      }
+
       await apiJson<{ ok: boolean }>(`/friend/status`, {
         method: 'POST',
         json: { roomId, status: 'playing' },

--- a/apps/hub/app/setup/page.tsx
+++ b/apps/hub/app/setup/page.tsx
@@ -18,6 +18,16 @@ interface DiagnosticInfo {
   };
 }
 
+interface RegisterResponse {
+  ok: boolean;
+  reason?: 'duplicate' | 'conflict' | 'length' | 'charset' | 'bad-request' | 'bad-nickname' | 'server-error';
+  error?: string;
+}
+
+function shouldUseLocalProfileFallback(status: number, reason?: string): boolean {
+  return status === 0 || status === 401 || status === 503 || status >= 500 || reason === 'server-error';
+}
+
 function SetupForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -64,20 +74,18 @@ function SetupForm() {
       return;
     }
 
-    // apiJsonを使用してサーバ側で重複チェック
+    const saveProfileAndContinue = () => {
+      setProfile({ nickname: r.value });
+      const returnTo = searchParams.get('returnTo');
+      router.replace(returnTo || '/home');
+    };
+
+    // サーバ側で重複チェックできる場合は行い、ローカル環境ではプロフィール保存を優先する
     try {
-      console.log('[setup] About to call API with:', r.value);
-      interface RegisterResponse {
-        ok: boolean;
-        reason?: 'duplicate' | 'length' | 'charset' | 'bad-request' | 'server-error';
-        error?: string;
-      }
-      
       const response = await apiJson<RegisterResponse>('/api/username/register', {
         method: 'POST',
         json: { name: r.value },
       });
-      console.log('[setup] API response:', response);
 
       // 診断情報を保存（成功時）
       setDiagnostic({
@@ -86,12 +94,7 @@ function SetupForm() {
         error: null
       });
 
-      // プロフィール保存
-      setProfile({ nickname: r.value });
-      
-      // 遷移
-      const returnTo = searchParams.get('returnTo');
-      router.replace(returnTo || '/home');
+      saveProfileAndContinue();
     } catch (err) {
       let status = 0;
       let body: unknown = null;
@@ -109,9 +112,15 @@ function SetupForm() {
         
         const response = body as { reason?: string; error?: string };
         const reason = response?.reason ?? (status >= 500 ? "server" : "network");
+
+        if (shouldUseLocalProfileFallback(status, reason)) {
+          saveProfileAndContinue();
+          return;
+        }
+
         const errorMsg = 
-          reason === "duplicate" ? "このユーザー名はすでにつかわれています" :
-          reason === "length"    ? "1〜8文字で入力してください" :
+          reason === "duplicate" || reason === "conflict" ? "このユーザー名はすでにつかわれています" :
+          reason === "length" || reason === "bad-nickname" ? "1〜8文字で入力してください" :
           reason === "charset"   ? "利用できない文字が含まれています" :
           reason === "server" || reason === "server-error"
             ? `登録に失敗しました（サーバエラー: ${response?.error || 'Unknown'}）` :
@@ -124,7 +133,8 @@ function SetupForm() {
           body: null,
           error: err instanceof Error ? err.message : 'Unknown error'
         });
-        setError("通信に失敗しました。電波状況を確認して再試行してください");
+        saveProfileAndContinue();
+        return;
       }
       setIsSubmitting(false);
     }
@@ -173,7 +183,7 @@ function SetupForm() {
       body: diagnostic?.body,
       error: diagnostic?.error,
       cookies: document.cookie.substring(0, 200),
-      profile: localStorage.getItem('profile'),
+      profile: localStorage.getItem('five-cucumber-profile'),
       networkTest: diagnostic?.networkTest,
       timestamp: Date.now(),
       nickname: nickname,
@@ -255,7 +265,7 @@ function SetupForm() {
               <div><strong>User Agent:</strong> {navigator.userAgent}</div>
               <div><strong>Online:</strong> {navigator.onLine ? 'Yes' : 'No'}</div>
               <div><strong>Cookies:</strong> {document.cookie.substring(0, 100)}...</div>
-              <div><strong>Profile:</strong> {localStorage.getItem('profile') || 'None'}</div>
+              <div><strong>Profile:</strong> {localStorage.getItem('five-cucumber-profile') || 'None'}</div>
               <div><strong>Current Input:</strong> "{nickname}" (length: {nickname.length})</div>
               <div><strong>Trimmed:</strong> "{nickname.trim()}" (length: {nickname.trim().length})</div>
             </div>

--- a/apps/hub/components/Header.tsx
+++ b/apps/hub/components/Header.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { getNickname } from '@/lib/profile';
+import { getNickname, PROFILE_UPDATED_EVENT } from '@/lib/profile';
 import { t } from '@/lib/i18n';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -20,8 +20,12 @@ export default function Header(){
     };
     
     window.addEventListener('storage', handleStorageChange);
-    return () => window.removeEventListener('storage', handleStorageChange);
-  }, []);
+    window.addEventListener(PROFILE_UPDATED_EVENT, handleStorageChange);
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+      window.removeEventListener(PROFILE_UPDATED_EVENT, handleStorageChange);
+    };
+  }, [pathname]);
 
   if (pathname?.startsWith('/home')) {
     return null;

--- a/apps/hub/components/ui/EllipseTable.tsx
+++ b/apps/hub/components/ui/EllipseTable.tsx
@@ -5,6 +5,8 @@ import { getCucumberIcons } from '@/lib/game-core/rules';
 import { layoutSeatsEllipse } from '@/lib/layoutEllipse';
 import { CSSProperties, useEffect } from 'react';
 
+const DEBUG_TABLE_LAYOUT = process.env.NEXT_PUBLIC_DEBUG_GAME === '1';
+
 interface EllipseTableProps {
   state: GameState;
   config: GameConfig;
@@ -52,7 +54,7 @@ export function EllipseTable({
 
   // デバッグログ（開発時のみ）
   useEffect(() => {
-    if (process.env.NODE_ENV === 'development') {
+    if (DEBUG_TABLE_LAYOUT) {
       console.log('[EllipseTable Debug]', {
         currentPlayerIndex,
         stateCurrentPlayer: state.currentPlayer,

--- a/apps/hub/lib/game-core/engine.ts
+++ b/apps/hub/lib/game-core/engine.ts
@@ -203,14 +203,6 @@ export function finalRound(state: GameState, config: GameConfig, rng: SeededRng)
   const { winner, penalty } = calculateFinalTrickPenalty(newState.trickCards, config);
 
   if (winner >= 0) {
-    console.log(
-      '[Engine-Cucumber] player:',
-      winner,
-      'adding:',
-      penalty,
-      'total:',
-      newState.players[winner].cucumbers + penalty
-    );
     newState.players[winner].cucumbers += penalty;
   }
 

--- a/apps/hub/lib/game-core/rules.ts
+++ b/apps/hub/lib/game-core/rules.ts
@@ -71,11 +71,8 @@ export function determineTrickWinner(trickCards: Move[]): number {
 
 // 最終トリックのペナルティ計算
 export function calculateFinalTrickPenalty(trickCards: Move[], _config: GameConfig): { winner: number; penalty: number } {
-  console.log('[Penalty] Input trickCards:', JSON.stringify(trickCards));
   const playedCards = trickCards.filter(tc => !tc.isDiscard);
-  console.log('[Penalty] playedCards (after filter):', JSON.stringify(playedCards));
   if (playedCards.length === 0) {
-    console.log('[Penalty] Result: winner=', -1, 'penalty=', 0);
     return { winner: -1, penalty: 0 };
   }
 
@@ -84,7 +81,6 @@ export function calculateFinalTrickPenalty(trickCards: Move[], _config: GameConf
 
   const allPlayedOne = playedCards.every(tc => tc.card === 1);
   if (allPlayedOne) {
-    console.log('[Penalty] Result: winner=', winner, 'penalty=', 0);
     return { winner, penalty: 0 };
   }
 
@@ -94,7 +90,6 @@ export function calculateFinalTrickPenalty(trickCards: Move[], _config: GameConf
     penalty *= 2;
   }
 
-  console.log('[Penalty] Result: winner=', winner, 'penalty=', penalty);
   return { winner, penalty };
 }
 

--- a/apps/hub/lib/profile.ts
+++ b/apps/hub/lib/profile.ts
@@ -5,6 +5,7 @@ export interface Profile {
 }
 
 const PROFILE_KEY = 'five-cucumber-profile';
+export const PROFILE_UPDATED_EVENT = 'five-cucumber-profile-updated';
 
 // 許容文字の正規表現（半角英数字、ひらがな、カタカナ、漢字）
 const ALLOWED_CHARS = /^[A-Za-z0-9\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]+$/;
@@ -47,6 +48,7 @@ export function setProfile(profile: Profile): void {
   
   try {
     localStorage.setItem(PROFILE_KEY, JSON.stringify(profile));
+    window.dispatchEvent(new Event(PROFILE_UPDATED_EVENT));
   } catch {
     // エラーは無視
   }
@@ -111,4 +113,5 @@ export function resetProfile(): void {
   if (typeof window === 'undefined') return;
   
   localStorage.removeItem(PROFILE_KEY);
+  window.dispatchEvent(new Event(PROFILE_UPDATED_EVENT));
 }

--- a/apps/hub/lib/roomSystemUnified.ts
+++ b/apps/hub/lib/roomSystemUnified.ts
@@ -2,6 +2,14 @@
 
 import { Room } from '@/types/room';
 
+const DEBUG_ROOM_SYSTEM = process.env.NEXT_PUBLIC_DEBUG_ROOMS === '1';
+
+function logRoomDebug(...args: unknown[]): void {
+  if (DEBUG_ROOM_SYSTEM) {
+    console.log(...args);
+  }
+}
+
 // サーバーサイド用メモリストレージ（グローバル）
 let serverRooms: Map<string, Room> | null = null;
 
@@ -12,8 +20,8 @@ export function getServerRoomsStorage(): Map<string, Room> {
   // グローバル変数が初期化されていない場合、必ず初期化する
   if (!serverRooms) {
     serverRooms = new Map();
-    console.log('[RoomSystem] Initialized server-side room storage');
-    console.log('[RoomSystem] Server rooms map created:', serverRooms);
+    logRoomDebug('[RoomSystem] Initialized server-side room storage');
+    logRoomDebug('[RoomSystem] Server rooms map created:', serverRooms);
   }
   return serverRooms;
 }
@@ -48,15 +56,15 @@ export function getRoomFromMemory(roomId: string): Room | null {
     throw new Error('This function is for server-side only');
   }
   const storage = getServerRoomsStorage();
-  console.log('[RoomSystem] Getting room from memory:', roomId);
-  console.log('[RoomSystem] Available rooms in memory:', Array.from(storage.keys()));
-  console.log('[RoomSystem] Storage size:', storage.size);
-  console.log('[RoomSystem] Storage object:', storage);
+  logRoomDebug('[RoomSystem] Getting room from memory:', roomId);
+  logRoomDebug('[RoomSystem] Available rooms in memory:', Array.from(storage.keys()));
+  logRoomDebug('[RoomSystem] Storage size:', storage.size);
+  logRoomDebug('[RoomSystem] Storage object:', storage);
 
   const room = storage.get(roomId);
-  console.log('[RoomSystem] Room found in memory:', room ? 'yes' : 'no');
+  logRoomDebug('[RoomSystem] Room found in memory:', room ? 'yes' : 'no');
   if (room) {
-    console.log('[RoomSystem] Room data:', JSON.stringify(room, null, 2));
+    logRoomDebug('[RoomSystem] Room data:', JSON.stringify(room, null, 2));
   }
 
   return room || null;
@@ -70,21 +78,21 @@ export function putRoomToMemory(room: Room): void {
     throw new Error('This function is for server-side only');
   }
   const storage = getServerRoomsStorage();
-  console.log('[RoomSystem] Saving room to memory:', room.id);
-  console.log('[RoomSystem] Room data:', JSON.stringify(room, null, 2));
-  console.log('[RoomSystem] Storage before save size:', storage.size);
-  console.log('[RoomSystem] Storage before save keys:', Array.from(storage.keys()));
+  logRoomDebug('[RoomSystem] Saving room to memory:', room.id);
+  logRoomDebug('[RoomSystem] Room data:', JSON.stringify(room, null, 2));
+  logRoomDebug('[RoomSystem] Storage before save size:', storage.size);
+  logRoomDebug('[RoomSystem] Storage before save keys:', Array.from(storage.keys()));
 
   storage.set(room.id, room);
-  console.log('[RoomSystem] Saved room to server memory:', room.id);
-  console.log('[RoomSystem] Current storage size:', storage.size);
-  console.log('[RoomSystem] Available rooms after save:', Array.from(storage.keys()));
+  logRoomDebug('[RoomSystem] Saved room to server memory:', room.id);
+  logRoomDebug('[RoomSystem] Current storage size:', storage.size);
+  logRoomDebug('[RoomSystem] Available rooms after save:', Array.from(storage.keys()));
 
   // デバッグ用: 保存されたルームの確認
   const savedRoom = storage.get(room.id);
-  console.log('[RoomSystem] Verification - saved room exists:', savedRoom ? 'yes' : 'no');
+  logRoomDebug('[RoomSystem] Verification - saved room exists:', savedRoom ? 'yes' : 'no');
   if (savedRoom) {
-    console.log('[RoomSystem] Verification - saved room data matches:', JSON.stringify(savedRoom) === JSON.stringify(room));
+    logRoomDebug('[RoomSystem] Verification - saved room data matches:', JSON.stringify(savedRoom) === JSON.stringify(room));
   }
 }
 
@@ -107,7 +115,7 @@ function getRoomsStorage(): Map<string, Room> {
   if (typeof window === 'undefined') {
     if (!serverRooms) {
       serverRooms = new Map();
-      console.log('[RoomSystem] Initialized server-side room storage');
+      logRoomDebug('[RoomSystem] Initialized server-side room storage');
     }
     return serverRooms;
   }
@@ -116,13 +124,13 @@ function getRoomsStorage(): Map<string, Room> {
   try {
     const stored = localStorage.getItem('five-cucumber-rooms-v2');
     if (!stored) {
-      console.log('[RoomSystem] No client-side room storage found');
+      logRoomDebug('[RoomSystem] No client-side room storage found');
       return new Map();
     }
     
     const roomsArray = JSON.parse(stored) as Array<[string, Room]>;
     const rooms = new Map(roomsArray);
-    console.log('[RoomSystem] Loaded client-side rooms:', rooms.size);
+    logRoomDebug('[RoomSystem] Loaded client-side rooms:', rooms.size);
     return rooms;
   } catch (error) {
     console.error('[RoomSystem] Failed to load client-side rooms:', error);
@@ -137,7 +145,7 @@ function saveRoomsToStorage(rooms: Map<string, Room>): void {
   // サーバーサイドはメモリに保存（既に参照で更新済み）
   if (typeof window === 'undefined') {
     serverRooms = rooms;
-    console.log('[RoomSystem] Saved server-side rooms:', rooms.size);
+    logRoomDebug('[RoomSystem] Saved server-side rooms:', rooms.size);
     return;
   }
   
@@ -145,7 +153,7 @@ function saveRoomsToStorage(rooms: Map<string, Room>): void {
   try {
     const roomsArray = Array.from(rooms.entries());
     localStorage.setItem('five-cucumber-rooms-v2', JSON.stringify(roomsArray));
-    console.log('[RoomSystem] Saved client-side rooms:', rooms.size);
+    logRoomDebug('[RoomSystem] Saved client-side rooms:', rooms.size);
   } catch (error) {
     console.error('[RoomSystem] Failed to save client-side rooms:', error);
   }
@@ -218,10 +226,10 @@ export function createRoom(roomSize: number, nickname: string, turnSeconds: numb
  */
 export function joinRoom(roomId: string, nickname: string): { success: boolean; roomId?: string; reason?: string } {
   try {
-    console.log(`[RoomSystem] Attempting to join room ${roomId} with nickname: ${nickname}`);
+    logRoomDebug(`[RoomSystem] Attempting to join room ${roomId} with nickname: ${nickname}`);
     
     if (!nickname || typeof nickname !== 'string' || !nickname.trim()) {
-      console.log('[RoomSystem] Invalid nickname provided');
+      logRoomDebug('[RoomSystem] Invalid nickname provided');
       return { success: false, reason: 'bad-request' };
     }
 
@@ -229,29 +237,29 @@ export function joinRoom(roomId: string, nickname: string): { success: boolean; 
     const room = rooms.get(roomId);
 
     if (!room) {
-      console.log(`[RoomSystem] Room ${roomId} not found`);
+      logRoomDebug(`[RoomSystem] Room ${roomId} not found`);
       return { success: false, reason: 'not-found' };
     }
 
     if (room.status !== 'waiting') {
-      console.log(`[RoomSystem] Room ${roomId} is not in waiting status: ${room.status}`);
+      logRoomDebug(`[RoomSystem] Room ${roomId} is not in waiting status: ${room.status}`);
       return { success: false, reason: 'locked' };
     }
 
     const trimmedNickname = nickname.trim();
-    console.log(`[RoomSystem] Room ${roomId} current seats:`, room.seats.map((s, i) => `${i}: ${s?.nickname || 'empty'}`));
+    logRoomDebug(`[RoomSystem] Room ${roomId} current seats:`, room.seats.map((s, i) => `${i}: ${s?.nickname || 'empty'}`));
 
     // 既に着席済み（同名）の場合はそのままOK（再入室）
     const existingIndex = room.seats.findIndex(s => s && s.nickname === trimmedNickname);
     if (existingIndex >= 0) {
-      console.log(`[RoomSystem] Player ${trimmedNickname} already in room at seat ${existingIndex}`);
+      logRoomDebug(`[RoomSystem] Player ${trimmedNickname} already in room at seat ${existingIndex}`);
       return { success: true, roomId };
     }
 
     // 空席検索して着席
     const emptyIndex = room.seats.findIndex(s => s === null);
     if (emptyIndex === -1) {
-      console.log(`[RoomSystem] Room ${roomId} is full`);
+      logRoomDebug(`[RoomSystem] Room ${roomId} is full`);
       return { success: false, reason: 'full' };
     }
 
@@ -259,7 +267,7 @@ export function joinRoom(roomId: string, nickname: string): { success: boolean; 
     rooms.set(roomId, room);
     saveRoomsToStorage(rooms);
 
-    console.log(`[RoomSystem] Player ${trimmedNickname} successfully joined room ${roomId} at seat ${emptyIndex}`);
+    logRoomDebug(`[RoomSystem] Player ${trimmedNickname} successfully joined room ${roomId} at seat ${emptyIndex}`);
     return { success: true, roomId };
   } catch (error) {
     console.error('Room join error:', error);

--- a/docs/local-playability.md
+++ b/docs/local-playability.md
@@ -1,0 +1,46 @@
+# Local Playability Baseline
+
+This document defines how the Web app should behave in a local development environment when Firebase Admin, KV, Redis, or Ably are not configured.
+
+## Backend-Free Local Flow
+
+The following routes must work without Firebase Admin or a shared store:
+
+- `/setup`
+- `/home`
+- `/cucumber/cpu/settings`
+- `/cucumber/cpu/play`
+
+`/setup` validates the nickname in the browser first. If the server-side username reservation is unavailable because authentication or backend configuration is missing, the app saves a local-only profile in `localStorage` and continues. Server-side duplicate-name protection only applies when the username registration API is fully configured.
+
+CPU play is a local mode. It must not require Firebase, KV, Redis, or Ably.
+
+## Friend Room Local Mode
+
+Friend rooms have two different behaviors:
+
+- Local room review mode
+- Server-synchronized friend match mode
+
+When `NEXT_PUBLIC_USE_SERVER` and `NEXT_PUBLIC_HAS_SHARED_STORE` are unset or false, friend room create/join pages use browser `localStorage`. This is only for checking room creation, room joining, and the waiting-room UI in one browser profile. It is not a real multi-device friend match.
+
+Starting an actual friend match requires server synchronization. In local room review mode, the waiting room should show a clear message instead of starting a broken match.
+
+## Server-Synchronized Friend Match Requirements
+
+For real friend-room play across users or devices, configure:
+
+- Firebase client environment variables for browser sign-in.
+- Firebase Admin credentials for server token verification.
+- KV or Redis shared store credentials.
+- `NEXT_PUBLIC_HAS_SHARED_STORE=true` or `NEXT_PUBLIC_USE_SERVER=true` when the client should use server synchronization.
+- Ably credentials if realtime room updates are expected.
+
+If server synchronization is enabled but authentication or shared-store settings are missing, the UI should say which backend requirement is missing instead of surfacing a generic network error.
+
+## Debug Output
+
+Normal local play should keep the browser console quiet. Verbose logs are opt-in:
+
+- `NEXT_PUBLIC_DEBUG_GAME=1` enables CPU game debug logs.
+- `NEXT_PUBLIC_DEBUG_ROOMS=1` enables room-system debug logs.


### PR DESCRIPTION
## Summary
- Allow `/setup` to continue with a local-only profile when server username registration is unavailable locally.
- Add localStorage-based friend room review behavior when server sync is disabled, with clearer backend requirement messages when sync is enabled but misconfigured.
- Gate noisy CPU/room debug logs behind explicit debug env flags and document local playability behavior.

## Validation
- `git diff --cached --check`
- `pnpm --filter @five-cucumber/hub test` (30 passed)
- `pnpm -w run type-check`
- Headless Chrome CDP smoke: `/setup?returnTo=/cucumber/cpu/settings` -> CPU settings -> `/cucumber/cpu/play`, local profile persisted and header showed nickname.