### PR TITLE
2026-05-26 09:38 JST: route and test cleanup

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -55,12 +55,15 @@ See `docs/work-plan.md` for details.
 
 ## Near-Term Priority
 
-Finish Phase 3 Friend Match MVP, then stop for user review before starting Phase 4.
+Finish Phase 4 Route and Test Cleanup, then stop for user review before starting Phase 5.
 
 ## Open Decisions
 
 - Define the exact review checklist for "Web version complete."
-- Decide whether legacy generic `/play/[gameId]` and `/lobby/[gameId]` routes should be redirected, removed, or revived later.
 - Decide whether UI should formally adopt Tailwind or move away from Tailwind-style utility classes.
 - Decide whether future Blender use is asset-generation only or part of a larger 3D workflow.
 - Decide whether Unity is ever a separate edition, a prototype, or unnecessary.
+
+## Resolved Route Decision
+
+Legacy generic `/play/[gameId]` and `/lobby/[gameId]` routes are retained as compatibility redirects to the current MVP routes. They should not contain separate legacy UI or old room-code behavior.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,12 @@ tests/             root-level Playwright tests
 /online                   future public online mode placeholder
 ```
 
-Legacy generic routes under `/play/[gameId]` and `/lobby/[gameId]` are not the current MVP path unless a future phase explicitly revives them.
+Legacy generic routes are compatibility redirects only:
+
+- `/play/cucumber5` -> `/cucumber/cpu/play`
+- `/lobby/cucumber5?mode=friends` -> `/friend`
+- `/lobby/cucumber5?mode=cpu` -> `/cucumber/cpu/settings`
+- `/lobby/cucumber5?mode=public` -> `/online`
 
 ## Quick Start
 

--- a/apps/hub/app/(routes)/lobby/[gameId]/page.tsx
+++ b/apps/hub/app/(routes)/lobby/[gameId]/page.tsx
@@ -1,94 +1,28 @@
-'use client';
-import { useState, useEffect } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { redirect } from 'next/navigation';
 
-type LobbyUser = { isAnonymous: boolean } | null;
+type LegacyLobbyPageProps = {
+  params: { gameId: string };
+  searchParams?: Record<string, string | string[] | undefined>;
+};
 
-// AuthProvider削除済みのため、ダミーのuseAuth実装
-const useAuth = (): { user: LobbyUser } => ({ user: null });
+function firstSearchValue(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
 
-function genCode(){ return String(Math.floor(Math.random()*100000)).padStart(5,'0'); }
+export default function LegacyLobbyPage({ params, searchParams }: LegacyLobbyPageProps) {
+  if (params.gameId !== 'cucumber5') {
+    redirect('/home');
+  }
 
-export default function LobbyPage({ params: _params }: { params: { gameId:string } }){
-  const { user } = useAuth();
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const urlMode = searchParams.get('mode');
+  const mode = firstSearchValue(searchParams?.mode);
 
-  useEffect(() => {
-    if (urlMode === 'friends' && (!user || user.isAnonymous)) {
-      const currentUrl = window.location.href;
-      router.replace(`/auth/login?next=${encodeURIComponent(currentUrl)}`);
-    }
-  }, [user, urlMode, router]);
+  if (mode === 'friends') {
+    redirect('/friend');
+  }
 
-  const [mode,setMode] = useState<'idle'|'create'|'join'>('idle');
-  const [seats,setSeats] = useState(4);
-  const [code,setCode] = useState('');
-  const [created,setCreated] = useState<string|null>(null);
-  const canJoin = /^\d{5}$/.test(code);
+  if (mode === 'cpu') {
+    redirect('/cucumber/cpu/settings');
+  }
 
-  return (
-    <main className="min-h-[calc(100svh-64px)] px-6 py-8">
-      <h1 className="text-2xl mb-6" style={{color:'var(--ink)'}}>オンラインロビー</h1>
-      <div className="grid gap-6 md:grid-cols-2">
-        {/* ルーム作成 */}
-        <section className="rounded-2xl p-6 bg-[var(--paper)] shadow">
-          <h2 className="text-xl mb-2" style={{color:'var(--cuke)'}}>ルーム作成</h2>
-          <p className="text-sm mb-4" style={{color:'var(--ink)'}}>5桁コードを発行してフレンドを招待</p>
-          <label className="block text-sm mb-2">人数（2–6）</label>
-          <input type="number" min={2} max={6} value={seats}
-            onChange={(e)=>setSeats(Number(e.target.value))}
-            className="border rounded px-3 py-2 mb-3 w-32" />
-          <button className="rounded-xl px-4 py-2 shadow"
-            style={{background:'var(--brass)',color:'#fff'}}
-            onClick={()=>{ setCreated(genCode()); setMode('create'); }}>
-            5桁コードを発行
-          </button>
-          {mode==='create' && created && (
-            <div className="mt-4 p-4 rounded-xl border" style={{borderColor:'var(--paper-edge)'}}>
-              <div className="text-sm opacity-70 mb-1">あなたのルームコード</div>
-              <div className="text-3xl tracking-widest font-mono">{created}</div>
-              <div className="mt-3 flex gap-2">
-                <button className="rounded-lg px-3 py-2 border"
-                  onClick={async()=>{ await navigator.clipboard.writeText(created); }}>
-                  コピー
-                </button>
-                <button className="rounded-lg px-3 py-2 border"
-                  onClick={()=>alert('TODO: Firebaseに部屋作成→待機画面へ')}>
-                  待機へ
-                </button>
-              </div>
-            </div>
-          )}
-        </section>
-        {/* ルーム参加 */}
-        <section className="rounded-2xl p-6 bg-[var(--paper)] shadow">
-          <h2 className="text-xl mb-2" style={{color:'var(--cuke)'}}>ルーム参加</h2>
-          <p className="text-sm mb-4" style={{color:'var(--ink)'}}>受け取った5桁コードを入力</p>
-          <input inputMode="numeric" pattern="\d{5}" maxLength={5}
-            placeholder="例: 12345" value={code}
-            onChange={(e)=>setCode(e.target.value.replace(/\D/g,''))}
-            className="border rounded px-4 py-3 text-2xl font-mono tracking-widest" />
-          <div className="mt-3 text-sm" style={{color:'var(--ink)'}}>
-            {!canJoin && code.length>0 && <span>5桁の数字を入力してください</span>}
-          </div>
-          <div className="mt-4 flex gap-2">
-            <button className="rounded-xl px-4 py-2 shadow disabled:opacity-50"
-              style={{background:'var(--brass)',color:'#fff'}} disabled={!canJoin}
-              onClick={()=>alert(`TODO: ルーム ${code} に参加`)}>
-              参加する
-            </button>
-            <button
-              type="button"
-              className="rounded-xl px-4 py-2 border"
-              onClick={() => router.push('/home')}
-            >
-              戻る
-            </button>
-          </div>
-        </section>
-      </div>
-    </main>
-  );
+  redirect('/online');
 }

--- a/apps/hub/app/(routes)/play/[gameId]/page.tsx
+++ b/apps/hub/app/(routes)/play/[gameId]/page.tsx
@@ -1,38 +1,41 @@
-'use client';
-import { useEffect, useRef, useState } from 'react';
+import { redirect } from 'next/navigation';
 
-type PlayPageProps = {
+type LegacyPlayPageProps = {
   params: { gameId: string };
   searchParams?: Record<string, string | string[] | undefined>;
 };
 
-export default function PlayPage({ params, searchParams }: PlayPageProps) {
-  const rootRef = useRef<HTMLDivElement>(null);
-  const [isLoaded, setIsLoaded] = useState(false);
+function appendLegacyPlaySearchParams(
+  path: string,
+  searchParams?: LegacyPlayPageProps['searchParams'],
+) {
+  const query = new URLSearchParams();
 
-  useEffect(() => {
-    // 一時的にシンプルな実装
-    const timer = setTimeout(() => {
-      setIsLoaded(true);
-    }, 1000);
+  for (const [key, value] of Object.entries(searchParams ?? {})) {
+    if (value === undefined) {
+      continue;
+    }
 
-    return () => clearTimeout(timer);
-  }, [params.gameId]);
+    const targetKey = key === 'difficulty' ? 'cpuLevel' : key;
 
-  return (
-    <main className="min-h-[calc(100svh-64px)] p-4">
-      <div ref={rootRef} className="w-full h-[80svh] rounded-xl bg-[var(--paper)] shadow grid place-items-center">
-        {isLoaded ? (
-          <div className="text-center">
-            <div className="text-2xl mb-4" style={{color:'var(--cuke)'}}>５本のきゅうり</div>
-            <div className="text-lg mb-2" style={{color:'var(--ink)'}}>ゲーム画面</div>
-            <div className="text-sm opacity-70 mb-4">ゲームID: {params.gameId}</div>
-            <div className="text-sm opacity-70">モード: {searchParams?.mode || 'cpu'}</div>
-          </div>
-        ) : (
-          <span className="opacity-60">読み込み中…</span>
-        )}
-      </div>
-    </main>
-  );
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        query.append(targetKey, item);
+      }
+      continue;
+    }
+
+    query.set(targetKey, value);
+  }
+
+  const queryString = query.toString();
+  return queryString ? `${path}?${queryString}` : path;
+}
+
+export default function LegacyPlayPage({ params, searchParams }: LegacyPlayPageProps) {
+  if (params.gameId === 'cucumber5') {
+    redirect(appendLegacyPlaySearchParams('/cucumber/cpu/play', searchParams));
+  }
+
+  redirect('/home');
 }

--- a/docs/deploy/firebase-auth-setup.md
+++ b/docs/deploy/firebase-auth-setup.md
@@ -1,88 +1,45 @@
-# Firebase Email Link認証設定ガイド
+# Firebase Authentication Setup
 
-## 1. Firebaseコンソールでの設定
+The current MVP does not use an email-link login page. Browser clients use Firebase client configuration for anonymous authentication, and friend-room API routes verify Firebase ID tokens on the server when server synchronization is enabled.
 
-### Email Link認証を有効化
+## Firebase Console
 
-1. **Firebaseコンソール**にログイン
-2. 対象プロジェクトを選択
-3. 左メニューから **「Authentication」** → **「Sign-in method」**
-4. **「Email/Password」** を選択
-5. **「Email link (passwordless sign-in)」** を有効化
-6. **「Save」** で保存
+1. Open Firebase Console.
+2. Select the project used by the deployed app.
+3. Open Authentication > Sign-in method.
+4. Enable Anonymous sign-in.
+5. Add these authorized domains under Authentication > Settings:
+   - `localhost`
+   - the production Vercel domain
+   - any preview or custom domains used for testing
 
-### 認証ドメインの設定
+## Client Environment Variables
 
-1. **「Authentication」** → **「Settings」** → **「Authorized domains」**
-2. 以下のドメインを追加：
-   - `localhost` (開発用)
-   - `five-cucumber-hub.vercel.app` (本番用)
-   - その他必要なドメイン
-
-## 2. 環境変数の設定
-
-### ローカル環境 (.env.local)
+Set these for local and deployed environments:
 
 ```env
-NEXT_PUBLIC_APP_ORIGIN=http://localhost:3000
+NEXT_PUBLIC_FIREBASE_API_KEY=your-api-key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=your-project-id
+NEXT_PUBLIC_FIREBASE_APP_ID=your-app-id
 ```
 
-### Vercel環境
+## Server Environment Variables
 
-1. Vercelダッシュボード → プロジェクト → **「Settings」**
-2. **「Environment Variables」** → **「Add New」**
-3. 以下を設定：
-   - **Name**: `NEXT_PUBLIC_APP_ORIGIN`
-   - **Value**: `https://five-cucumber-hub.vercel.app`
-   - **Environment**: `Production`
+Friend-room server sync requires Firebase Admin credentials so API routes can verify client tokens:
 
-## 3. 動作確認手順
-
-### ログイン機能のテスト
-
-1. `/auth/login` にアクセス
-2. **「新規作成」** タブを選択
-3. ユーザー名とメールアドレスを入力
-4. **「リンクを送信」** をクリック
-5. メール受信確認
-6. メール内のリンクをクリック
-7. `/auth/complete` で認証完了
-8. `/home` にリダイレクト確認
-
-### ログイン機能のテスト
-
-1. **「ログイン」** タブを選択
-2. メールアドレスを入力
-3. **「リンクを送信」** をクリック
-4. メール内のリンクで認証完了
-
-## 4. トラブルシューティング
-
-### よくある問題
-
-- **メールが届かない**: 迷惑メールフォルダを確認
-- **リンクが無効**: 同じブラウザで開く必要がある
-- **認証エラー**: Firebase設定と環境変数を再確認
-
-### ログ確認
-
-```bash
-# 開発環境でのログ確認
-pnpm -w dev
-
-# ブラウザの開発者ツールでコンソールエラーを確認
+```env
+FIREBASE_PROJECT_ID=your-project-id
+FIREBASE_CLIENT_EMAIL=firebase-adminsdk-...
+FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
 ```
 
-## 5. セキュリティ考慮事項
+## Smoke Check
 
-- Email Link認証は一時的なリンク（有効期限あり）
-- 同じデバイス/ブラウザでのみ有効
-- 本番環境ではHTTPS必須
-- ユーザー名の重複チェック（現在は簡易実装）
+1. Open `/home`.
+2. Set a nickname through `/setup` if needed.
+3. Open `/friend/create`.
+4. Create a room.
+5. Confirm the server-backed flow succeeds when shared-store variables are present.
 
-## 6. 今後の改善点
-
-- [ ] Cloud Functions でのユーザー名排他制御
-- [ ] メールテンプレートのカスタマイズ
-- [ ] 認証状態の永続化
-- [ ] エラーハンドリングの強化
+If Firebase Admin credentials or shared-store variables are missing, the UI should show a backend requirement message instead of starting a broken multi-device match.

--- a/docs/deploy/testing-guide.md
+++ b/docs/deploy/testing-guide.md
@@ -1,187 +1,90 @@
-# メールリンク認証テストガイド
+# Deployment Smoke Test Guide
 
-## テスト環境の準備
+This guide covers the current Web MVP smoke checks for local and deployed environments.
 
-### 1. ローカル環境でのテスト
+## Setup
+
+Local:
 
 ```bash
-# 開発サーバー起動
 pnpm -w dev
-
-# ブラウザで http://localhost:3000 にアクセス
 ```
 
-### 2. 本番環境でのテスト
+Open `http://localhost:3000`.
 
-- Vercelデプロイ完了後、本番URLでテスト
-- 環境変数が正しく設定されていることを確認
+Production:
 
-## テストケース
+- Use the latest deployed URL.
+- Confirm required Firebase client variables are present.
+- Confirm Firebase Admin and KV/Redis variables are present before testing real multi-device friend matches.
 
-### ケース1: 新規ユーザー登録
+## Core Smoke Tests
 
-#### 手順
-1. `/auth/login` にアクセス
-2. **「新規作成」** タブを選択
-3. ユーザー名を入力（例: `testuser`）
-4. メールアドレスを入力（例: `test@example.com`）
-5. **「リンクを送信」** をクリック
+### Home
 
-#### 期待結果
-- 「送信完了」メッセージが表示される
-- 入力したメールアドレスが表示される
-- メールが受信される
+1. Open `/home`.
+2. Confirm the `5本のきゅうり` title is visible.
+3. Confirm these links exist:
+   - CPU match: `/cucumber/cpu/settings`
+   - Friend match: `/friend/create`
+   - Online placeholder: `/online`
+   - Rules: `/rules`
 
-#### 確認項目
-- [ ] フォームバリデーションが正常に動作
-- [ ] エラーメッセージが適切に表示
-- [ ] メール送信が成功
-- [ ] 送信完了画面が表示
+### CPU Match
 
-### ケース2: メールリンクでの認証完了
+1. Open `/cucumber/cpu/settings`.
+2. Select player count, time limit, cucumber limit, and CPU difficulty.
+3. Start the match.
+4. Confirm the app navigates to `/cucumber/cpu/play`.
+5. Confirm the battle HUD, seats, and seven starting hand cards render.
 
-#### 手順
-1. 受信したメール内のリンクをクリック
-2. `/auth/complete` にリダイレクトされる
-3. 認証処理が実行される
-4. `/home` にリダイレクトされる
+### Friend Match
 
-#### 期待結果
-- 認証が正常に完了する
-- ユーザー情報がFirestoreに保存される
-- ホーム画面にリダイレクトされる
+1. Open `/friend`.
+2. Open `/friend/create`.
+3. Create a room after setting a nickname when prompted.
+4. Confirm the generated room code is six digits.
+5. Open `/friend/join` in a second browser profile or device.
+6. Join with the six-digit room code.
+7. Confirm both players reach the waiting room.
 
-#### 確認項目
-- [ ] 認証完了メッセージが表示
-- [ ] Firestoreに `profiles/{uid}` が作成される
-- [ ] Firestoreに `usernames/{name}` が作成される
-- [ ] ホーム画面に正しくリダイレクト
-- [ ] ヘッダーにユーザー名が表示
+When server sync is disabled or backend variables are missing, local review mode may create rooms only in the same browser storage. Real multi-device friend matches require Firebase authentication plus the shared store.
 
-### ケース3: 既存ユーザーのログイン
+### Legacy Route Compatibility
 
-#### 手順
-1. `/auth/login` にアクセス
-2. **「ログイン」** タブを選択
-3. 登録済みのメールアドレスを入力
-4. **「リンクを送信」** をクリック
-5. メール内のリンクで認証
+1. Open `/play/cucumber5?mode=cpu&players=2&difficulty=easy`.
+2. Confirm it redirects to `/cucumber/cpu/play` and maps `difficulty` to `cpuLevel`.
+3. Open `/lobby/cucumber5?mode=friends`.
+4. Confirm it redirects to `/friend`.
+5. Open `/lobby/cucumber5?mode=public`.
+6. Confirm it redirects to `/online`.
 
-#### 期待結果
-- 新規作成時と同様に認証が完了
-- 既存のユーザー情報が保持される
+## Validation Commands
 
-#### 確認項目
-- [ ] ログインタブが正常に動作
-- [ ] 既存ユーザーでの認証が成功
-- [ ] ユーザー情報が正しく表示
-
-### ケース4: ホーム画面の3CTA
-
-#### 手順
-1. 認証完了後、ホーム画面にアクセス
-2. 3つのCTAボタンを確認
-
-#### 期待結果
-- CPU対戦、オンライン対戦、フレンド対戦の3つが表示
-- 各ボタンが正しいリンクに遷移
-
-#### 確認項目
-- [ ] 3つのCTAが正しく表示
-- [ ] CPU対戦ボタンが `/play/cucumber5?mode=cpu...` に遷移
-- [ ] オンライン対戦ボタンが `/lobby/cucumber5?mode=public` に遷移
-- [ ] フレンド対戦ボタンが `/lobby/cucumber5?mode=friends` に遷移
-
-## エラーケースのテスト
-
-### ケース5: 無効なメールアドレス
-
-#### 手順
-1. 無効なメールアドレスを入力
-2. 送信を試行
-
-#### 期待結果
-- 適切なエラーメッセージが表示
-- 送信が失敗する
-
-### ケース6: 無効なリンク
-
-#### 手順
-1. 無効な認証リンクにアクセス
-
-#### 期待結果
-- エラーメッセージが表示
-- 適切なフォールバック処理が実行
-
-## パフォーマンステスト
-
-### ケース7: 同時アクセス
-
-#### 手順
-1. 複数のブラウザで同時に認証を試行
-2. レスポンス時間を測定
-
-#### 確認項目
-- [ ] 認証処理が正常に完了
-- [ ] レスポンス時間が許容範囲内
-- [ ] エラーが発生しない
-
-## セキュリティテスト
-
-### ケース8: 認証状態の確認
-
-#### 手順
-1. 認証完了後、ページをリロード
-2. 認証状態が保持されることを確認
-
-#### 確認項目
-- [ ] 認証状態が正しく保持
-- [ ] ユーザー情報が正しく表示
-- [ ] 未認証時の適切なリダイレクト
-
-## テスト結果の記録
-
-### テスト結果テンプレート
-
-```
-テスト日時: YYYY-MM-DD HH:MM
-テスト環境: [ローカル/本番]
-テスト者: [名前]
-
-ケース1: 新規ユーザー登録
-- 結果: [成功/失敗]
-- 備考: [詳細]
-
-ケース2: メールリンクでの認証完了
-- 結果: [成功/失敗]
-- 備考: [詳細]
-
-... (以下同様)
-```
-
-## 問題が発生した場合
-
-### ログの確認
+Use the smallest relevant command first, then broaden when needed:
 
 ```bash
-# ブラウザの開発者ツール
-console.log('認証エラー:', error)
-
-# Firebase コンソール
-# Authentication > Users でユーザー情報を確認
-# Firestore でデータの保存状況を確認
+pnpm -w run type-check
+pnpm -w run test
+pnpm -w run build
 ```
 
-### よくある問題と解決方法
+For root-level Playwright smoke tests:
 
-1. **メールが届かない**
-   - 迷惑メールフォルダを確認
-   - Firebase設定を確認
+```bash
+pnpm exec playwright test tests/home.spec.ts tests/navigation.spec.ts tests/game.spec.ts --project=chromium
+```
 
-2. **認証エラー**
-   - 環境変数の設定を確認
-   - Firebase設定を確認
+## Result Template
 
-3. **リダイレクトエラー**
-   - `NEXT_PUBLIC_APP_ORIGIN` の設定を確認
-   - 認証ドメインの設定を確認
+```text
+Test time: YYYY-MM-DD HH:MM JST
+Environment: local / production
+Commit: <sha>
+
+Home: pass / fail
+CPU match: pass / fail
+Friend match: pass / fail
+Legacy redirects: pass / fail
+Notes:
+```

--- a/docs/deploy/vercel-env-setup.md
+++ b/docs/deploy/vercel-env-setup.md
@@ -11,6 +11,14 @@
 | `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` | `your-project.firebaseapp.com` | Firebase Auth Domain |
 | `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | `your-project-id` | Firebase Project ID |
 | `NEXT_PUBLIC_FIREBASE_APP_ID` | `your-app-id` | Firebase App ID |
+| `FIREBASE_PROJECT_ID` | `your-project-id` | API token verification for server sync |
+| `FIREBASE_CLIENT_EMAIL` | `firebase-adminsdk-...` | API token verification for server sync |
+| `FIREBASE_PRIVATE_KEY` | `-----BEGIN PRIVATE KEY-----...` | API token verification for server sync |
+| `KV_REST_API_URL` / `KV_REST_API_TOKEN` | Vercel KV or compatible values | Shared friend-room state |
+| `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` | Upstash Redis values | Shared friend-room state fallback |
+| `NEXT_PUBLIC_HAS_SHARED_STORE` | `true` | Enable server-backed friend-room flow |
+| `NEXT_PUBLIC_USE_SERVER` | `true` | Enable server-backed friend-room flow |
+| `ABLY_API_KEY` | Ably key | Optional room update acceleration |
 
 ## Vercelでの設定手順
 
@@ -72,11 +80,12 @@ pnpm -w dev
 console.log(process.env.NEXT_PUBLIC_APP_ORIGIN)
 ```
 
-### 2. 認証機能のテスト
+### 2. 現行MVPの動作確認
 
-1. `/auth/login` にアクセス
-2. メールリンク認証が正常に動作することを確認
-3. 認証後のリダイレクトが正しく動作することを確認
+1. `/home` にアクセス
+2. `/cucumber/cpu/settings` からCPU対戦を開始できることを確認
+3. `/friend/create` と `/friend/join` で6桁ルームコードの作成・参加導線を確認
+4. サーバー同期を使う場合、Firebase匿名認証と共有ストア設定が不足していないことを確認
 
 ## トラブルシューティング
 

--- a/docs/i18n/en.json
+++ b/docs/i18n/en.json
@@ -100,17 +100,17 @@
   "time.justNow": "Just now",
   
   "lobby.create.title": "Create Room",
-  "lobby.create.desc": "Generate a 5-digit code to invite friends",
-  "lobby.create.generate": "Generate 5-digit Code",
+  "lobby.create.desc": "Generate a 6-digit code to invite friends",
+  "lobby.create.generate": "Generate 6-digit Code",
   "lobby.create.code": "Your Room Code",
   "lobby.create.copy": "Copy",
   "lobby.create.wait": "Go to Waiting",
   "lobby.participants": "Participants",
   "lobby.start": "Start Game",
   "lobby.join.title": "Join Room",
-  "lobby.join.desc": "Enter the 5-digit code you received",
-  "lobby.join.placeholder": "e.g. 12345",
+  "lobby.join.desc": "Enter the 6-digit code you received",
+  "lobby.join.placeholder": "e.g. 123456",
   "lobby.join.submit": "Join",
   "common.back": "Back",
-  "validation.code": "Please enter 5 digits"
+  "validation.code": "Please enter 6 digits"
 }

--- a/docs/i18n/ja.json
+++ b/docs/i18n/ja.json
@@ -100,17 +100,17 @@
   "time.justNow": "たった今",
   
   "lobby.create.title": "ルーム作成",
-  "lobby.create.desc": "5桁コードを発行してフレンドを招待",
-  "lobby.create.generate": "5桁コードを発行",
+  "lobby.create.desc": "6桁コードを発行してフレンドを招待",
+  "lobby.create.generate": "6桁コードを発行",
   "lobby.create.code": "あなたのルームコード",
   "lobby.create.copy": "コピー",
   "lobby.create.wait": "待機へ",
   "lobby.participants": "参加者",
   "lobby.start": "対戦開始",
   "lobby.join.title": "ルーム参加",
-  "lobby.join.desc": "受け取った5桁コードを入力",
-  "lobby.join.placeholder": "例: 12345",
+  "lobby.join.desc": "受け取った6桁コードを入力",
+  "lobby.join.placeholder": "例: 123456",
   "lobby.join.submit": "参加する",
   "common.back": "戻る",
-  "validation.code": "5桁の数字を入力してください"
+  "validation.code": "6桁の数字を入力してください"
 }

--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -25,7 +25,7 @@
 - [ ] プッシュ通知
 - [ ] 音声/効果音
 - [ ] Firebase Admin / KV 未設定時のローカル開発挙動
-- [ ] `/play/[gameId]` と `/lobby/[gameId]` の扱い
+- [x] `/play/[gameId]` と `/lobby/[gameId]` の扱い: 現行MVPルートへの互換リダイレクトとして維持
 
 ## 収益化/分析
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -32,6 +32,7 @@ Unity and Blender are deferred. They should not be introduced into the repositor
 - Friend waiting room at `/friend/room/[roomId]`
 - Friend match play at `/friend/play/[roomCode]`
 - Rules pages at `/rules` and `/rules/cucumber5`
+- Compatibility redirects from legacy `/play/cucumber5` and `/lobby/cucumber5` routes to current MVP routes
 
 ### Deferred
 
@@ -81,7 +82,6 @@ The Web version can be considered complete when all of these are true:
 - Legacy docs and tests still mention old routes or old flow assumptions.
 - Public online mode is only a placeholder.
 - Friend match depends on authenticated API requests and shared store configuration.
-- Generic `/play/[gameId]` and `/lobby/[gameId]` routes are legacy paths, not the current MVP flow.
 - Some UI files still use Tailwind-style utility classes even though Tailwind is not configured as a project dependency.
 - Debug logs and diagnostic surfaces need cleanup before production polish.
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,5 +1,7 @@
 # Telemetry Specification
 
+Historical reference only. This document records an earlier analytics concept and has not been aligned with the current MVP routes. Treat `docs/product-spec.md` and `README.md` as authoritative for current routes.
+
 ## イベント設計
 
 ### Firebase Analytics Events

--- a/docs/ux/style-guide.md
+++ b/docs/ux/style-guide.md
@@ -1,5 +1,7 @@
 # UX Style Guide - Table of Classics
 
+Historical reference only. This document preserves earlier UX ideas and old route sketches. Current product scope and routes are defined in `docs/product-spec.md` and `README.md`.
+
 ## Design Principles
 
 ### 可読性とアクセシビリティ

--- a/docs/work-plan.md
+++ b/docs/work-plan.md
@@ -80,7 +80,7 @@ Goal: remove confusion from legacy paths and stale tests.
 
 Tasks:
 
-- Decide whether `/play/[gameId]` and `/lobby/[gameId]` should be removed, redirected, or revived later.
+- Retain `/play/[gameId]` and `/lobby/[gameId]` as compatibility redirects to current MVP routes.
 - Update root Playwright tests to current routes and current UI.
 - Remove references to nonexistent `/stats`, `/settings`, `/auth/login`, old modal behavior, and old 5-digit room codes from current docs.
 - Keep historical docs marked as reference only.

--- a/tests/game.spec.ts
+++ b/tests/game.spec.ts
@@ -1,114 +1,35 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
-test.describe('Cucumber5 Game', () => {
-  test('should start game with 4 players', async ({ page }) => {
-    await page.goto('/play/cucumber5?mode=cpu&players=4&difficulty=normal');
-    
-    // Wait for game to load
-    await page.waitForSelector('.cucumber5-game', { timeout: 10000 });
-    
-    // Check if game elements are present
-    await expect(page.locator('.cucumber5-game')).toBeVisible();
-    await expect(page.locator('.game-hud')).toBeVisible();
-    await expect(page.locator('.player-hand')).toBeVisible();
-    
-    // Check for 4 player seats
-    const seats = page.locator('.seat');
-    await expect(seats).toHaveCount(4);
-    
-    // Check if seats are positioned correctly (no overlap)
-    const seatBoxes = await seats.boundingBox();
-    if (seatBoxes) {
-      // Basic overlap check - seats should be positioned in a circle
-      const centerX = 400; // Approximate center
-      const centerY = 300;
-      const radius = 200; // Approximate radius
-      
-      // Check that seats are roughly positioned in a circle
-      for (let i = 0; i < 4; i++) {
-        const seat = seats.nth(i);
-        const box = await seat.boundingBox();
-        if (box) {
-          const distance = Math.sqrt(
-            Math.pow(box.x + box.width/2 - centerX, 2) + 
-            Math.pow(box.y + box.height/2 - centerY, 2)
-          );
-          expect(distance).toBeLessThan(radius + 100); // Allow some tolerance
-        }
-      }
+test.describe('Cucumber5 CPU Game', () => {
+  test('starts a CPU match from the current route', async ({ page }) => {
+    await page.goto('/cucumber/cpu/play?players=4&turnSeconds=0&maxCucumbers=5&cpuLevel=normal');
+
+    await expect(page).toHaveTitle(/CPU対戦 \| Five Cucumber/);
+    await expect(page.locator('.battle-hud')).toContainText('第1回戦');
+    await expect(page.locator('.ellipse-table')).toBeVisible();
+    await expect(page.locator('#hand-dock')).toBeVisible();
+    await expect(page.locator('#seats .seat')).toHaveCount(4);
+    await expect(page.locator('#hand-dock .game-card')).toHaveCount(7);
+  });
+
+  test('renders supported CPU player counts', async ({ page }) => {
+    for (const count of [2, 3, 4, 5, 6]) {
+      await page.goto(
+        `/cucumber/cpu/play?players=${count}&turnSeconds=0&maxCucumbers=5&cpuLevel=easy`,
+      );
+
+      await expect(page.locator('.ellipse-table')).toBeVisible();
+      await expect(page.locator('#seats .seat')).toHaveCount(count);
+      await expect(page.locator('#seats')).toHaveClass(new RegExp(`players-${count}`));
     }
   });
 
-  test('should handle different player counts', async ({ page }) => {
-    const playerCounts = [2, 3, 4, 5, 6];
-    
-    for (const count of playerCounts) {
-      await page.goto(`/play/cucumber5?mode=cpu&players=${count}&difficulty=normal`);
-      
-      // Wait for game to load
-      await page.waitForSelector('.cucumber5-game', { timeout: 10000 });
-      
-      // Check correct number of seats
-      const seats = page.locator('.seat');
-      await expect(seats).toHaveCount(count);
-      
-      // Check that seats don't overlap significantly
-      const seatBoxes = await seats.all();
-      for (let i = 0; i < seatBoxes.length; i++) {
-        for (let j = i + 1; j < seatBoxes.length; j++) {
-          const box1 = await seatBoxes[i].boundingBox();
-          const box2 = await seatBoxes[j].boundingBox();
-          
-          if (box1 && box2) {
-            // Check for significant overlap (more than 50% of smaller element)
-            const overlap = Math.max(0, Math.min(box1.x + box1.width, box2.x + box2.width) - Math.max(box1.x, box2.x)) *
-                          Math.max(0, Math.min(box1.y + box1.height, box2.y + box2.height) - Math.max(box1.y, box2.y));
-            
-            const smallerArea = Math.min(box1.width * box1.height, box2.width * box2.height);
-            const overlapRatio = overlap / smallerArea;
-            
-            expect(overlapRatio).toBeLessThan(0.5); // Less than 50% overlap
-          }
-        }
-      }
-    }
-  });
+  test('shows playable cards when it is the human turn', async ({ page }) => {
+    await page.goto(
+      '/cucumber/cpu/play?players=2&turnSeconds=0&maxCucumbers=6&cpuLevel=easy&seed=5',
+    );
 
-  test('should display game UI elements', async ({ page }) => {
-    await page.goto('/play/cucumber5?mode=cpu&players=4&difficulty=normal');
-    
-    // Wait for game to load
-    await page.waitForSelector('.cucumber5-game', { timeout: 10000 });
-    
-    // Check HUD elements
-    await expect(page.locator('.round-indicator')).toBeVisible();
-    await expect(page.locator('.timer-display')).toBeVisible();
-    await expect(page.locator('.game-title')).toContainText('５本のきゅうり');
-    
-    // Check center area
-    await expect(page.locator('.center-area')).toBeVisible();
-    await expect(page.locator('.center-area__field')).toBeVisible();
-    await expect(page.locator('.center-area__graveyard')).toBeVisible();
-    
-    // Check player hand
-    await expect(page.locator('.player-hand')).toBeVisible();
-    await expect(page.locator('.player-hand__card')).toHaveCount(7); // Initial 7 cards
-  });
-
-  test('should handle card interactions', async ({ page }) => {
-    await page.goto('/play/cucumber5?mode=cpu&players=4&difficulty=normal');
-    
-    // Wait for game to load
-    await page.waitForSelector('.cucumber5-game', { timeout: 10000 });
-    
-    // Wait for player's turn
-    await page.waitForSelector('.player-hand__card--playable', { timeout: 15000 });
-    
-    // Click on a playable card
-    const playableCard = page.locator('.player-hand__card--playable').first();
-    await playableCard.click();
-    
-    // Check that card was played (field should update)
-    await expect(page.locator('.center-area__card--field')).toBeVisible();
+    await expect(page.locator('#hand-dock .game-card')).toHaveCount(7);
+    await expect(page.locator('#hand-dock .game-card.playable').first()).toBeVisible();
   });
 });

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,44 +1,32 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.describe('Home Page', () => {
-  test('should display home page with game tiles', async ({ page }) => {
+  test('shows the current game entry points', async ({ page }) => {
     await page.goto('/home');
-    
-    // Check if the page loads
+
     await expect(page).toHaveTitle(/Five Cucumber/);
-    
-    // Check for main elements
-    await expect(page.locator('h1')).toContainText('ようこそ');
-    await expect(page.locator('[data-testid="presence-badge"]')).toBeVisible();
-    
-    // Check for game tile
-    await expect(page.locator('.game-tile')).toBeVisible();
-    await expect(page.locator('.game-tile__name')).toContainText('５本のきゅうり');
+    await expect(page.getByRole('heading', { name: '5本のきゅうり' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'ルール説明' })).toHaveAttribute(
+      'href',
+      '/rules',
+    );
+    await expect(page.getByRole('link', { name: 'CPU対戦を始める' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'フレンド対戦を始める' })).toBeVisible();
   });
 
-  test('should filter games by player count', async ({ page }) => {
+  test('opens CPU settings from the primary CTA', async ({ page }) => {
     await page.goto('/home');
-    
-    // Change player count
-    await page.selectOption('select[id="playerCount"]', '2');
-    
-    // Check if game is still visible (cucumber5 supports 2-6 players)
-    await expect(page.locator('.game-tile')).toBeVisible();
-    
-    // Change to unsupported player count
-    await page.selectOption('select[id="playerCount"]', '1');
-    
-    // Check if no games message appears
-    await expect(page.locator('.no-games')).toBeVisible();
+    await page.getByRole('link', { name: 'CPU対戦を始める' }).click();
+
+    await expect(page).toHaveURL('/cucumber/cpu/settings');
+    await expect(page.getByRole('heading', { name: 'CPU 対戦の設定' })).toBeVisible();
   });
 
-  test('should navigate to lobby when clicking play', async ({ page }) => {
+  test('opens friend room creation from the primary CTA', async ({ page }) => {
     await page.goto('/home');
-    
-    // Click play button
-    await page.click('.game-tile .btn--primary');
-    
-    // Should navigate to lobby
-    await expect(page).toHaveURL(/\/lobby\/cucumber5/);
+    await page.getByRole('link', { name: 'フレンド対戦を始める' }).click();
+
+    await expect(page).toHaveURL('/friend/create');
+    await expect(page.getByRole('heading', { name: 'フレンドルームを作成' })).toBeVisible();
   });
 });

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -1,54 +1,41 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.describe('Navigation', () => {
-  test('should navigate between pages', async ({ page }) => {
+  test('home links point at current MVP routes', async ({ page }) => {
     await page.goto('/home');
-    
-    // Navigate to stats
-    await page.click('a[href="/stats"]');
-    await expect(page).toHaveURL('/stats');
-    await expect(page.locator('h1')).toContainText('統計');
-    
-    // Navigate to settings
-    await page.click('a[href="/settings"]');
-    await expect(page).toHaveURL('/settings');
-    await expect(page.locator('h1')).toContainText('設定');
-    
-    // Navigate back to home
-    await page.click('a[href="/home"]');
-    await expect(page).toHaveURL('/home');
-    await expect(page.locator('h1')).toContainText('ようこそ');
+
+    await expect(page).toHaveTitle(/Five Cucumber/);
+    await expect(page.getByRole('heading', { name: '5本のきゅうり' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'CPU対戦を始める' })).toHaveAttribute(
+      'href',
+      '/cucumber/cpu/settings',
+    );
+    await expect(page.getByRole('link', { name: 'フレンド対戦を始める' })).toHaveAttribute(
+      'href',
+      '/friend/create',
+    );
+    await expect(page.getByRole('link', { name: 'オンライン対戦' })).toHaveAttribute(
+      'href',
+      '/online',
+    );
   });
 
-  test('should handle mobile navigation', async ({ page }) => {
-    // Set mobile viewport
-    await page.setViewportSize({ width: 375, height: 667 });
-    await page.goto('/home');
-    
-    // Check if mobile menu toggle is visible
-    await expect(page.locator('.header-menu-toggle')).toBeVisible();
-    
-    // Open mobile menu
-    await page.click('.header-menu-toggle');
-    await expect(page.locator('.header-mobile-menu')).toBeVisible();
-    
-    // Navigate using mobile menu
-    await page.click('.mobile-nav-link[href="/stats"]');
-    await expect(page).toHaveURL('/stats');
-    
-    // Menu should close after navigation
-    await expect(page.locator('.header-mobile-menu')).not.toBeVisible();
+  test('legacy play route redirects to CPU play and preserves settings', async ({ page }) => {
+    await page.goto('/play/cucumber5?mode=cpu&players=2&difficulty=easy&turnSeconds=0');
+
+    await expect(page).toHaveURL(
+      /\/cucumber\/cpu\/play\?mode=cpu&players=2&cpuLevel=easy&turnSeconds=0$/,
+    );
   });
 
-  test('should maintain active state in navigation', async ({ page }) => {
-    await page.goto('/home');
-    
-    // Check home link is active
-    await expect(page.locator('a[href="/home"]')).toHaveClass(/nav-link--active/);
-    
-    // Navigate to stats
-    await page.click('a[href="/stats"]');
-    await expect(page.locator('a[href="/stats"]')).toHaveClass(/nav-link--active/);
-    await expect(page.locator('a[href="/home"]')).not.toHaveClass(/nav-link--active/);
+  test('legacy lobby route redirects to current entry points', async ({ page }) => {
+    await page.goto('/lobby/cucumber5?mode=friends');
+    await expect(page).toHaveURL('/friend');
+
+    await page.goto('/lobby/cucumber5?mode=cpu');
+    await expect(page).toHaveURL('/cucumber/cpu/settings');
+
+    await page.goto('/lobby/cucumber5?mode=public');
+    await expect(page).toHaveURL('/online');
   });
 });


### PR DESCRIPTION
## Summary
- Replace legacy `/play/[gameId]` and `/lobby/[gameId]` UI with compatibility redirects to current MVP routes.
- Refresh root Playwright smoke specs for current home, CPU, friend, online, and legacy redirect flows.
- Update current deployment/docs route guidance, Firebase auth setup, six-digit room-code copy, and mark old UX/telemetry docs as historical reference.

## Validation
- `pnpm -w run type-check`
- `pnpm --filter @five-cucumber/hub test`
- `pnpm -w run test`
- `pnpm -w run build`
- `git diff --check`
- Browser smoke check on local dev server for `/home`, legacy redirects, and `/cucumber/cpu/play`

## Note
- `pnpm exec playwright test tests/home.spec.ts tests/navigation.spec.ts tests/game.spec.ts --project=chromium` could not run because the repository does not currently provide a `playwright` binary/dependency.