### PR TITLE
Phase 3: Friend match MVP (2026-05-17 18:13 JST)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -23,6 +23,7 @@ Unity and Blender remain deferred. Do not add Unity or Blender files during ordi
 - `docs/product-spec.md`
 - `docs/work-plan.md`
 - `docs/rules/cucumber5.md`
+- `docs/friend-match-sync.md`
 - `docs/deprecated-docs.md`
 - `AGENTS.md`
 - `AI_RULES.md`
@@ -54,7 +55,7 @@ See `docs/work-plan.md` for details.
 
 ## Near-Term Priority
 
-Complete the Phase 2 review gate, then start Phase 3 Friend Match MVP only after user confirmation.
+Finish Phase 3 Friend Match MVP, then stop for user review before starting Phase 4.
 
 ## Open Decisions
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Use these documents as the current source of truth:
 - `docs/product-spec.md` - current product specification
 - `docs/work-plan.md` - implementation phases and task order
 - `docs/rules/cucumber5.md` - game rule specification
+- `docs/friend-match-sync.md` - friend-room synchronization strategy
 - `docs/local-playability.md` - local backend fallback and server-sync behavior
 
 Older investigation notes, legacy flow descriptions, and `.docx` proposal files remain as historical reference only. When they conflict with the canonical docs above, follow the canonical docs.

--- a/apps/hub/app/api/friend/create/route.ts
+++ b/apps/hub/app/api/friend/create/route.ts
@@ -2,6 +2,11 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 import { kvExists, kvSaveJSON, roomTTL } from '@/lib/kv';
+import {
+  createFriendRoom,
+  normalizeFriendRoomSettings,
+  normalizeNickname,
+} from '@/lib/friend-room';
 import { CreateRoomRequest, Room } from '@/types/room';
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyAuth } from '@/lib/auth';
@@ -39,6 +44,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     }
 
     const { roomSize, nickname, turnSeconds, maxCucumbers } = body;
+    const trimmedNickname = normalizeNickname(nickname);
 
     // 数値フィールドの正規化
     const nRoomSize = parseNumberish(roomSize);
@@ -76,7 +82,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     }
 
     // バリデーション
-    if (!nickname || typeof nickname !== 'string' || !nickname.trim()) {
+    if (!trimmedNickname) {
       return NextResponse.json(
         { ok: false, reason: 'bad-request' },
         { status: 400, headers: noStore }
@@ -132,16 +138,16 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         { status: 500, headers: noStore }
       );
     }
-    const room: Room = {
-      id,
-      size: nRoomSize,
-      seats: Array.from({ length: nRoomSize }, () => null),
-      status: 'waiting',
-      createdAt: Date.now(),
+    const settings = normalizeFriendRoomSettings({
+      roomSize: nRoomSize,
       turnSeconds: nTurnSeconds,
       maxCucumbers: nMaxCucumbers,
-    };
-    room.seats[0] = { nickname: nickname.trim() };
+    });
+    const room: Room = createFriendRoom({
+      id,
+      nickname: trimmedNickname,
+      ...settings,
+    });
 
     const roomId = String(room.id ?? id);
     const key = `friend:room:${roomId}`;

--- a/apps/hub/app/api/friend/game/[roomId]/route.ts
+++ b/apps/hub/app/api/friend/game/[roomId]/route.ts
@@ -4,6 +4,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { json } from '@/lib/http';
 import { verifyAuth } from '@/lib/auth';
 import { withLock } from '@/lib/lock';
+import { countJoinedPlayers, getSeatIndex, isRoomHost, normalizeNickname, normalizeRoomId } from '@/lib/friend-room';
+import { kvGetJSON } from '@/lib/kv';
+import type { Room } from '@/types/room';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -11,12 +14,14 @@ export const revalidate = 0;
 
 type GameInitBody = {
   type: 'init';
+  nickname?: unknown;
   state: GameState;
   config: GameConfig;
 };
 
 type GameMoveBody = {
   type: 'move';
+  nickname?: unknown;
   move: Move;
 };
 
@@ -30,8 +35,12 @@ export async function GET(
   const auth = await verifyAuth(req);
   if (!auth) return json({ error: 'Unauthorized' }, 401);
   try {
-    const roomId = params.roomId;
-    if (!roomId) return json({ ok: false, reason: 'bad-request' }, 400);
+    const roomId = normalizeRoomId(params.roomId);
+    const nickname = normalizeNickname(req.nextUrl.searchParams.get('nickname'));
+    if (roomId.length !== 6 || !nickname) return json({ ok: false, reason: 'bad-request' }, 400);
+    const room = await kvGetJSON<Room>(`friend:room:${roomId}`);
+    if (!room) return json({ ok: false, reason: 'room-not-found' }, 404);
+    if (getSeatIndex(room, nickname) < 0) return json({ ok: false, reason: 'not-member' }, 403);
     const snap = await getGame(roomId);
     if (!snap) return json({ ok: false, reason: 'not-found' }, 404);
     return json({ ok: true, snapshot: snap }, 200);
@@ -49,8 +58,8 @@ export async function POST(
   const auth = await verifyAuth(req);
   if (!auth) return json({ error: 'Unauthorized' }, 401);
   try {
-    const roomId = params.roomId;
-    if (!roomId) return json({ ok: false, reason: 'bad-request' }, 400);
+    const roomId = normalizeRoomId(params.roomId);
+    if (roomId.length !== 6) return json({ ok: false, reason: 'bad-request' }, 400);
     
     let body: unknown;
     try {
@@ -64,11 +73,24 @@ export async function POST(
     }
     
     const requestBody = body as Partial<GameRequestBody>;
+    const nickname = normalizeNickname(requestBody.nickname);
+    if (!nickname) return json({ ok: false, reason: 'bad-request' }, 400);
+
+    const room = await kvGetJSON<Room>(`friend:room:${roomId}`);
+    if (!room) return json({ ok: false, reason: 'room-not-found' }, 404);
+    const actorSeatIndex = getSeatIndex(room, nickname);
+    if (actorSeatIndex < 0) return json({ ok: false, reason: 'not-member' }, 403);
     
     if (requestBody.type === 'init') {
       const { state, config } = requestBody;
       if (!state || !config || typeof state !== 'object' || typeof config !== 'object') {
         return json({ ok: false, reason: 'bad-request' }, 400);
+      }
+      if (!isRoomHost(room, nickname)) {
+        return json({ ok: false, reason: 'host-only' }, 403);
+      }
+      if (room.status !== 'playing' || countJoinedPlayers(room) !== room.size) {
+        return json({ ok: false, reason: 'room-not-ready' }, 409);
       }
       const snap = await initGame(roomId, { state: state as GameState, config: config as GameConfig });
       return json({ ok: true, snapshot: snap }, 200);
@@ -79,10 +101,17 @@ export async function POST(
       if (!move || typeof move !== 'object') {
         return json({ ok: false, reason: 'bad-request' }, 400);
       }
+      const candidateMove = move as Move;
+      if (room.status !== 'playing') {
+        return json({ ok: false, reason: 'room-not-playing' }, 409);
+      }
+      if (candidateMove.player !== actorSeatIndex) {
+        return json({ ok: false, reason: 'player-mismatch' }, 403);
+      }
       try {
         const snap = await withLock(
           `game:${roomId}`,
-          () => applyServerMove(roomId, move as Move),
+          () => applyServerMove(roomId, candidateMove),
           { ttlMs: 5000, retry: 2, retryDelayMs: 100 },
         );
         if (!snap) return json({ ok: false, reason: 'not-found' }, 404);

--- a/apps/hub/app/api/friend/join/route.ts
+++ b/apps/hub/app/api/friend/join/route.ts
@@ -5,6 +5,7 @@ export const revalidate = 0;
 import { kvGetJSON, kvSaveJSON, roomTTL } from '@/lib/kv';
 import { withLock } from '@/lib/lock';
 import { realtime } from '@/lib/realtime';
+import { joinRoomSnapshot, normalizeNickname, normalizeRoomId } from '@/lib/friend-room';
 import { Room, RoomSeat } from '@/types/room';
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyAuth } from '@/lib/auth';
@@ -27,34 +28,23 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
   try {
     const raw = (await req.json()) as JoinRoomPayload;
-    const nicknameInput = typeof raw.nickname === 'string' ? raw.nickname.trim() : '';
+    const nicknameInput = normalizeNickname(raw.nickname);
     const roomIdCandidate = raw.roomId ?? raw.code ?? raw.roomCode;
-    const roomId = roomIdCandidate === undefined || roomIdCandidate === null ? '' : String(roomIdCandidate).trim();
+    const roomId = normalizeRoomId(roomIdCandidate);
 
-    if (!nicknameInput || !roomId) {
+    if (!nicknameInput || roomId.length !== 6) {
       return NextResponse.json({ ok: false, reason: 'bad-request' }, { status: 400, headers: noStore });
     }
 
     const { room, status } = await withLock(`friend-room:${roomId}`, async () => {
       const room = await kvGetJSON<Room>(keyOf(roomId));
-      if (!room) {
-        return { status: 'not-found' as const };
-      }
-      if (room.status !== 'waiting') {
-        return { status: 'locked' as const };
+      const result = joinRoomSnapshot(room, nicknameInput);
+      if (!result.ok) {
+        return { status: result.reason };
       }
 
-      const already = room.seats.some((seat) => seat?.nickname === nicknameInput);
-      if (!already) {
-        const emptyIndex = room.seats.findIndex((seat) => seat === null);
-        if (emptyIndex === -1) {
-          return { status: 'full' as const };
-        }
-        room.seats[emptyIndex] = { nickname: nicknameInput };
-      }
-
-      await kvSaveJSON(keyOf(roomId), room, roomTTL);
-      return { status: 'ok' as const, room };
+      await kvSaveJSON(keyOf(roomId), result.room, roomTTL);
+      return { status: 'ok' as const, room: result.room };
     }, { retry: 2, retryDelayMs: 100 });
 
     if (status === 'not-found') {
@@ -65,6 +55,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     }
     if (status === 'full') {
       return NextResponse.json({ ok: false, reason: 'full' }, { status: 409, headers: noStore });
+    }
+    if (!room) {
+      return NextResponse.json({ ok: false, reason: 'bad-request' }, { status: 400, headers: noStore });
     }
 
     try {

--- a/apps/hub/app/api/friend/leave/route.ts
+++ b/apps/hub/app/api/friend/leave/route.ts
@@ -5,6 +5,7 @@ import type { Room, RoomSeat } from '@/types/room';
 import { kvGetJSON, kvSaveJSON, roomTTL } from '@/lib/kv';
 import { verifyAuth } from '@/lib/auth';
 import { withLock } from '@/lib/lock';
+import { normalizeNickname, normalizeRoomId } from '@/lib/friend-room';
 
 const keyOf = (id: string) => `friend:room:${id}`;
 
@@ -24,10 +25,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   if (!auth) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   try {
     const body = (await req.json()) as LeaveRoomPayload;
-    const roomId = typeof body.roomId === 'string' ? body.roomId.trim() : '';
-    const nickname = typeof body.nickname === 'string' ? body.nickname.trim() : '';
+    const roomId = normalizeRoomId(body.roomId);
+    const nickname = normalizeNickname(body.nickname);
 
-    if (!roomId || !nickname) {
+    if (roomId.length !== 6 || !nickname) {
       return json({ ok: false, reason: 'bad-request' }, 400);
     }
 

--- a/apps/hub/app/api/friend/room/[roomId]/route.ts
+++ b/apps/hub/app/api/friend/room/[roomId]/route.ts
@@ -7,6 +7,7 @@ import { kv, roomTTL } from '@/lib/kv';
 import { NextResponse } from 'next/server';
 import type { Room } from '@/types/room';
 import { verifyAuth } from '@/lib/auth';
+import { normalizeRoomId } from '@/lib/friend-room';
 
 const keyOf = (id: string) => `friend:room:${id}`;
 const noStore = { 'Cache-Control': 'no-store, no-cache, max-age=0, must-revalidate' } as const;
@@ -14,7 +15,10 @@ const noStore = { 'Cache-Control': 'no-store, no-cache, max-age=0, must-revalida
 export async function GET(req: Request, { params }: { params: { roomId: string } }) {
   const auth = await verifyAuth(req);
   if (!auth) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const id = String(params.roomId);
+  const id = normalizeRoomId(params.roomId);
+  if (id.length !== 6) {
+    return NextResponse.json({ ok: false, reason: 'bad-request' }, { status: 400, headers: noStore });
+  }
   try {
     const room = await kv.get<Room>(keyOf(id));
     if (!room) {

--- a/apps/hub/app/api/friend/status/route.ts
+++ b/apps/hub/app/api/friend/status/route.ts
@@ -5,6 +5,7 @@ import type { Room, RoomStatus } from '@/types/room';
 import { kvGetJSON, kvSaveJSON, roomTTL } from '@/lib/kv';
 import { verifyAuth } from '@/lib/auth';
 import { withLock } from '@/lib/lock';
+import { canStartRoom, normalizeNickname, normalizeRoomId } from '@/lib/friend-room';
 
 const keyOf = (id: string) => `friend:room:${id}`;
 
@@ -12,7 +13,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-type StatusPayload = { roomId?: unknown; status?: unknown };
+type StatusPayload = { roomId?: unknown; status?: unknown; nickname?: unknown };
 
 const isRoomStatus = (value: string): value is RoomStatus =>
   value === 'waiting' || value === 'playing' || value === 'closed';
@@ -22,10 +23,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   if (!auth) return json({ error: 'Unauthorized' }, 401);
   try {
     const body = (await req.json()) as StatusPayload;
-    const roomId = typeof body.roomId === 'string' ? body.roomId.trim() : '';
+    const roomId = normalizeRoomId(body.roomId);
     const statusInput = typeof body.status === 'string' ? body.status.trim() : '';
+    const nickname = normalizeNickname(body.nickname);
 
-    if (!roomId || !statusInput || !isRoomStatus(statusInput)) {
+    if (roomId.length !== 6 || !statusInput || !isRoomStatus(statusInput) || !nickname) {
       return json({ ok: false, reason: 'bad-request' }, 400);
     }
 
@@ -33,6 +35,17 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       const room = await kvGetJSON<Room>(keyOf(roomId));
       if (!room) {
         return json({ ok: false, reason: 'not-found' }, 404);
+      }
+
+      if (statusInput === 'playing') {
+        const startCheck = canStartRoom(room, nickname);
+        if (!startCheck.ok) {
+          return json({ ok: false, reason: startCheck.reason }, startCheck.reason === 'host-only' ? 403 : 409);
+        }
+      }
+
+      if (statusInput === 'closed' && !room.seats.some((seat) => seat?.nickname === nickname)) {
+        return json({ ok: false, reason: 'not-member' }, 403);
       }
 
       // 無効な状態遷移を防止

--- a/apps/hub/app/friend/join/page.tsx
+++ b/apps/hub/app/friend/join/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { apiJson, ApiRequestError } from "@/lib/api";
+import { normalizeRoomId } from "@/lib/friend-room";
 import { getNickname } from "@/lib/profile";
 import { getRoom, joinRoom, upsertLocalRoom } from "@/lib/roomSystemUnified";
 import { USE_SERVER_SYNC } from "@/lib/serverSync";
@@ -80,7 +81,11 @@ export default function FriendJoinPage() {
       return;
     }
 
-    const trimmedRoomCode = roomCode.trim();
+    const trimmedRoomCode = normalizeRoomId(roomCode);
+    if (trimmedRoomCode.length !== 6) {
+      setError('ルーム番号の形式が正しくありません');
+      return;
+    }
 
     setIsJoining(true);
     setError(null);
@@ -91,7 +96,7 @@ export default function FriendJoinPage() {
         return;
       }
 
-      const data = await apiJson<RoomResponse>('/friend/join', {
+      const data = await apiJson<RoomResponse>('/api/friend/join', {
         method: 'POST',
         json: { roomId: trimmedRoomCode, nickname },
       });
@@ -101,7 +106,7 @@ export default function FriendJoinPage() {
             upsertLocalRoom(data.room);
           } else {
             // 追加取得で保存を試みる
-            const rd = await apiJson<RoomResponse>(`/friend/room/${data.roomId}`);
+            const rd = await apiJson<RoomResponse>(`/api/friend/room/${data.roomId}`);
             if (rd.ok && rd.room) {
               upsertLocalRoom(rd.room);
             } else {

--- a/apps/hub/app/friend/play/[roomCode]/page.tsx
+++ b/apps/hub/app/friend/play/[roomCode]/page.tsx
@@ -5,6 +5,7 @@ import { BattleHud, EllipseTable, Timer } from '@/components/ui';
 import PageBackground from '@/components/ui/PageBackground';
 import { BACKGROUNDS } from '@/lib/backgrounds';
 import { apiJson, apiRequest } from '@/lib/api';
+import { normalizeRoomId } from '@/lib/friend-room';
 import {
   GameConfig,
   GameState,
@@ -26,7 +27,7 @@ import '../../../cucumber/cpu/play/game.css';
 function FriendPlayContent() {
   const params = useParams();
   const router = useRouter();
-  const roomCode = params.roomCode as string;
+  const roomCode = normalizeRoomId(params.roomCode);
 
   const [gameState, setGameState] = useState<GameState | null>(null);
   const [gameOver, setGameOver] = useState(false);
@@ -54,6 +55,10 @@ function FriendPlayContent() {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const lastVersionRef = useRef<number>(0);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const debugRooms = process.env.NEXT_PUBLIC_DEBUG_ROOMS === '1';
+  const debugWarn = (...args: unknown[]) => {
+    if (debugRooms) console.warn(...args);
+  };
 
   type FriendGameResponse = { ok: true; snapshot: GameSnapshot } | { ok: false; reason: string };
   type UpdateStatusResponse = { ok: boolean; reason?: string };
@@ -106,7 +111,7 @@ function FriendPlayContent() {
         return { room: localRoom, playerIndex };
       }
 
-      const data = await apiJson<RoomResponse>(`/friend/room/${roomCode}`);
+      const data = await apiJson<RoomResponse>(`/api/friend/room/${roomCode}`);
       if (!data.ok || !data.room) throw new Error('Invalid room data');
 
       setRoomConfig(data.room);
@@ -115,7 +120,7 @@ function FriendPlayContent() {
       setMySeatIndex(playerIndex);
       return { room: data.room, playerIndex };
     } catch (error) {
-      console.error('[Friend Game] Failed to fetch room config:', error);
+      debugWarn('[Friend Game] Failed to fetch room config:', error);
       router.push('/home');
       return null;
     }
@@ -128,25 +133,36 @@ function FriendPlayContent() {
       if (!info) return;
       const room = info.room;
       const myIndex = info.playerIndex;
+      const nickname = getNickname();
+      if (!nickname) {
+        router.push(`/setup?returnTo=/friend/play/${roomCode}`);
+        return;
+      }
+
+      if (!useServer) {
+        setToast('このローカルルームは待機画面の確認用です。フレンド対戦の開始にはサーバー同期設定が必要です。');
+        router.push(`/friend/room/${roomCode}`);
+        return;
+      }
 
       // ルームの状態をチェック
       if (room.status !== 'playing') {
         if (myIndex === 0) {
           try {
-            await apiJson<UpdateStatusResponse>('/friend/status', {
+            await apiJson<UpdateStatusResponse>('/api/friend/status', {
               method: 'POST',
-              json: { roomId: roomCode, status: 'playing' },
+              json: { roomId: roomCode, status: 'playing', nickname },
             });
             room.status = 'playing';
           } catch (e) {
-            console.warn('[Friend Game] Failed to set playing status:', e);
+            debugWarn('[Friend Game] Failed to set playing status:', e);
           }
         } else {
           let tries = 0;
           while (tries < 5) {
             await new Promise((resolve) => setTimeout(resolve, 400));
             try {
-              const d = await apiJson<RoomResponse>(`/friend/room/${roomCode}`);
+              const d = await apiJson<RoomResponse>(`/api/friend/room/${roomCode}`);
               if (d.ok && d.room?.status === 'playing') {
                 room.status = 'playing';
                 break;
@@ -163,7 +179,6 @@ function FriendPlayContent() {
         }
       }
 
-      const nickname = getNickname();
       const isPlayerInRoom = room.seats.some((seat) => seat?.nickname === nickname);
       if (!isPlayerInRoom) {
         router.push(`/friend/room/${roomCode}`);
@@ -195,15 +210,15 @@ function FriendPlayContent() {
         setGameResults([]);
         setIsGameInitialized(true);
         try {
-          const data = await apiJson<FriendGameResponse>(`/friend/game/${roomCode}`, {
+          const data = await apiJson<FriendGameResponse>(`/api/friend/game/${roomCode}`, {
             method: 'POST',
-            json: { type: 'init', state, config },
+            json: { type: 'init', nickname, state, config },
           });
           if (data.ok) {
             lastVersionRef.current = data.snapshot.version ?? 1;
           }
         } catch (initError) {
-          console.warn('[Friend Game] Failed to persist snapshot:', initError);
+          debugWarn('[Friend Game] Failed to persist snapshot:', initError);
         }
       } else {
         // ゲストはサーバーのスナッ��ショットを取得するまで待機
@@ -211,7 +226,7 @@ function FriendPlayContent() {
           let retries = 0;
           while (retries < 10) {
             try {
-              const data = await apiJson<FriendGameResponse>(`/friend/game/${roomCode}`);
+              const data = await apiJson<FriendGameResponse>(`/api/friend/game/${roomCode}?nickname=${encodeURIComponent(nickname)}`);
               if (data.ok) {
                 const rng = new SeededRngClass(data.snapshot.config.seed);
                 gameRef.current = {
@@ -246,7 +261,7 @@ function FriendPlayContent() {
           try {
             const controller = new AbortController();
             const timeoutId = setTimeout(() => controller.abort(), 8000);
-            const response = await apiRequest<FriendGameResponse>(`/friend/game/${roomCode}`, {
+            const response = await apiRequest<FriendGameResponse>(`/api/friend/game/${roomCode}?nickname=${encodeURIComponent(nickname)}`, {
               signal: controller.signal,
               headers: { 'Cache-Control': 'no-cache', Pragma: 'no-cache' },
               parseAs: 'json',
@@ -269,13 +284,13 @@ function FriendPlayContent() {
             }
           } catch (error) {
             if (error && typeof error === 'object' && 'name' in error && error.name === 'AbortError') {
-              console.warn('[Game Poll] Request timeout');
+              debugWarn('[Game Poll] Request timeout');
             }
           }
         }, 3000);
       }
     } catch (error) {
-      console.error('[Friend Game] Failed to start game:', error);
+      debugWarn('[Friend Game] Failed to start game:', error);
       setToast('ゲーム初期化に失敗しました');
       router.push('/home');
     }
@@ -303,9 +318,11 @@ function FriendPlayContent() {
         isDiscard: isDiscardMove,
       };
 
-      const data = await apiJson<FriendGameResponse>(`/friend/game/${roomCode}`, {
+      const nickname = getNickname();
+      if (!nickname) return;
+      const data = await apiJson<FriendGameResponse>(`/api/friend/game/${roomCode}`, {
         method: 'POST',
-        json: { type: 'move', move },
+        json: { type: 'move', nickname, move },
       });
       if (data.ok) {
         lastVersionRef.current = data.snapshot.version ?? lastVersionRef.current + 1;
@@ -316,7 +333,7 @@ function FriendPlayContent() {
         checkGameOver(data.snapshot.state);
       }
     } catch (error) {
-      console.error('[Friend Game] Error during move:', error);
+      debugWarn('[Friend Game] Error during move:', error);
       setToast('カード送信に失敗しました');
       setTimeout(() => setToast(null), 3000);
     } finally {

--- a/apps/hub/app/friend/room/[roomId]/page.tsx
+++ b/apps/hub/app/friend/room/[roomId]/page.tsx
@@ -3,8 +3,7 @@
 import { FriendRoomLayout, PlayerSeatGrid, RoomActionBar, RoomSummaryCard } from "@/components/ui";
 import { apiJson, apiRequest, ApiRequestError } from "@/lib/api";
 import { getNickname } from "@/lib/profile";
-import { getClientAuthUid } from '@/lib/clientAuth';
-import { makeClient } from "@/lib/realtime-client";
+import { normalizeRoomId } from "@/lib/friend-room";
 import { getRoom as getLocalRoom } from "@/lib/roomSystemUnified";
 import { USE_SERVER_SYNC } from "@/lib/serverSync";
 import type { Room, RoomResponse } from "@/types/room";
@@ -18,7 +17,7 @@ export default function RoomWaitingPage() {
   const useServer = USE_SERVER_SYNC;
   const params = useParams();
   const router = useRouter();
-  const roomId = params.roomId as string;
+  const roomId = normalizeRoomId(params.roomId);
   const [room, setRoom] = useState<Room | null>(null);
   const [nickname, setNickname] = useState<string | null>(null);
   const [isInRoom, setIsInRoom] = useState(false);
@@ -26,6 +25,13 @@ export default function RoomWaitingPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [copied, setCopied] = useState(false);
   const [mounted, setMounted] = useState(false);
+  const debugRooms = process.env.NEXT_PUBLIC_DEBUG_ROOMS === '1';
+  const debugLog = (...args: unknown[]) => {
+    if (debugRooms) console.log(...args);
+  };
+  const debugWarn = (...args: unknown[]) => {
+    if (debugRooms) console.warn(...args);
+  };
 
   useEffect(() => {
     document.title = `ルーム ${roomId} | Five Cucumber`;
@@ -60,7 +66,7 @@ export default function RoomWaitingPage() {
             const controller = new AbortController();
             timeoutId = setTimeout(() => controller.abort(), 10000); // 10秒タイムアウト
 
-            const response = await apiRequest<RoomResponse>(`/friend/room/${roomId}`, {
+            const response = await apiRequest<RoomResponse>(`/api/friend/room/${roomId}`, {
               signal: controller.signal,
               headers: {
                 'Cache-Control': 'no-cache',
@@ -88,7 +94,7 @@ export default function RoomWaitingPage() {
               setError('ルーム情報の取得に失敗しました');
             }
           } catch (err) {
-            console.error('Room fetch error:', err);
+            debugWarn('Room fetch error:', err);
             if (err instanceof DOMException && err.name === 'AbortError') {
               setError('リクエストがタイムアウトしました。ネットワーク状況を確認してください。');
             } else if (err instanceof ApiRequestError && err.response.status === 404) {
@@ -108,7 +114,7 @@ export default function RoomWaitingPage() {
 
             // スマホでのネットワーク不安定さを考慮してリトライ
             if (retryCount < 2) {
-              console.log(`Room fetch retry ${retryCount + 1}/2`);
+              debugLog(`Room fetch retry ${retryCount + 1}/2`);
               setTimeout(() => fetchRoom(retryCount + 1), 1000);
               return;
             }
@@ -125,7 +131,7 @@ export default function RoomWaitingPage() {
         // スマホ対応: User-Agentを確認
         const userAgent = navigator.userAgent;
         const isMobile = /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile/.test(userAgent);
-        console.log('[RoomPage] User agent:', userAgent, 'Mobile:', isMobile);
+        debugLog('[RoomPage] User agent:', userAgent, 'Mobile:', isMobile);
 
         const pollInterval: ReturnType<typeof setInterval> | undefined = useServer
           ? setInterval(() => fetchRoom(), isMobile ? 2000 : 3000)
@@ -134,7 +140,7 @@ export default function RoomWaitingPage() {
         // デバッグ用: サーバーメモリの状況を確認
         if (useServer) {
           fetchRoom().then(() => {
-            console.log('[RoomPage] Initial fetch completed');
+            debugLog('[RoomPage] Initial fetch completed');
           });
         }
 
@@ -142,43 +148,47 @@ export default function RoomWaitingPage() {
         if (useServer && currentNickname) {
           (async () => {
             try {
+              const [{ getClientAuthUid }, { makeClient }] = await Promise.all([
+                import('@/lib/clientAuth'),
+                import('@/lib/realtime-client'),
+              ]);
               const authUid = await getClientAuthUid();
               const channelName = `room-${roomId}-user-${currentNickname}`;
-              console.log(`[RoomPage] Initializing Ably client for room: ${roomId}, user: ${currentNickname}, authUid: ${authUid}, mobile: ${isMobile}`);
+              debugLog(`[RoomPage] Initializing Ably client for room: ${roomId}, user: ${currentNickname}, authUid: ${authUid}, mobile: ${isMobile}`);
 
               const ablyClient = makeClient(authUid, channelName);
               const channel = ablyClient.channels.get(channelName);
 
             // スマホ対応: チャネル状態を監視
             channel.on('attaching', () => {
-              console.log('[RoomPage] Ably channel attaching...');
+              debugLog('[RoomPage] Ably channel attaching...');
             });
 
             channel.on('attached', () => {
-              console.log('[RoomPage] Ably channel attached successfully');
+              debugLog('[RoomPage] Ably channel attached successfully');
             });
 
             channel.on('failed', (stateChange: Types.ChannelStateChange) => {
-              console.error('[RoomPage] Ably channel failed:', stateChange.reason);
+              debugWarn('[RoomPage] Ably channel failed:', stateChange.reason);
               // スマホではAblyが失敗しやすいので、警告を表示
               if (isMobile) {
-                console.warn('[RoomPage] Ably failed on mobile - relying on polling fallback');
+                debugWarn('[RoomPage] Ably failed on mobile - relying on polling fallback');
               }
             });
 
             channel.subscribe('room_updated', (message: Types.Message) => {
-              console.log('[RoomPage] Received room_updated event:', message.data);
+              debugLog('[RoomPage] Received room_updated event:', message.data);
               const { room: updatedRoom, event, joinedPlayer } = message.data;
 
               if (updatedRoom) {
-                console.log('[RoomPage] Updating room state with new data:', updatedRoom);
+                debugLog('[RoomPage] Updating room state with new data:', updatedRoom);
                 setRoom(updatedRoom);
 
                 const isParticipating = updatedRoom.seats.some((seat: Room['seats'][number]) => seat?.nickname === currentNickname);
                 setIsInRoom(isParticipating);
 
                 if (event === 'player_joined' && joinedPlayer) {
-                  console.log(`[RoomPage] Player ${joinedPlayer} joined the room`);
+                  debugLog(`[RoomPage] Player ${joinedPlayer} joined the room`);
                   // スマホでは通知を表示してユーザーに知らせる
                   if (isMobile && 'Notification' in window && Notification.permission === 'granted') {
                     new Notification('Five Cucumber', {
@@ -189,13 +199,13 @@ export default function RoomWaitingPage() {
               }
             });
 
-            console.log(`[RoomPage] Subscribed to room updates for room: ${roomId}, user: ${currentNickname}`);
+            debugLog(`[RoomPage] Subscribed to room updates for room: ${roomId}, user: ${currentNickname}`);
 
             } catch (error) {
-              console.error('[RoomPage] Failed to initialize Ably client:', error);
+              debugWarn('[RoomPage] Failed to initialize Ably client:', error);
               // スマホではAblyが失敗しやすいので、警告を表示
               if (isMobile) {
-                console.warn('[RoomPage] Ably initialization failed on mobile - relying on polling fallback');
+                debugWarn('[RoomPage] Ably initialization failed on mobile - relying on polling fallback');
               }
             }
           })();
@@ -226,12 +236,12 @@ export default function RoomWaitingPage() {
         return;
       }
 
-      await apiJson<{ ok: boolean; reason?: string }>(`/friend/leave`, {
+      await apiJson<{ ok: boolean; reason?: string }>(`/api/friend/leave`, {
         method: 'POST',
         json: { roomId, nickname },
       });
     } catch (err) {
-      console.error('Leave room error:', err);
+      debugWarn('Leave room error:', err);
     } finally {
       router.push('/home');
     }
@@ -255,23 +265,14 @@ export default function RoomWaitingPage() {
         return;
       }
 
-      await apiJson<{ ok: boolean }>(`/friend/status`, {
+      await apiJson<{ ok: boolean; reason?: string }>(`/api/friend/status`, {
         method: 'POST',
-        json: { roomId, status: 'playing' },
+        json: { roomId, status: 'playing', nickname },
       });
       router.push(`/friend/play/${roomId}`);
     } catch (err) {
-      console.error('Start game error, fallback to local:', err);
-      try {
-        const { updateRoomStatus, getRoom, upsertLocalRoom } = await import('@/lib/roomSystemUnified');
-        updateRoomStatus(roomId, 'playing');
-        const local = getRoom(roomId);
-        if (local) {
-          const updatedRoom: Room = { ...local, status: 'playing' };
-          upsertLocalRoom(updatedRoom);
-        }
-      } catch {}
-      router.push(`/friend/play/${roomId}`);
+      debugWarn('Start game error:', err);
+      setError('ゲーム開始に失敗しました。認証、共有ストア、または参加者状態を確認してください。');
     }
   };
 
@@ -282,7 +283,7 @@ export default function RoomWaitingPage() {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
-      console.warn('Copy room id failed:', err);
+      debugWarn('Copy room id failed:', err);
     }
   };
 

--- a/apps/hub/lib/__tests__/friend-room.test.ts
+++ b/apps/hub/lib/__tests__/friend-room.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canStartRoom,
+  createFriendRoom,
+  getSeatIndex,
+  isValidRoomId,
+  joinRoomSnapshot,
+  normalizeFriendRoomSettings,
+  normalizeRoomId,
+} from '../friend-room';
+
+describe('friend-room helpers', () => {
+  it('ルームIDを6桁数字に正規化して検証する', () => {
+    expect(normalizeRoomId('12-34 56 789')).toBe('123456');
+    expect(isValidRoomId('123456')).toBe(true);
+    expect(isValidRoomId('12345')).toBe(false);
+    expect(isValidRoomId('abcdef')).toBe(false);
+  });
+
+  it('フレンドルーム設定を許可範囲に丸める', () => {
+    expect(normalizeFriendRoomSettings({ roomSize: 9, turnSeconds: -1, maxCucumbers: 99 })).toEqual({
+      roomSize: 6,
+      turnSeconds: 0,
+      maxCucumbers: 7,
+    });
+    expect(normalizeFriendRoomSettings({ roomSize: 1, turnSeconds: 45, maxCucumbers: 2 })).toEqual({
+      roomSize: 2,
+      turnSeconds: 30,
+      maxCucumbers: 4,
+    });
+  });
+
+  it('作成者をホスト席に固定してルームを作成する', () => {
+    const room = createFriendRoom({
+      id: '123456',
+      nickname: ' host ',
+      roomSize: 3,
+      turnSeconds: 15,
+      maxCucumbers: 5,
+      createdAt: 100,
+    });
+
+    expect(room.id).toBe('123456');
+    expect(room.seats).toEqual([{ nickname: 'host' }, null, null]);
+    expect(getSeatIndex(room, 'host')).toBe(0);
+  });
+
+  it('同名参加は冪等で、空席には最小indexから着席する', () => {
+    const room = createFriendRoom({
+      id: '123456',
+      nickname: 'host',
+      roomSize: 3,
+      turnSeconds: 15,
+      maxCucumbers: 5,
+    });
+
+    const firstJoin = joinRoomSnapshot(room, 'guest');
+    expect(firstJoin.ok).toBe(true);
+    if (!firstJoin.ok) throw new Error('unexpected join failure');
+    expect(firstJoin.seatIndex).toBe(1);
+    expect(firstJoin.room.seats[1]).toEqual({ nickname: 'guest' });
+
+    const secondJoin = joinRoomSnapshot(firstJoin.room, 'guest');
+    expect(secondJoin.ok).toBe(true);
+    if (!secondJoin.ok) throw new Error('unexpected rejoin failure');
+    expect(secondJoin.alreadyJoined).toBe(true);
+    expect(secondJoin.seatIndex).toBe(1);
+  });
+
+  it('満室の新規参加を拒否する', () => {
+    const room = createFriendRoom({
+      id: '123456',
+      nickname: 'host',
+      roomSize: 2,
+      turnSeconds: 15,
+      maxCucumbers: 5,
+    });
+    const joined = joinRoomSnapshot(room, 'guest');
+    if (!joined.ok) throw new Error('unexpected join failure');
+
+    expect(joinRoomSnapshot(joined.room, 'third')).toEqual({ ok: false, reason: 'full' });
+  });
+
+  it('ホストかつ満室の待機ルームだけ開始できる', () => {
+    const room = createFriendRoom({
+      id: '123456',
+      nickname: 'host',
+      roomSize: 2,
+      turnSeconds: 15,
+      maxCucumbers: 5,
+    });
+
+    expect(canStartRoom(room, 'host')).toEqual({ ok: false, reason: 'not-full' });
+    const joined = joinRoomSnapshot(room, 'guest');
+    if (!joined.ok) throw new Error('unexpected join failure');
+    expect(canStartRoom(joined.room, 'guest')).toEqual({ ok: false, reason: 'host-only' });
+    expect(canStartRoom(joined.room, 'host')).toEqual({ ok: true });
+  });
+});

--- a/apps/hub/lib/__tests__/nickname.test.ts
+++ b/apps/hub/lib/__tests__/nickname.test.ts
@@ -1,4 +1,5 @@
 import { graphemeLength, normalizeNickname, validateNickname } from '../nickname';
+import { describe, expect, test } from 'vitest';
 
 describe('nickname validation', () => {
   describe('validateNickname', () => {

--- a/apps/hub/lib/friend-room.ts
+++ b/apps/hub/lib/friend-room.ts
@@ -1,0 +1,121 @@
+import type { Room, RoomSeat } from '@/types/room';
+
+export const FRIEND_ROOM_ID_PATTERN = /^\d{6}$/;
+
+export type FriendRoomSettings = {
+  roomSize: number;
+  turnSeconds: number;
+  maxCucumbers: number;
+};
+
+export type FriendRoomCreateInput = FriendRoomSettings & {
+  id: string;
+  nickname: string;
+  createdAt?: number;
+  seed?: number;
+};
+
+export type RoomJoinResult =
+  | { ok: true; room: Room; seatIndex: number; alreadyJoined: boolean }
+  | { ok: false; reason: 'bad-request' | 'not-found' | 'locked' | 'full' };
+
+export function normalizeRoomId(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  return String(value).replace(/\D/g, '').slice(0, 6);
+}
+
+export function isValidRoomId(value: unknown): boolean {
+  return FRIEND_ROOM_ID_PATTERN.test(typeof value === 'string' ? value : String(value ?? ''));
+}
+
+export function normalizeNickname(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function clampNumber(value: unknown, min: number, max: number, fallback: number): number {
+  const numberValue = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numberValue)) return fallback;
+  return Math.min(max, Math.max(min, Math.trunc(numberValue)));
+}
+
+export function normalizeFriendRoomSettings(settings: Partial<FriendRoomSettings>): FriendRoomSettings {
+  return {
+    roomSize: clampNumber(settings.roomSize, 2, 6, 4),
+    turnSeconds: clampNumber(settings.turnSeconds, 0, 30, 15),
+    maxCucumbers: clampNumber(settings.maxCucumbers, 4, 7, 5),
+  };
+}
+
+export function createFriendRoom(input: FriendRoomCreateInput): Room {
+  const nickname = normalizeNickname(input.nickname);
+  if (!isValidRoomId(input.id) || !nickname) {
+    throw new Error('bad-request');
+  }
+
+  const settings = normalizeFriendRoomSettings(input);
+  const room: Room = {
+    id: input.id,
+    size: settings.roomSize,
+    seats: Array.from({ length: settings.roomSize }, () => null),
+    status: 'waiting',
+    createdAt: input.createdAt ?? Date.now(),
+    turnSeconds: settings.turnSeconds,
+    maxCucumbers: settings.maxCucumbers,
+    seed: input.seed,
+  };
+  room.seats[0] = { nickname };
+  return room;
+}
+
+export function countJoinedPlayers(room: Room): number {
+  return room.seats.filter((seat): seat is Exclude<RoomSeat, null> => seat !== null).length;
+}
+
+export function getSeatIndex(room: Room, nickname: string): number {
+  const normalized = normalizeNickname(nickname);
+  if (!normalized) return -1;
+  return room.seats.findIndex((seat) => seat?.nickname === normalized);
+}
+
+export function isRoomHost(room: Room, nickname: string): boolean {
+  return room.seats[0]?.nickname === normalizeNickname(nickname);
+}
+
+export function canStartRoom(room: Room, nickname: string): { ok: true } | { ok: false; reason: string } {
+  if (!isRoomHost(room, nickname)) return { ok: false, reason: 'host-only' };
+  if (room.status !== 'waiting') return { ok: false, reason: 'invalid-transition' };
+  if (countJoinedPlayers(room) !== room.size) return { ok: false, reason: 'not-full' };
+  return { ok: true };
+}
+
+export function joinRoomSnapshot(room: Room | null, nicknameInput: unknown): RoomJoinResult {
+  const nickname = normalizeNickname(nicknameInput);
+  if (!nickname) return { ok: false, reason: 'bad-request' };
+  if (!room) return { ok: false, reason: 'not-found' };
+  if (room.status !== 'waiting') return { ok: false, reason: 'locked' };
+
+  const existingIndex = getSeatIndex(room, nickname);
+  if (existingIndex >= 0) {
+    return {
+      ok: true,
+      room,
+      seatIndex: existingIndex,
+      alreadyJoined: true,
+    };
+  }
+
+  const emptyIndex = room.seats.findIndex((seat) => seat === null);
+  if (emptyIndex < 0) return { ok: false, reason: 'full' };
+
+  const nextRoom: Room = {
+    ...room,
+    seats: room.seats.map((seat, index) => (index === emptyIndex ? { nickname } : seat)),
+  };
+
+  return {
+    ok: true,
+    room: nextRoom,
+    seatIndex: emptyIndex,
+    alreadyJoined: false,
+  };
+}

--- a/apps/hub/lib/realtime-ably.ts
+++ b/apps/hub/lib/realtime-ably.ts
@@ -2,6 +2,13 @@ import Ably from 'ably/promises';
 import type { RealtimeAdapter } from './realtime-adapter';
 
 let restInstance: InstanceType<typeof Ably.Rest> | null = null;
+const DEBUG_ROOMS = process.env.NEXT_PUBLIC_DEBUG_ROOMS === '1';
+const debugLog = (...args: unknown[]) => {
+  if (DEBUG_ROOMS) console.log(...args);
+};
+const debugWarn = (...args: unknown[]) => {
+  if (DEBUG_ROOMS) console.warn(...args);
+};
 
 function getRest(): InstanceType<typeof Ably.Rest> {
   if (!process.env.ABLY_API_KEY) {
@@ -9,7 +16,7 @@ function getRest(): InstanceType<typeof Ably.Rest> {
   }
 
   if (!restInstance) {
-    console.log('[Ably] Initializing Ably REST client');
+    debugLog('[Ably] Initializing Ably REST client');
     restInstance = new Ably.Rest(process.env.ABLY_API_KEY);
   }
   return restInstance;
@@ -20,20 +27,20 @@ export const ablyAdapter: RealtimeAdapter = {
     try {
       const rest = getRest();
       const channel = rest.channels.get(`room-${roomId}-user-${uid}`);
-      console.log('[Ably] Publishing to user channel:', roomId, uid, event);
+      debugLog('[Ably] Publishing to user channel:', roomId, uid, event);
       await channel.publish(event, payload);
     } catch (error) {
-      console.error('[Ably] Failed to publish to user via room channel:', error);
+      debugWarn('[Ably] Failed to publish to user via room channel:', error);
       throw error;
     }
   },
   async publishToMany(roomId, uids, event, build) {
     try {
       const rest = getRest();
-      console.log('[Ably] Publishing to many user channels:', roomId, uids.length, event);
+      debugLog('[Ably] Publishing to many user channels:', roomId, uids.length, event);
 
       if (uids.length === 0) {
-        console.log('[Ably] No users to publish to, skipping');
+        debugLog('[Ably] No users to publish to, skipping');
         return;
       }
 
@@ -44,10 +51,10 @@ export const ablyAdapter: RealtimeAdapter = {
         })
       );
 
-      console.log('[Ably] Successfully published to user channels');
+      debugLog('[Ably] Successfully published to user channels');
     } catch (error) {
-      console.error('[Ably] Failed to publish to room channel:', error);
-      console.warn('[Ably] Some publishes may have failed, but continuing...');
+      debugWarn('[Ably] Failed to publish to room channel:', error);
+      debugWarn('[Ably] Some publishes may have failed, but continuing...');
     }
   },
 };

--- a/apps/hub/lib/realtime-client.ts
+++ b/apps/hub/lib/realtime-client.ts
@@ -3,12 +3,20 @@ import * as Ably from 'ably';
 import type { Types } from 'ably';
 import { apiJson } from '@/lib/api';
 
+const DEBUG_ROOMS = process.env.NEXT_PUBLIC_DEBUG_ROOMS === '1';
+const debugLog = (...args: unknown[]) => {
+  if (DEBUG_ROOMS) console.log(...args);
+};
+const debugWarn = (...args: unknown[]) => {
+  if (DEBUG_ROOMS) console.warn(...args);
+};
+
 type AblyTokenResponse =
   | { ok: true; token: Types.TokenRequest }
   | { ok: false; reason: string; message?: string };
 
 export function makeClient(clientId: string, channelName: string): Types.RealtimePromise {
-  console.log('[Ably] Creating client for user:', clientId, 'channel:', channelName);
+  debugLog('[Ably] Creating client for user:', clientId, 'channel:', channelName);
 
   const authCallback: NonNullable<Types.AuthOptions['authCallback']> = async (_tokenParams, callback) => {
     try {
@@ -19,7 +27,7 @@ export function makeClient(clientId: string, channelName: string): Types.Realtim
       }
       callback(null, data.token);
     } catch (error) {
-      console.error('[Ably] authCallback error:', error);
+      debugWarn('[Ably] authCallback error:', error);
       const errorMessage = error instanceof Error ? error.message : String(error);
       callback(errorMessage, null);
     }
@@ -47,23 +55,23 @@ export function makeClient(clientId: string, channelName: string): Types.Realtim
 
   // 接続状態を監視
   client.connection.on('connecting', () => {
-    console.log('[Ably] Connecting...');
+    debugLog('[Ably] Connecting...');
   });
 
   client.connection.on('connected', () => {
-    console.log('[Ably] Connected successfully');
+    debugLog('[Ably] Connected successfully');
   });
 
   client.connection.on('failed', (stateChange) => {
-    console.error('[Ably] Connection failed:', stateChange.reason);
+    debugWarn('[Ably] Connection failed:', stateChange.reason);
   });
 
   client.connection.on('disconnected', () => {
-    console.warn('[Ably] Disconnected - will auto-reconnect');
+    debugWarn('[Ably] Disconnected - will auto-reconnect');
   });
 
   client.connection.on('suspended', () => {
-    console.warn('[Ably] Connection suspended - will retry');
+    debugWarn('[Ably] Connection suspended - will retry');
   });
 
   return client;

--- a/apps/hub/lib/redis.ts
+++ b/apps/hub/lib/redis.ts
@@ -1,6 +1,7 @@
 import { kv } from '@vercel/kv';
 
 export const redis = kv;
+const DEBUG_ROOMS = process.env.NEXT_PUBLIC_DEBUG_ROOMS === '1';
 
 // Vercel KVが利用できない場合のフォールバック
 export const isRedisAvailable = () => {
@@ -8,7 +9,9 @@ export const isRedisAvailable = () => {
   const hasUrl = !!process.env.KV_REST_API_URL || !!process.env.VERCEL_REDIS_URL;
   const hasToken = !!process.env.KV_REST_API_TOKEN || !!process.env.VERCEL_REDIS_TOKEN;
   const enabled = hasUrl && hasToken;
-  console.log('[Redis] KV availability:', { hasUrl, hasToken, enabled, nodeEnv: process.env.NODE_ENV });
+  if (DEBUG_ROOMS) {
+    console.log('[Redis] KV availability:', { hasUrl, hasToken, enabled, nodeEnv: process.env.NODE_ENV });
+  }
   return enabled;
 };
 

--- a/apps/hub/lib/roomSystemUnified.ts
+++ b/apps/hub/lib/roomSystemUnified.ts
@@ -1,5 +1,11 @@
 // 統一されたルームシステム（クライアント・サーバー両対応）
 
+import {
+  createFriendRoom,
+  joinRoomSnapshot,
+  normalizeFriendRoomSettings,
+  normalizeNickname,
+} from '@/lib/friend-room';
 import { Room } from '@/types/room';
 
 const DEBUG_ROOM_SYSTEM = process.env.NEXT_PUBLIC_DEBUG_ROOMS === '1';
@@ -179,37 +185,23 @@ function generateRoomId(): string {
 }
 
 /**
- * 数値を指定範囲内にクランプ
- */
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
-}
-
-/**
  * ルームを作成（作成者は seats[0] に固定配置）
  */
 export function createRoom(roomSize: number, nickname: string, turnSeconds: number = 15, maxCucumbers: number = 6): { success: boolean; roomId?: string; reason?: string } {
   try {
-    if (!nickname || typeof nickname !== 'string' || !nickname.trim()) {
+    const trimmedNickname = normalizeNickname(nickname);
+    if (!trimmedNickname) {
       return { success: false, reason: 'bad-request' };
     }
 
-    const size = clamp(roomSize, 2, 6);
     const rooms = getRoomsStorage();
     const id = generateRoomId();
-
-    const room: Room = {
+    const settings = normalizeFriendRoomSettings({ roomSize, turnSeconds, maxCucumbers });
+    const room = createFriendRoom({
       id,
-      size,
-      seats: Array.from({ length: size }, () => null),
-      status: 'waiting',
-      createdAt: Date.now(),
-      turnSeconds: Math.max(0, turnSeconds),
-      maxCucumbers: clamp(maxCucumbers, 4, 7)
-    };
-
-    // ★ 作成者は必ず先頭席（seats[0]）に配置
-    room.seats[0] = { nickname: nickname.trim() };
+      nickname: trimmedNickname,
+      ...settings,
+    });
 
     rooms.set(id, room);
     saveRoomsToStorage(rooms);
@@ -227,47 +219,25 @@ export function createRoom(roomSize: number, nickname: string, turnSeconds: numb
 export function joinRoom(roomId: string, nickname: string): { success: boolean; roomId?: string; reason?: string } {
   try {
     logRoomDebug(`[RoomSystem] Attempting to join room ${roomId} with nickname: ${nickname}`);
-    
-    if (!nickname || typeof nickname !== 'string' || !nickname.trim()) {
+
+    const trimmedNickname = normalizeNickname(nickname);
+    if (!trimmedNickname) {
       logRoomDebug('[RoomSystem] Invalid nickname provided');
       return { success: false, reason: 'bad-request' };
     }
 
     const rooms = getRoomsStorage();
     const room = rooms.get(roomId);
-
-    if (!room) {
-      logRoomDebug(`[RoomSystem] Room ${roomId} not found`);
-      return { success: false, reason: 'not-found' };
+    const result = joinRoomSnapshot(room ?? null, trimmedNickname);
+    if (!result.ok) {
+      logRoomDebug(`[RoomSystem] Room join failed: ${result.reason}`);
+      return { success: false, reason: result.reason };
     }
 
-    if (room.status !== 'waiting') {
-      logRoomDebug(`[RoomSystem] Room ${roomId} is not in waiting status: ${room.status}`);
-      return { success: false, reason: 'locked' };
-    }
-
-    const trimmedNickname = nickname.trim();
-    logRoomDebug(`[RoomSystem] Room ${roomId} current seats:`, room.seats.map((s, i) => `${i}: ${s?.nickname || 'empty'}`));
-
-    // 既に着席済み（同名）の場合はそのままOK（再入室）
-    const existingIndex = room.seats.findIndex(s => s && s.nickname === trimmedNickname);
-    if (existingIndex >= 0) {
-      logRoomDebug(`[RoomSystem] Player ${trimmedNickname} already in room at seat ${existingIndex}`);
-      return { success: true, roomId };
-    }
-
-    // 空席検索して着席
-    const emptyIndex = room.seats.findIndex(s => s === null);
-    if (emptyIndex === -1) {
-      logRoomDebug(`[RoomSystem] Room ${roomId} is full`);
-      return { success: false, reason: 'full' };
-    }
-
-    room.seats[emptyIndex] = { nickname: trimmedNickname };
-    rooms.set(roomId, room);
+    rooms.set(roomId, result.room);
     saveRoomsToStorage(rooms);
 
-    logRoomDebug(`[RoomSystem] Player ${trimmedNickname} successfully joined room ${roomId} at seat ${emptyIndex}`);
+    logRoomDebug(`[RoomSystem] Player ${trimmedNickname} successfully joined room ${roomId} at seat ${result.seatIndex}`);
     return { success: true, roomId };
   } catch (error) {
     console.error('Room join error:', error);

--- a/apps/hub/lib/roomsRedis.ts
+++ b/apps/hub/lib/roomsRedis.ts
@@ -2,54 +2,61 @@ import type { Room, RoomGameSnapshot } from '@/types/room';
 import { isRedisAvailable, redis } from './redis';
 
 const key = (id: string) => `room:${id}`;
+const DEBUG_ROOMS = process.env.NEXT_PUBLIC_DEBUG_ROOMS === '1';
+const debugLog = (...args: unknown[]) => {
+  if (DEBUG_ROOMS) console.log(...args);
+};
+const debugWarn = (...args: unknown[]) => {
+  if (DEBUG_ROOMS) console.warn(...args);
+};
 
 export async function getRoomByIdRedis(roomId: string): Promise<Room | null> {
   if (!isRedisAvailable()) {
-    console.log('[Redis] Vercel KV not available, skipping Redis operations');
+    debugLog('[Redis] Vercel KV not available, skipping Redis operations');
     return null;
   }
 
   try {
-    console.log('[Redis] Getting room from KV:', key(roomId));
+    debugLog('[Redis] Getting room from KV:', key(roomId));
     const obj = await redis.get<Room>(key(roomId));
     if (!obj) return null;
     return obj as Room;
   } catch (error) {
-    console.warn('[Redis] Failed to get room from KV:', error);
+    debugWarn('[Redis] Failed to get room from KV:', error);
     return null;
   }
 }
 
 export async function putRoomRedis(room: Room): Promise<void> {
   if (!isRedisAvailable()) {
-    console.log('[Redis] Vercel KV not available, skipping Redis save');
+    debugLog('[Redis] Vercel KV not available, skipping Redis save');
     return;
   }
 
   try {
-    console.log('[Redis] Saving room to KV:', key(room.id));
+    debugLog('[Redis] Saving room to KV:', key(room.id));
     await redis.set(key(room.id), room);
   } catch (error) {
-    console.warn('[Redis] Failed to save room to KV:', error);
+    debugWarn('[Redis] Failed to save room to KV:', error);
     throw error;
   }
 }
 
 export async function updateRoomRedis(roomId: string, patch: Partial<Room>): Promise<boolean> {
   if (!isRedisAvailable()) {
-    console.log('[Redis] Vercel KV not available, skipping Redis update');
+    debugLog('[Redis] Vercel KV not available, skipping Redis update');
     return false;
   }
 
   try {
-    console.log('[Redis] Updating room in KV:', key(roomId));
+    debugLog('[Redis] Updating room in KV:', key(roomId));
     const current = await redis.get<Room>(key(roomId));
     if (!current) return false;
     const next = { ...current, ...patch } as Room;
     await redis.set(key(roomId), next);
     return true;
   } catch (error) {
-    console.warn('[Redis] Failed to update room in KV:', error);
+    debugWarn('[Redis] Failed to update room in KV:', error);
     return false;
   }
 }

--- a/apps/hub/vitest.config.ts
+++ b/apps/hub/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: [
+      'lib/__tests__/**/*.test.ts',
       'lib/game-core/__tests__/**/*.test.ts',
       'lib/modes/**/__tests__/**/*.test.ts',
     ],

--- a/docs/friend-match-sync.md
+++ b/docs/friend-match-sync.md
@@ -1,0 +1,45 @@
+# Friend Match Synchronization
+
+This document records the Phase 3 MVP synchronization strategy for friend-room matches.
+
+## Source of Truth
+
+Friend matches use server-side API routes as the gameplay authority.
+
+- Room metadata is stored under `friend:room:<6-digit-room-id>` in the shared KV store.
+- Game snapshots are written by the friend game API after host initialization and each accepted move.
+- Clients poll the game API for authoritative state updates.
+- Ably is an optional room-update accelerator. Polling remains the required fallback.
+
+The browser `localStorage` room store is only a local review mode for room creation, joining, and waiting-room UI. It is not a real multi-device match store, and local review rooms cannot start friend gameplay.
+
+## Room ID Rule
+
+Friend room IDs are exactly six digits.
+
+- Create API generates six digits.
+- Join UI strips non-digits and caps input at six digits.
+- Room, join, status, leave, and game APIs reject malformed IDs.
+
+## Authority Checks
+
+The server checks room membership before game actions.
+
+- Only the host seat can start a waiting room.
+- Starting requires all seats to be filled.
+- Only the host can initialize the game snapshot.
+- A move is accepted only when the submitted nickname matches the move player's seat.
+
+These checks currently use the room nickname/seat model already present in the app. Firebase auth still gates server API access, but seat authorization for this MVP is based on room membership.
+
+## Required Environment
+
+Real friend matches require:
+
+- Firebase client configuration for anonymous sign-in.
+- Firebase Admin configuration for API token verification.
+- KV shared-store credentials.
+- `NEXT_PUBLIC_HAS_SHARED_STORE=true` or `NEXT_PUBLIC_USE_SERVER=true` when the client should use server synchronization.
+- `ABLY_API_KEY` only when realtime room update events are desired.
+
+Without these, the app should show a clear backend requirement message instead of starting a broken match.

--- a/docs/work-plan.md
+++ b/docs/work-plan.md
@@ -62,6 +62,7 @@ Goal: make friend-room play reliable enough for real users.
 Tasks:
 
 - Confirm the server-source-of-truth strategy: KV, Redis, polling, Ably, or a combination.
+  - Phase 3 MVP decision: room metadata lives in shared KV, game updates go through the friend game API, clients poll authoritative snapshots, and Ably is optional acceleration.
 - Verify room creation, join, waiting room, start, play, and game-over flow with two browser sessions.
 - Ensure room IDs, copy text, and validation all use the same 6-digit rule.
 - Clarify host-only actions and non-host behavior.


### PR DESCRIPTION
## Summary
- Centralized friend-room helpers for 6-digit room IDs, settings normalization, host checks, seat lookup, and join behavior.
- Hardened friend APIs so room/status/game actions validate 6-digit IDs, room membership, host-only start/init, full-room start, and player-to-seat move ownership.
- Updated friend create/join/waiting/play flows to use the server API paths consistently, pass actor nicknames for server authorization, block local review rooms from starting gameplay, and avoid Firebase/Ably initialization when server sync is disabled.
- Gated Ably/KV debug logs behind `NEXT_PUBLIC_DEBUG_ROOMS` and documented the Phase 3 synchronization strategy in `docs/friend-match-sync.md`.
- Added friend-room unit coverage and brought the existing nickname tests into the hub Vitest suite.

## Validation
- `pnpm --filter @five-cucumber/hub test` (61 tests passing)
- `pnpm --filter @five-cucumber/hub type-check`
- `pnpm -w run type-check`
- `pnpm -w run build`
- `git diff --check`
- Browser smoke: local friend create -> local join -> waiting room full -> host start shows local-review block message.
- Fresh headless browser profile smoke: seeded local full room renders `/friend/room/123456` without runtime overlay or console errors.

## Notes
- `pnpm -w run check:store` was attempted with `BASE_URL=http://127.0.0.1:3000`; it cannot complete in this local environment because the shared-store diagnostic and friend/create API require Firebase auth, returning 401 without an auth token.
- Existing functions package still warns that it expects Node 18 while this environment is Node v22.16.0.