### PR TITLE
2026-06-02 antique asset requirements

### DIFF
--- a/assets/ui/antique/README.md
+++ b/assets/ui/antique/README.md
@@ -11,6 +11,8 @@ Generated source assets for the antique cucumber table direction.
 
 ## Processing
 
+Asset requirements are defined in `asset-requirements.md`.
+
 Run this from the repository root to regenerate `processed/`:
 
 ```powershell
@@ -18,3 +20,9 @@ powershell -ExecutionPolicy Bypass -File tooling\process-antique-assets.ps1
 ```
 
 The cleanup script preserves `source/` and writes transparent PNGs into `processed/`.
+
+To validate current source and processed assets without rewriting files:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tooling\process-antique-assets.ps1 -ValidateOnly
+```

--- a/assets/ui/antique/asset-requirements.md
+++ b/assets/ui/antique/asset-requirements.md
@@ -1,0 +1,54 @@
+# Antique UI Asset Requirements
+
+This document defines the accepted image assets for the antique cucumber UI direction.
+Replacement assets should keep the same file names and pass `tooling/process-antique-assets.ps1 -ValidateOnly`.
+
+## Validation Command
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tooling\process-antique-assets.ps1 -ValidateOnly
+```
+
+To regenerate processed cutouts:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tooling\process-antique-assets.ps1
+```
+
+## Shared Requirements
+
+- Format: PNG.
+- File name: exact match. The implementation expects these names.
+- Source path: `assets/ui/antique/source/`.
+- Processed path: `assets/ui/antique/processed/`, except `wood-table.png`, which is used directly at `assets/ui/antique/wood-table.png`.
+- Transparent cutouts: source images may contain baked checkerboard, but processed images must be alpha-cleaned and cropped by the script.
+- Source dimensions are strict. This keeps generated replacements from shifting layout unexpectedly.
+- Processed dimensions are maximums. Cropping can change the final width and height, but the output must fit within the declared box.
+- Aspect ratio is `width / height`.
+
+## Asset Table
+
+| File name | Part | Current source | Source requirement | Source max | Processed / direct output requirement | Output max |
+| --- | --- | ---: | --- | ---: | --- | ---: |
+| `wood-table.png` | Battle background | 1672x941, 1,972,455 bytes, ratio 1.777 | 1672x941, ratio 1.74-1.82 | 3,000,000 bytes | Direct: 1672x941, ratio 1.74-1.82 | 3,000,000 bytes |
+| `oval-table-wide.png` | CPU battle oval table frame | 1672x941, 2,259,383 bytes, ratio 1.777 | 1672x941, ratio 1.74-1.82 | 3,000,000 bytes | Processed: <=1672x941, ratio 1.78-1.90 | 3,500,000 bytes |
+| `room-frame-round.png` | Room and lobby circular frame | 1254x1254, 1,804,898 bytes, ratio 1.000 | 1254x1254, ratio 0.98-1.02 | 2,500,000 bytes | Processed: <=640x640, ratio 0.94-1.04 | 1,000,000 bytes |
+| `seat-frame.png` | Player seat frame | 1254x1254, 1,686,393 bytes, ratio 1.000 | 1254x1254, ratio 0.98-1.02 | 2,500,000 bytes | Processed: <=420x420, ratio 0.90-1.02 | 512,000 bytes |
+| `label-strip.png` | Long label strip | 2508x627, 1,340,708 bytes, ratio 4.000 | 2508x627, ratio 3.95-4.05 | 2,000,000 bytes | Processed: <=1254x314, ratio 5.80-6.80 | 512,000 bytes |
+| `card-face-normal.png` | Normal card face frame | 1060x1484, 1,564,464 bytes, ratio 0.714 | 1060x1484, ratio 0.70-0.73 | 2,500,000 bytes | Processed: <=212x297, ratio 0.66-0.74 | 256,000 bytes |
+| `card-face-special-1.png` | Special card face frame | 1060x1484, 1,894,522 bytes, ratio 0.714 | 1060x1484, ratio 0.70-0.73 | 2,500,000 bytes | Processed: <=212x297, ratio 0.66-0.74 | 256,000 bytes |
+| `card-face-danger-15.png` | Danger 15 card face frame | 1060x1484, 1,286,864 bytes, ratio 0.714 | 1060x1484, ratio 0.70-0.73 | 2,500,000 bytes | Processed: <=212x297, ratio 0.66-0.74 | 256,000 bytes |
+| `card-back.png` | Card back | 1060x1484, 1,993,408 bytes, ratio 0.714 | 1060x1484, ratio 0.70-0.73 | 2,500,000 bytes | Processed: <=212x297, ratio 0.66-0.74 | 256,000 bytes |
+| `cucumber-icon.png` | Cucumber point icon | 1254x1254, 1,010,094 bytes, ratio 1.000 | 1254x1254, ratio 0.98-1.02 | 1,500,000 bytes | Processed: <=256x256, ratio 0.82-0.94 | 128,000 bytes |
+
+## Implementation Rejection Rules
+
+The processing script fails before writing output when a source asset is missing, renamed, non-PNG, too large, or outside its required dimensions/aspect ratio.
+
+`-ValidateOnly` also fails when processed/direct assets are missing, oversized, or outside their allowed output dimensions/aspect ratio. Use it before committing replacement assets.
+
+## Notes
+
+- `card-face-danger-15.png` clears checkerboard pixels inside the card center in addition to edge cleanup.
+- `wood-table.png` is intentionally direct-use because it is the full background texture, not a transparent cutout.
+- If the UI later needs higher-resolution exports, update this document and the script requirements in the same change.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "vercel:check": "node tooling/check-next-output.cjs",
-    "assets:exists": "node tooling/check-home-assets.cjs"
+    "assets:exists": "node tooling/check-home-assets.cjs",
+    "assets:antique": "powershell -ExecutionPolicy Bypass -File tooling/process-antique-assets.ps1",
+    "assets:antique:check": "powershell -ExecutionPolicy Bypass -File tooling/process-antique-assets.ps1 -ValidateOnly"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/tooling/process-antique-assets.ps1
+++ b/tooling/process-antique-assets.ps1
@@ -1,9 +1,97 @@
 param(
   [string]$SourceDir = "assets/ui/antique/source",
-  [string]$OutputDir = "assets/ui/antique/processed"
+  [string]$OutputDir = "assets/ui/antique/processed",
+  [switch]$ValidateOnly
 )
 
 Add-Type -AssemblyName System.Drawing
+
+function Get-AntiqueImageInfo {
+  param([string]$Path)
+
+  if (-not (Test-Path -LiteralPath $Path)) {
+    return $null
+  }
+
+  $item = Get-Item -LiteralPath $Path
+  $bitmap = [System.Drawing.Bitmap]::new($item.FullName)
+  try {
+    return [pscustomobject]@{
+      Path = $item.FullName
+      Width = $bitmap.Width
+      Height = $bitmap.Height
+      Aspect = [double]$bitmap.Width / [double]$bitmap.Height
+      Bytes = $item.Length
+    }
+  }
+  finally {
+    $bitmap.Dispose()
+  }
+}
+
+function Test-AntiqueImageRequirement {
+  param(
+    [string]$Path,
+    [hashtable]$Requirement,
+    [string]$Kind
+  )
+
+  $errors = [System.Collections.Generic.List[string]]::new()
+  $info = Get-AntiqueImageInfo $Path
+
+  if ($null -eq $info) {
+    $errors.Add("missing ${Kind}: $Path")
+    return $errors.ToArray()
+  }
+
+  if ([System.IO.Path]::GetExtension($Path).ToLowerInvariant() -ne ".png") {
+    $errors.Add("invalid extension for ${Kind}: $Path")
+  }
+
+  if ($Requirement.ContainsKey("Width") -and $info.Width -ne [int]$Requirement.Width) {
+    $errors.Add("${Kind} width must be $($Requirement.Width)px: $Path is $($info.Width)px")
+  }
+
+  if ($Requirement.ContainsKey("Height") -and $info.Height -ne [int]$Requirement.Height) {
+    $errors.Add("${Kind} height must be $($Requirement.Height)px: $Path is $($info.Height)px")
+  }
+
+  if ($Requirement.ContainsKey("MaxWidth") -and $info.Width -gt [int]$Requirement.MaxWidth) {
+    $errors.Add("${Kind} width must be <= $($Requirement.MaxWidth)px: $Path is $($info.Width)px")
+  }
+
+  if ($Requirement.ContainsKey("MaxHeight") -and $info.Height -gt [int]$Requirement.MaxHeight) {
+    $errors.Add("${Kind} height must be <= $($Requirement.MaxHeight)px: $Path is $($info.Height)px")
+  }
+
+  if ($Requirement.ContainsKey("AspectMin") -and $info.Aspect -lt [double]$Requirement.AspectMin) {
+    $errors.Add("${Kind} aspect must be >= $($Requirement.AspectMin): $Path is $([Math]::Round($info.Aspect, 3))")
+  }
+
+  if ($Requirement.ContainsKey("AspectMax") -and $info.Aspect -gt [double]$Requirement.AspectMax) {
+    $errors.Add("${Kind} aspect must be <= $($Requirement.AspectMax): $Path is $([Math]::Round($info.Aspect, 3))")
+  }
+
+  if ($Requirement.ContainsKey("MaxBytes") -and $info.Bytes -gt [int64]$Requirement.MaxBytes) {
+    $errors.Add("${Kind} size must be <= $($Requirement.MaxBytes) bytes: $Path is $($info.Bytes) bytes")
+  }
+
+  return $errors.ToArray()
+}
+
+function Assert-NoAntiqueAssetErrors {
+  param([object[]]$Errors)
+
+  if ($Errors.Count -eq 0) {
+    return
+  }
+
+  foreach ($errorMessage in $Errors) {
+    Write-Error $errorMessage
+  }
+
+  exit 1
+}
 
 $processorSource = @"
 using System;
@@ -195,16 +283,74 @@ public static class AntiqueAssetProcessor
 Add-Type -TypeDefinition $processorSource -ReferencedAssemblies System.Drawing
 
 $assets = @(
-  @{ Name = "oval-table-wide.png"; MaxWidth = 1672; MaxHeight = 941; ClearInner = $false; X = 0; Y = 0; W = 0; H = 0 },
-  @{ Name = "room-frame-round.png"; MaxWidth = 640; MaxHeight = 640; ClearInner = $false; X = 0; Y = 0; W = 0; H = 0 },
-  @{ Name = "seat-frame.png"; MaxWidth = 420; MaxHeight = 420; ClearInner = $false; X = 0; Y = 0; W = 0; H = 0 },
-  @{ Name = "label-strip.png"; MaxWidth = 1254; MaxHeight = 314; ClearInner = $false; X = 0; Y = 0; W = 0; H = 0 },
-  @{ Name = "card-face-normal.png"; MaxWidth = 212; MaxHeight = 297; ClearInner = $false; X = 0; Y = 0; W = 0; H = 0 },
-  @{ Name = "card-face-special-1.png"; MaxWidth = 212; MaxHeight = 297; ClearInner = $false; X = 0; Y = 0; W = 0; H = 0 },
-  @{ Name = "card-face-danger-15.png"; MaxWidth = 212; MaxHeight = 297; ClearInner = $true; X = 0.09; Y = 0.16; W = 0.82; H = 0.74 },
-  @{ Name = "card-back.png"; MaxWidth = 212; MaxHeight = 297; ClearInner = $false; X = 0; Y = 0; W = 0; H = 0 },
-  @{ Name = "cucumber-icon.png"; MaxWidth = 256; MaxHeight = 256; ClearInner = $false; X = 0; Y = 0; W = 0; H = 0 }
+  @{ Name = "oval-table-wide.png"; Part = "CPU battle oval table frame"; SourceWidth = 1672; SourceHeight = 941; SourceAspectMin = 1.74; SourceAspectMax = 1.82; MaxSourceBytes = 3000000; MaxWidth = 1672; MaxHeight = 941; OutputAspectMin = 1.78; OutputAspectMax = 1.90; MaxOutputBytes = 3500000; ClearInner = $false; X = 0; Y = 0; W = 0; H = 0 },
+  @{ Name = "room-frame-round.png"; Part = "Room and lobby circular frame"; SourceWidth = 1254; SourceHeight = 1254; SourceAspectMin = 0.98; SourceAspectMax = 1.02; MaxSourceBytes = 2500000; MaxWidth = 640; MaxHeight = 640; OutputAspectMin = 0.94; OutputAspectMax = 1.04; MaxOutputBytes = 1000000; ClearInner = $false; X = 0; Y = 0; W = 0; H = 0 },
+  @{ Name = "seat-frame.png"; Part = "Player seat frame"; SourceWidth = 1254; SourceHeight = 1254; SourceAspectMin = 0.98; SourceAspectMax = 1.02; MaxSourceBytes = 2500000; MaxWidth = 420; MaxHeight = 420; OutputAspectMin = 0.90; OutputAspectMax = 1.02; MaxOutputBytes = 512000; ClearInner = $false; X = 0; Y = 0; W = 0; H = 0 },
+  @{ Name = "label-strip.png"; Part = "Long label strip"; SourceWidth = 2508; SourceHeight = 627; SourceAspectMin = 3.95; SourceAspectMax = 4.05; MaxSourceBytes = 2000000; MaxWidth = 1254; MaxHeight = 314; OutputAspectMin = 5.80; OutputAspectMax = 6.80; MaxOutputBytes = 512000; ClearInner = $false; X = 0; Y = 0; W = 0; H = 0 },
+  @{ Name = "card-face-normal.png"; Part = "Normal card face frame"; SourceWidth = 1060; SourceHeight = 1484; SourceAspectMin = 0.70; SourceAspectMax = 0.73; MaxSourceBytes = 2500000; MaxWidth = 212; MaxHeight = 297; OutputAspectMin = 0.66; OutputAspectMax = 0.74; MaxOutputBytes = 256000; ClearInner = $false; X = 0; Y = 0; W = 0; H = 0 },
+  @{ Name = "card-face-special-1.png"; Part = "Special card face frame"; SourceWidth = 1060; SourceHeight = 1484; SourceAspectMin = 0.70; SourceAspectMax = 0.73; MaxSourceBytes = 2500000; MaxWidth = 212; MaxHeight = 297; OutputAspectMin = 0.66; OutputAspectMax = 0.74; MaxOutputBytes = 256000; ClearInner = $false; X = 0; Y = 0; W = 0; H = 0 },
+  @{ Name = "card-face-danger-15.png"; Part = "Danger 15 card face frame"; SourceWidth = 1060; SourceHeight = 1484; SourceAspectMin = 0.70; SourceAspectMax = 0.73; MaxSourceBytes = 2500000; MaxWidth = 212; MaxHeight = 297; OutputAspectMin = 0.66; OutputAspectMax = 0.74; MaxOutputBytes = 256000; ClearInner = $true; X = 0.09; Y = 0.16; W = 0.82; H = 0.74 },
+  @{ Name = "card-back.png"; Part = "Card back"; SourceWidth = 1060; SourceHeight = 1484; SourceAspectMin = 0.70; SourceAspectMax = 0.73; MaxSourceBytes = 2500000; MaxWidth = 212; MaxHeight = 297; OutputAspectMin = 0.66; OutputAspectMax = 0.74; MaxOutputBytes = 256000; ClearInner = $false; X = 0; Y = 0; W = 0; H = 0 },
+  @{ Name = "cucumber-icon.png"; Part = "Cucumber point icon"; SourceWidth = 1254; SourceHeight = 1254; SourceAspectMin = 0.98; SourceAspectMax = 1.02; MaxSourceBytes = 1500000; MaxWidth = 256; MaxHeight = 256; OutputAspectMin = 0.82; OutputAspectMax = 0.94; MaxOutputBytes = 128000; ClearInner = $false; X = 0; Y = 0; W = 0; H = 0 }
 )
+
+$directAssets = @(
+  @{ Name = "wood-table.png"; Part = "Battle background"; OutputPath = "assets/ui/antique/wood-table.png"; SourceWidth = 1672; SourceHeight = 941; SourceAspectMin = 1.74; SourceAspectMax = 1.82; MaxSourceBytes = 3000000; OutputWidth = 1672; OutputHeight = 941; OutputAspectMin = 1.74; OutputAspectMax = 1.82; MaxOutputBytes = 3000000 }
+)
+
+$sourceErrors = @()
+foreach ($asset in $assets) {
+  $inputPath = Join-Path $SourceDir $asset.Name
+  $sourceErrors += Test-AntiqueImageRequirement $inputPath @{
+    Width = $asset.SourceWidth
+    Height = $asset.SourceHeight
+    AspectMin = $asset.SourceAspectMin
+    AspectMax = $asset.SourceAspectMax
+    MaxBytes = $asset.MaxSourceBytes
+  } "source $($asset.Name)"
+}
+
+foreach ($asset in $directAssets) {
+  $inputPath = Join-Path $SourceDir $asset.Name
+  $sourceErrors += Test-AntiqueImageRequirement $inputPath @{
+    Width = $asset.SourceWidth
+    Height = $asset.SourceHeight
+    AspectMin = $asset.SourceAspectMin
+    AspectMax = $asset.SourceAspectMax
+    MaxBytes = $asset.MaxSourceBytes
+  } "source $($asset.Name)"
+}
+
+Assert-NoAntiqueAssetErrors $sourceErrors
+
+if ($ValidateOnly) {
+  $outputErrors = @()
+
+  foreach ($asset in $assets) {
+    $outputPath = Join-Path $OutputDir $asset.Name
+    $outputErrors += Test-AntiqueImageRequirement $outputPath @{
+      MaxWidth = $asset.MaxWidth
+      MaxHeight = $asset.MaxHeight
+      AspectMin = $asset.OutputAspectMin
+      AspectMax = $asset.OutputAspectMax
+      MaxBytes = $asset.MaxOutputBytes
+    } "processed $($asset.Name)"
+  }
+
+  foreach ($asset in $directAssets) {
+    $outputErrors += Test-AntiqueImageRequirement $asset.OutputPath @{
+      Width = $asset.OutputWidth
+      Height = $asset.OutputHeight
+      AspectMin = $asset.OutputAspectMin
+      AspectMax = $asset.OutputAspectMax
+      MaxBytes = $asset.MaxOutputBytes
+    } "direct $($asset.Name)"
+  }
+
+  Assert-NoAntiqueAssetErrors $outputErrors
+  Write-Output "antique asset validation passed"
+  exit 0
+}
 
 foreach ($asset in $assets) {
   $inputPath = Join-Path $SourceDir $asset.Name
@@ -220,5 +366,26 @@ foreach ($asset in $assets) {
     [double]$asset.W,
     [double]$asset.H
   )
+  $outputErrors = Test-AntiqueImageRequirement $outputPath @{
+    MaxWidth = $asset.MaxWidth
+    MaxHeight = $asset.MaxHeight
+    AspectMin = $asset.OutputAspectMin
+    AspectMax = $asset.OutputAspectMax
+    MaxBytes = $asset.MaxOutputBytes
+  } "processed $($asset.Name)"
+  Assert-NoAntiqueAssetErrors $outputErrors
   Write-Output "processed $($asset.Name)"
 }
+
+$directOutputErrors = @()
+foreach ($asset in $directAssets) {
+  $directOutputErrors += Test-AntiqueImageRequirement $asset.OutputPath @{
+    Width = $asset.OutputWidth
+    Height = $asset.OutputHeight
+    AspectMin = $asset.OutputAspectMin
+    AspectMax = $asset.OutputAspectMax
+    MaxBytes = $asset.MaxOutputBytes
+  } "direct $($asset.Name)"
+}
+
+Assert-NoAntiqueAssetErrors $directOutputErrors


### PR DESCRIPTION
## Summary
- add antique UI asset requirements with file names, parts, source/output dimensions, aspect ratios, and file size limits
- make the antique asset processing script reject missing or nonconforming source/processed/direct assets
- add package scripts for regenerating and checking antique assets

## Verification
- `powershell -ExecutionPolicy Bypass -File tooling\process-antique-assets.ps1 -ValidateOnly`
- `powershell -ExecutionPolicy Bypass -File tooling\process-antique-assets.ps1`
- `pnpm -w run assets:antique:check`
- `pnpm -w run copy:assets`
- `pnpm -w run assets:exists`
- `pnpm -w run type-check`
- `pnpm -w run build`