### PR TITLE
Phase 2: CPU match MVP (2026-05-17 17:01 JST)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -54,12 +54,11 @@ See `docs/work-plan.md` for details.
 
 ## Near-Term Priority
 
-Finish Phase 0, then stop for user review before starting Phase 1.
+Complete the Phase 2 review gate, then start Phase 3 Friend Match MVP only after user confirmation.
 
 ## Open Decisions
 
 - Define the exact review checklist for "Web version complete."
-- Decide local behavior when Firebase Admin or KV is missing.
 - Decide whether legacy generic `/play/[gameId]` and `/lobby/[gameId]` routes should be redirected, removed, or revived later.
 - Decide whether UI should formally adopt Tailwind or move away from Tailwind-style utility classes.
 - Decide whether future Blender use is asset-generation only or part of a larger 3D workflow.

--- a/apps/hub/app/cucumber/cpu/play/game.css
+++ b/apps/hub/app/cucumber/cpu/play/game.css
@@ -529,16 +529,30 @@
   color: #ff6b6b;
 }
 
-.game-over-overlay__home {
+.game-over-overlay__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
   margin-top: 2rem;
+}
+
+.game-over-overlay__home {
   padding: 1rem 3rem;
   font-size: 1.2rem;
   font-weight: 700;
   color: white;
   background: linear-gradient(to bottom, #4ade80, #16a34a);
   border-radius: 12px;
+  border: 0;
   text-decoration: none;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+}
+
+.game-over-overlay__home--secondary {
+  background: rgba(255, 255, 255, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.38);
 }
 
 /* --- カードアニメーション --- */

--- a/apps/hub/app/cucumber/cpu/play/page.tsx
+++ b/apps/hub/app/cucumber/cpu/play/page.tsx
@@ -70,6 +70,13 @@ function CpuPlayContent() {
   const scheduleCpuTurnRef = useRef<(() => void) | null>(null);
   const playCpuTurnRef = useRef<(() => Promise<void>) | null>(null);
 
+  const clearFinalTrickTimers = useCallback(() => {
+    for (const timer of finalTrickTimeoutsRef.current) {
+      clearTimeout(timer);
+    }
+    finalTrickTimeoutsRef.current = [];
+  }, []);
+
   // ゲーム状態の保存キー
   const getGameStateKey = useCallback((params: URLSearchParams) => {
     const players = params.get('players') || '4';
@@ -386,6 +393,10 @@ function CpuPlayContent() {
       const maxCucumbers = gameRef.current?.config.maxCucumbers ?? 6;
       const hasEliminated = state.players.some(player => player.cucumbers >= maxCucumbers);
       if (hasEliminated) {
+        const gameStateKey = getGameStateKey(searchParams);
+        localStorage.removeItem(gameStateKey);
+        clearFinalTrickTimers();
+
         const results = state.players
           .map((player, index) => ({
             name: index === 0 ? 'あなた' : `CPU ${index}`,
@@ -397,12 +408,16 @@ function CpuPlayContent() {
         setGameOver(true);
         setFinalTrickStarted(false);
         setIsAnimating(false);
+        setIsSubmitting(false);
+        setIsCardLocked(false);
+        setLockedCardId(null);
+        setOverlayText(null);
         return;
       }
 
       startNextRound(state);
     },
-    [startNextRound]
+    [clearFinalTrickTimers, getGameStateKey, searchParams, startNextRound]
   );
 
   const playMove = async (player: number, card: number) => {
@@ -785,18 +800,22 @@ function CpuPlayContent() {
 
   useEffect(() => {
     return () => {
-      for (const timer of finalTrickTimeoutsRef.current) {
-        clearTimeout(timer);
-      }
-      finalTrickTimeoutsRef.current = [];
+      clearFinalTrickTimers();
     };
-  }, []);
+  }, [clearFinalTrickTimers]);
 
   const handleBackToHome = () => {
     // ゲーム状態をクリア
+    clearFinalTrickTimers();
     const gameStateKey = getGameStateKey(searchParams);
     localStorage.removeItem(gameStateKey);
     router.push('/home');
+  };
+
+  const handleRestartGame = () => {
+    clearFinalTrickTimers();
+    clearCpuGameState();
+    void startGame();
   };
 
   if (!gameState) {
@@ -926,9 +945,22 @@ function CpuPlayContent() {
               ))}
             </div>
 
-            <a className="game-over-overlay__home" href="/home" onClick={handleBackToHome}>
-              ホームへ戻る
-            </a>
+            <div className="game-over-overlay__actions">
+              <button
+                type="button"
+                className="game-over-overlay__home"
+                onClick={handleRestartGame}
+              >
+                もう一度遊ぶ
+              </button>
+              <button
+                type="button"
+                className="game-over-overlay__home game-over-overlay__home--secondary"
+                onClick={handleBackToHome}
+              >
+                ホームへ戻る
+              </button>
+            </div>
           </div>
         ) : null}
       </BattleLayout>

--- a/apps/hub/lib/controllers/cpu.ts
+++ b/apps/hub/lib/controllers/cpu.ts
@@ -1,7 +1,13 @@
 // CPUプレイヤーのコントローラー（難易度別実装）
 
 import { SeededRng } from '../game-core/rng';
-import { estimateRemainingCards, getCucumberCount, getLegalMoves } from '../game-core/rules';
+import {
+  calculateFinalTrickPenalty,
+  determineTrickWinner,
+  estimateRemainingCards,
+  getCucumberCount,
+  getLegalMoves,
+} from '../game-core/rules';
 import { GameState, GameView, SimulationResult } from '../game-core/types';
 import { BaseController } from './base';
 
@@ -152,6 +158,7 @@ export class CpuController extends BaseController {
     const state = JSON.parse(JSON.stringify(view.state)) as GameState;
     const hand = state.players[this.playerIndex].hand;
     const moveIndex = hand.indexOf(initialMove);
+    let actionCount = state.actionCount ?? 0;
     
     if (moveIndex === -1) {
       return { finalCucumbers: [], winner: -1, penalty: 0 };
@@ -159,13 +166,15 @@ export class CpuController extends BaseController {
     
     // 初期手を適用
     hand.splice(moveIndex, 1);
-    state.trickCards.push({ player: this.playerIndex, card: initialMove, timestamp: Date.now() });
-    
-    if (state.fieldCard === null || initialMove >= state.fieldCard) {
-      state.fieldCard = initialMove;
-    } else {
+    const isInitialDiscard = state.fieldCard !== null && initialMove < state.fieldCard;
+    actionCount++;
+
+    if (isInitialDiscard) {
       state.players[this.playerIndex].graveyard.push(initialMove);
       state.sharedGraveyard.push(initialMove);
+    } else {
+      state.trickCards.push({ player: this.playerIndex, card: initialMove, timestamp: Date.now() });
+      state.fieldCard = initialMove;
     }
     
     // 残りのゲームをシミュレーション
@@ -200,28 +209,30 @@ export class CpuController extends BaseController {
       // 手を適用
       const cardIndex = cpuHand.indexOf(selectedMove);
       cpuHand.splice(cardIndex, 1);
-      state.trickCards.push({ player: currentPlayer, card: selectedMove, timestamp: Date.now() });
-      
-      if (state.fieldCard === null || selectedMove >= state.fieldCard) {
-        state.fieldCard = selectedMove;
-      } else {
+      const isDiscard = state.fieldCard !== null && selectedMove < state.fieldCard;
+      actionCount++;
+
+      if (isDiscard) {
         state.players[currentPlayer].graveyard.push(selectedMove);
         state.sharedGraveyard.push(selectedMove);
+      } else {
+        state.trickCards.push({ player: currentPlayer, card: selectedMove, timestamp: Date.now() });
+        state.fieldCard = selectedMove;
       }
       
       currentPlayer = (currentPlayer + 1) % state.players.length;
       
       // トリック完了チェック
-      if (state.trickCards.length === state.players.length) {
-        const maxCard = Math.max(...state.trickCards.map(tc => tc.card));
-        const winners = state.trickCards.filter(tc => tc.card === maxCard);
-        const winner = winners[winners.length - 1].player;
+      if (actionCount >= state.players.length) {
+        const winner = determineTrickWinner(state.trickCards);
+        if (winner < 0) break;
         
         state.currentPlayer = winner;
         state.firstPlayer = winner;
         state.currentTrick++;
         state.fieldCard = null;
         state.trickCards = [];
+        actionCount = 0;
         currentPlayer = winner;
         trickCount++;
       }
@@ -229,13 +240,7 @@ export class CpuController extends BaseController {
     
     // 最終トリックのペナルティ計算
     if (state.trickCards.length > 0) {
-      const maxCard = Math.max(...state.trickCards.map(tc => tc.card));
-      const hasOne = state.trickCards.some(tc => tc.card === 1);
-      const winners = state.trickCards.filter(tc => tc.card === maxCard);
-      const winner = winners[winners.length - 1].player;
-      
-      let penalty = getCucumberCount(maxCard);
-      if (hasOne) penalty *= 2;
+      const { winner, penalty } = calculateFinalTrickPenalty(state.trickCards, view.config);
       
       if (winner === this.playerIndex) {
         return { 

--- a/apps/hub/lib/game-core/__tests__/engine.test.ts
+++ b/apps/hub/lib/game-core/__tests__/engine.test.ts
@@ -327,6 +327,43 @@ describe('トリック完了', () => {
 });
 
 describe('1ゲーム完走', () => {
+  it.each([2, 3, 4, 5, 6])('%i人対戦の初期状態を作成できる', players => {
+    const rng = new SeededRng(players * 100);
+    const playerConfig: GameConfig = { ...config, players };
+    const state = createInitialState(playerConfig, rng);
+
+    expect(state.players).toHaveLength(players);
+    expect(state.players.every(player => player.hand.length === 7)).toBe(true);
+    expect(state.remainingCards).toHaveLength(105 - players * 7);
+    expect(state.currentPlayer).toBeGreaterThanOrEqual(0);
+    expect(state.currentPlayer).toBeLessThan(players);
+  });
+
+  it.each([2, 3, 4, 5, 6])('%i人対戦で7トリックの1ラウンドを完走できる', players => {
+    const rng = new SeededRng(players * 1000);
+    const playerConfig: GameConfig = {
+      ...config,
+      players,
+      initialCards: 7,
+      maxCucumbers: 999,
+    };
+    let state = createInitialState(playerConfig, rng);
+
+    for (let i = 0; i < playerConfig.initialCards * playerConfig.players; i++) {
+      const player = state.currentPlayer;
+      const legalMoves = getLegalMoves(state, player);
+      const card = Math.min(...legalMoves);
+      const isDiscard = !state.isFinalTrick && state.fieldCard !== null && card < state.fieldCard;
+      const result = applyMove(state, { player, card, isDiscard, timestamp: i }, playerConfig, rng);
+      expect(result.success).toBe(true);
+      state = result.newState;
+    }
+
+    expect(state.currentRound).toBe(2);
+    expect(state.players).toHaveLength(players);
+    expect(state.players.every(player => player.hand.length === 7)).toBe(true);
+  });
+
   it('7トリック完了後にラウンドが終了する', () => {
     const rng = new SeededRng(42);
     const longConfig: GameConfig = { ...config, initialCards: 7, maxCucumbers: 999 };

--- a/apps/hub/lib/game-core/__tests__/rules.test.ts
+++ b/apps/hub/lib/game-core/__tests__/rules.test.ts
@@ -64,6 +64,26 @@ describe('determineTrickWinner', () => {
 
     expect(determineTrickWinner(trick)).toBe(3);
   });
+
+  it('捨てカードは勝者判定に参加しない', () => {
+    const trick: Move[] = [
+      { player: 0, card: 14, timestamp: 1 },
+      { player: 1, card: 15, timestamp: 2, isDiscard: true },
+      { player: 2, card: 11, timestamp: 3 },
+      { player: 3, card: 14, timestamp: 4 },
+    ];
+
+    expect(determineTrickWinner(trick)).toBe(3);
+  });
+
+  it('勝者判定対象がない場合は-1を返す', () => {
+    const trick: Move[] = [
+      { player: 0, card: 1, timestamp: 1, isDiscard: true },
+      { player: 1, card: 2, timestamp: 2, isDiscard: true },
+    ];
+
+    expect(determineTrickWinner(trick)).toBe(-1);
+  });
 });
 
 describe('getLegalMoves', () => {
@@ -92,6 +112,33 @@ describe('getLegalMoves', () => {
     };
 
     expect(getLegalMoves(state, 0)).toEqual([2, 5]);
+  });
+
+  it('場のカードがある場合は場以上のカードと手札の最小カードを返す', () => {
+    const state = {
+      players: [
+        { hand: [1, 9, 12], cucumbers: 0, graveyard: [] },
+        { hand: [3], cucumbers: 0, graveyard: [] },
+        { hand: [4], cucumbers: 0, graveyard: [] },
+        { hand: [6], cucumbers: 0, graveyard: [] },
+      ],
+      currentPlayer: 0,
+      currentRound: 1,
+      currentTrick: 2,
+      fieldCard: 10,
+      sharedGraveyard: [],
+      trickCards: [],
+      actionCount: 0,
+      firstPlayer: 0,
+      isGameOver: false,
+      gameOverPlayers: [],
+      remainingCards: [],
+      cardCounts: [],
+      phase: 'AwaitMove' as const,
+      isFinalTrick: false,
+    };
+
+    expect(getLegalMoves(state, 0)).toEqual([12, 1]);
   });
 });
 

--- a/apps/hub/lib/game-core/rules.ts
+++ b/apps/hub/lib/game-core/rules.ts
@@ -53,20 +53,21 @@ export function getLegalMoves(state: GameState, player: number): number[] {
 
 // トリックの勝者を決定
 export function determineTrickWinner(trickCards: Move[]): number {
-  if (trickCards.length === 0) return -1;
+  const playedCards = trickCards.filter(trickCard => !trickCard.isDiscard);
+  if (playedCards.length === 0) return -1;
 
   let winnerIndex = 0;
-  let highestValue = trickCards[0].card;
+  let highestValue = playedCards[0].card;
 
-  for (let i = 1; i < trickCards.length; i++) {
+  for (let i = 1; i < playedCards.length; i++) {
     // 同値の場合は後から出したカードを勝者として上書きする
-    if (trickCards[i].card >= highestValue) {
-      highestValue = trickCards[i].card;
+    if (playedCards[i].card >= highestValue) {
+      highestValue = playedCards[i].card;
       winnerIndex = i;
     }
   }
 
-  return trickCards[winnerIndex].player;
+  return playedCards[winnerIndex].player;
 }
 
 // 最終トリックのペナルティ計算

--- a/apps/hub/lib/modes/cpu/__tests__/createTable.test.ts
+++ b/apps/hub/lib/modes/cpu/__tests__/createTable.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { createCpuTable, createCpuTableFromUrlParams } from '../createTable';
+
+describe('createCpuTable', () => {
+  it.each([2, 3, 4, 5, 6])('%i人分のコントローラーを作成する', players => {
+    const table = createCpuTable({
+      players,
+      turnSeconds: 15,
+      maxCucumbers: 5,
+      initialCards: 7,
+      cpuLevel: 'normal',
+      seed: 123,
+    });
+
+    expect(table.config.players).toBe(players);
+    expect(table.controllers).toHaveLength(players);
+    expect(table.controllers[0]).toBe(table.humanController);
+  });
+
+  it('URLパラメータの範囲外プレイヤー数を2〜6人に丸める', () => {
+    const tooFew = createCpuTableFromUrlParams(new URLSearchParams('players=1'));
+    const tooMany = createCpuTableFromUrlParams(new URLSearchParams('players=9'));
+
+    expect(tooFew.config.players).toBe(2);
+    expect(tooFew.controllers).toHaveLength(2);
+    expect(tooMany.config.players).toBe(6);
+    expect(tooMany.controllers).toHaveLength(6);
+  });
+
+  it('不正なCPU難易度はnormalに戻す', () => {
+    const table = createCpuTableFromUrlParams(new URLSearchParams('cpuLevel=expert'));
+
+    expect(table.config.cpuLevel).toBe('normal');
+  });
+});

--- a/apps/hub/lib/modes/cpu/createTable.ts
+++ b/apps/hub/lib/modes/cpu/createTable.ts
@@ -19,12 +19,21 @@ export interface CpuTable {
   humanController: HumanController;
 }
 
+function clampNumber(value: number, min: number, max: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, value));
+}
+
+function parseCpuLevel(value: string | null): 'easy' | 'normal' | 'hard' {
+  return value === 'easy' || value === 'normal' || value === 'hard' ? value : 'normal';
+}
+
 export function createCpuTable(tableConfig: CpuTableConfig): CpuTable {
   const config: GameConfig = {
-    players: tableConfig.players,
+    players: clampNumber(tableConfig.players, 2, 6, 4),
     turnSeconds: tableConfig.turnSeconds,
-    maxCucumbers: tableConfig.maxCucumbers,
-    initialCards: tableConfig.initialCards,
+    maxCucumbers: clampNumber(tableConfig.maxCucumbers, 4, 10, 5),
+    initialCards: clampNumber(tableConfig.initialCards, 1, 7, 7),
     cpuLevel: tableConfig.cpuLevel,
     seed: tableConfig.seed
   };
@@ -34,7 +43,7 @@ export function createCpuTable(tableConfig: CpuTableConfig): CpuTable {
   controllers[0] = humanController;
 
   // CPUコントローラーを作成
-  for (let i = 1; i < tableConfig.players; i++) {
+  for (let i = 1; i < config.players; i++) {
     const cpuController = new CpuController(i, tableConfig.cpuLevel, tableConfig.seed);
     controllers[i] = cpuController;
   }
@@ -52,7 +61,7 @@ export function createCpuTableFromUrlParams(params: URLSearchParams): CpuTable {
     turnSeconds: parseInt(params.get('turnSeconds') || '15') || null,
     maxCucumbers: parseInt(params.get('maxCucumbers') || '6'),
     initialCards: 7,
-    cpuLevel: (params.get('cpuLevel') as 'easy' | 'normal' | 'hard') || 'normal',
+    cpuLevel: parseCpuLevel(params.get('cpuLevel')),
     seed: parseInt(params.get('seed') || '0') || undefined
   };
 

--- a/apps/hub/vitest.config.ts
+++ b/apps/hub/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['lib/game-core/__tests__/**/*.test.ts'],
+    include: [
+      'lib/game-core/__tests__/**/*.test.ts',
+      'lib/modes/**/__tests__/**/*.test.ts',
+    ],
   },
 });


### PR DESCRIPTION
## Summary
- Hardened CPU table creation by clamping player/card/cucumber settings and validating CPU level URL params.
- Fixed discard handling in trick winner logic and aligned hard CPU rollout simulation with shared rule helpers.
- Added CPU game-over cleanup/restart actions and refreshed the near-term plan for the Phase 2 review gate.
- Expanded tests for 2-6 player setup, seven-trick round progression, discard winner behavior, and CPU table URL config.

## Validation
- `pnpm --filter @five-cucumber/hub test` (50 tests passing)
- `pnpm --filter @five-cucumber/hub type-check`
- `pnpm -w run type-check`
- `pnpm -w run build`
- `git diff --check`
- Browser smoke on `http://127.0.0.1:3000/cucumber/cpu/play` for `players=2` and `players=6`; CPU labels rendered and no browser error logs observed.

Notes: the existing functions package still warns that it expects Node 18 while the current environment is Node v22.16.0; build also keeps the existing Ably/got/keyv dynamic dependency warning.