### PR TITLE
2026-06-08 13:27 JST: clean UI flows and friend fallback

### DIFF
--- a/apps/hub/app/cucumber/cpu/play/game.css
+++ b/apps/hub/app/cucumber/cpu/play/game.css
@@ -1091,3 +1091,32 @@
     height: 19px;
   }
 }
+
+/* Clean UI pass: remove generated table/background images until layout is stable. */
+.cpu-play-layout .battle-layout__stage {
+  background: #1f4b31 !important;
+}
+
+.cpu-play-layout .battle-hud {
+  background: #fffaf0 !important;
+  color: #1f2937 !important;
+  border: 1px solid #ded4c0 !important;
+  box-shadow: 0 8px 20px rgba(17, 24, 39, 0.12) !important;
+  text-shadow: none !important;
+}
+
+.cpu-play-layout .ellipse-table {
+  border-radius: 28px;
+  background: transparent;
+}
+
+.cpu-play-layout .ellipse-table-inner {
+  background: #2f6f43 !important;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  box-shadow: inset 0 0 0 1px rgba(16, 80, 40, 0.45) !important;
+}
+
+.cpu-play-layout .ellipse-table-inner::before,
+.cpu-play-layout .ellipse-table-inner::after {
+  display: none !important;
+}

--- a/apps/hub/app/cucumber/cpu/play/page.tsx
+++ b/apps/hub/app/cucumber/cpu/play/page.tsx
@@ -22,8 +22,6 @@ import {
 import { createCpuTableFromUrlParams } from '@/lib/modes';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
-import PageBackground from '@/components/ui/PageBackground';
-import { BACKGROUNDS } from '@/lib/backgrounds';
 import './game.css';
 
 const DEBUG_CPU_GAME = process.env.NEXT_PUBLIC_DEBUG_GAME === '1';
@@ -820,12 +818,9 @@ function CpuPlayContent() {
 
   if (!gameState) {
     return (
-      <>
-        <PageBackground image={BACKGROUNDS.battle} />
-        <BattleLayout showOrientationHint>
-          <div className="grid place-items-center flex-1 text-white/80">Loading...</div>
-        </BattleLayout>
-      </>
+      <BattleLayout showOrientationHint>
+        <div className="grid place-items-center flex-1 text-white/80">Loading...</div>
+      </BattleLayout>
     );
   }
 
@@ -844,9 +839,7 @@ function CpuPlayContent() {
   const currentPlayerIndex = isAnimating || isFinalTrickPhase ? null : gameState.currentPlayer;
 
   return (
-    <>
-      <PageBackground image={BACKGROUNDS.battle} />
-      <BattleLayout showOrientationHint className="cpu-play-layout">
+    <BattleLayout showOrientationHint className="cpu-play-layout">
         <BattleHud
           round={displayRound}
           trick={displayTrick}
@@ -963,8 +956,7 @@ function CpuPlayContent() {
             </div>
           </div>
         ) : null}
-      </BattleLayout>
-    </>
+    </BattleLayout>
   );
 }
 

--- a/apps/hub/app/friend/create/page.tsx
+++ b/apps/hub/app/friend/create/page.tsx
@@ -86,6 +86,18 @@ export default function FriendCreatePage() {
     return `作成に失敗しました${message ? ` (${message})` : ""}`;
   };
 
+  const canFallbackToLocalRoom = (err: unknown) => {
+    if (!(err instanceof ApiRequestError)) return true;
+    const body = err.response.data as (RoomResponse & { error?: string }) | undefined;
+    return (
+      err.response.status === 0 ||
+      err.response.status === 401 ||
+      err.response.status === 503 ||
+      body?.reason === "no-shared-store" ||
+      body?.reason === "kv-failed"
+    );
+  };
+
   const createLocalRoom = (nickname: string) => {
     const result = createRoom(
       Number(settings.roomSize),
@@ -149,9 +161,17 @@ export default function FriendCreatePage() {
         } catch {}
         router.push(`/friend/room/${data.roomId}`);
       } else {
+        if (data?.reason === "no-shared-store" || data?.reason === "kv-failed") {
+          createLocalRoom(nickname);
+          return;
+        }
         setError(roomFailureMessage(data?.reason, data?.detail));
       }
     } catch (e: unknown) {
+      if (canFallbackToLocalRoom(e)) {
+        createLocalRoom(nickname);
+        return;
+      }
       setError(backendFailureMessage(e));
     } finally {
       setIsCreating(false);

--- a/apps/hub/app/friend/join/page.tsx
+++ b/apps/hub/app/friend/join/page.tsx
@@ -55,6 +55,17 @@ export default function FriendJoinPage() {
     return `ネットワークエラーが発生しました${message ? ` (${message})` : ''}`;
   };
 
+  const canFallbackToLocalJoin = (err: unknown) => {
+    if (!(err instanceof ApiRequestError)) return true;
+    const body = err.response.data as RoomResponse | { reason?: string } | undefined;
+    return (
+      err.response.status === 0 ||
+      err.response.status === 401 ||
+      err.response.status === 503 ||
+      body?.reason === 'no-shared-store'
+    );
+  };
+
   const joinLocalRoom = (trimmedRoomCode: string, nickname: string) => {
     const result = joinRoom(trimmedRoomCode, nickname);
     if (!result.success || !result.roomId) {
@@ -128,6 +139,10 @@ export default function FriendJoinPage() {
         setError(joinFailureMessage(data.reason));
       }
     } catch (err) {
+      if (canFallbackToLocalJoin(err)) {
+        joinLocalRoom(trimmedRoomCode, nickname);
+        return;
+      }
       setError(backendFailureMessage(err));
     } finally {
       setIsJoining(false);

--- a/apps/hub/app/friend/page.tsx
+++ b/apps/hub/app/friend/page.tsx
@@ -9,8 +9,7 @@ export default function FriendPage() {
   }, []);
 
   return (
-    <main className="friend-page bg-overlay-home">
-      <div className="friend-page__background" aria-hidden="true" />
+    <main className="friend-page">
       <div className="friend-page__container overlay-container">
         <header className="friend-page__header">
           <div className="friend-page__title-group">
@@ -54,12 +53,6 @@ export default function FriendPage() {
             </Link>
           </article>
         </section>
-      </div>
-
-      {/* 下段CTA（グリッド行3） */}
-      <div className="friend-page__cta">
-        <Link href="/friend/create" className="friend-cta__primary">ルームを作成</Link>
-        <Link href="/friend/join" className="friend-cta__secondary">ルームに参加</Link>
       </div>
     </main>
   );

--- a/apps/hub/app/friend/room/[roomId]/page.tsx
+++ b/apps/hub/app/friend/room/[roomId]/page.tsx
@@ -97,7 +97,10 @@ export default function RoomWaitingPage() {
             debugWarn('Room fetch error:', err);
             if (err instanceof DOMException && err.name === 'AbortError') {
               setError('リクエストがタイムアウトしました。ネットワーク状況を確認してください。');
-            } else if (err instanceof ApiRequestError && err.response.status === 404) {
+            } else if (
+              err instanceof ApiRequestError &&
+              [401, 404, 503].includes(err.response.status)
+            ) {
               const local = getLocalRoom(roomId);
               if (local) {
                 setRoom(local);
@@ -107,7 +110,11 @@ export default function RoomWaitingPage() {
                 setIsLoading(false);
                 return;
               }
-              setError('ルームが見つかりません。ルームが削除されたか、ルーム番号が間違っている可能性があります。');
+              setError(
+                err.response.status === 404
+                  ? 'ルームが見つかりません。ルームが削除されたか、ルーム番号が間違っている可能性があります。'
+                  : 'サーバー同期の設定が不足しています。ローカル確認用ルームがない場合、別端末とのフレンド対戦は開始できません。'
+              );
             } else {
               setError('ネットワークエラーが発生しました');
             }

--- a/apps/hub/app/globals.css
+++ b/apps/hub/app/globals.css
@@ -2281,6 +2281,354 @@ body[data-bg='battle']::before {
   }
 }
 
+/* === Clean UI pass: remove generated backgrounds and clarify navigation === */
+body {
+  background: #f7f4ec;
+  color: var(--antique-ink);
+}
+
+.home-shell {
+  min-height: 100svh;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  background: #f7f4ec;
+  color: var(--antique-ink);
+  font-family: 'Noto Sans JP', sans-serif;
+  padding: clamp(16px, 3vw, 32px);
+}
+
+.home-shell__topbar {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.home-shell__nav,
+.home-shell__quick-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.home-shell__text-link,
+.home-shell__quick-links a,
+.home-shell__language,
+.home-shell__profile {
+  color: #25533e;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.home-shell__text-link,
+.home-shell__language,
+.home-shell__profile,
+.home-shell__quick-links a {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 10px 16px;
+}
+
+.home-shell__text-link,
+.home-shell__language,
+.home-shell__quick-links a {
+  border: 1px solid #d8cfbc;
+  background: #fffaf0;
+}
+
+.home-shell__profile {
+  gap: 8px;
+  background: #25533e;
+  color: #ffffff;
+  box-shadow: 0 8px 18px rgba(37, 83, 62, 0.18);
+}
+
+.home-shell__profile-label {
+  font-size: 12px;
+  opacity: 0.8;
+}
+
+.home-shell__content {
+  width: min(760px, 100%);
+  margin: 0 auto;
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: clamp(22px, 4vw, 36px);
+  text-align: center;
+  padding-block: clamp(48px, 10vh, 96px);
+}
+
+.home-shell__title-block {
+  display: grid;
+  gap: 12px;
+}
+
+.home-shell__eyebrow {
+  margin: 0;
+  color: var(--antique-muted);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+}
+
+.home-shell__title {
+  margin: 0;
+  color: #174329;
+  font-family: 'Shippori Mincho', serif;
+  font-size: clamp(44px, 8vw, 76px);
+  line-height: 1.08;
+}
+
+.home-shell__lead {
+  margin: 0;
+  color: #4b5563;
+  font-size: clamp(15px, 2vw, 18px);
+  line-height: 1.8;
+}
+
+.home-shell__primary-actions {
+  width: min(480px, 100%);
+  display: grid;
+  gap: 14px;
+}
+
+.home-shell__action {
+  min-height: 76px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  gap: 2px;
+  text-decoration: none;
+  font-weight: 800;
+  font-size: clamp(20px, 3vw, 26px);
+  box-shadow: 0 10px 24px rgba(17, 24, 39, 0.12);
+  transition: transform 0.16s ease, box-shadow 0.16s ease;
+}
+
+.home-shell__action:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(17, 24, 39, 0.16);
+}
+
+.home-shell__action small {
+  font-size: 13px;
+  font-weight: 700;
+  opacity: 0.82;
+}
+
+.home-shell__action--primary {
+  background: #247a42;
+  color: #ffffff;
+}
+
+.home-shell__action--secondary {
+  background: #f59e3d;
+  color: #2d1a04;
+}
+
+.home-shell__quick-links {
+  justify-content: center;
+}
+
+.background-frame {
+  background: #f7f4ec;
+}
+
+.background-frame__image,
+.friend-page__background,
+.friend-room-page__background {
+  display: none;
+}
+
+.settings-layout,
+.friend-room,
+.friend-room-page__container {
+  color: var(--antique-ink);
+}
+
+.settings-layout {
+  width: min(960px, 100%);
+  padding: clamp(24px, 5vw, 56px) clamp(16px, 4vw, 24px);
+}
+
+.settings-layout__header,
+.friend-room__header,
+.friend-room__status-card,
+.room-summary-card {
+  background: #fffaf0;
+  border: 1px solid #ded4c0;
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(17, 24, 39, 0.08);
+}
+
+.settings-layout section,
+.friend-room-card section {
+  color: var(--antique-ink);
+}
+
+.settings-layout p,
+.friend-room-card p {
+  color: #4b5563;
+}
+
+.settings-layout .text-white\/80,
+.settings-layout .text-white\/70,
+.friend-room-card .text-white\/80,
+.friend-room-card .text-white\/70 {
+  color: #4b5563 !important;
+}
+
+.friend-page,
+.friend-room-page {
+  background: #f7f4ec;
+  color: var(--antique-ink);
+}
+
+.friend-page {
+  padding: clamp(24px, 5vw, 56px) clamp(16px, 5vw, 48px);
+}
+
+.friend-page__container {
+  align-content: start;
+  gap: clamp(24px, 5vw, 40px);
+}
+
+.friend-page__header {
+  background: #fffaf0;
+  border: 1px solid #ded4c0;
+  border-radius: 16px;
+  padding: clamp(22px, 4vw, 36px);
+  box-shadow: 0 8px 24px rgba(17, 24, 39, 0.08);
+}
+
+.friend-page__eyebrow,
+.friend-room-page__eyebrow {
+  color: #6b7280;
+}
+
+.friend-page__title,
+.friend-room-page__title,
+.friend-page__lead,
+.friend-room-page__lead,
+.overlay-title,
+.overlay-lead {
+  color: var(--antique-ink);
+  text-shadow: none;
+}
+
+.friend-page__rules {
+  background: #ffffff;
+  border-color: #d8cfbc;
+  color: #25533e;
+}
+
+.friend-actions {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.friend-action-card,
+.friend-room-card {
+  background: #ffffff;
+  color: var(--antique-ink);
+  border: 1px solid #ded4c0;
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(17, 24, 39, 0.08);
+}
+
+.friend-action-card__title,
+.friend-action-card__text {
+  color: var(--antique-ink);
+}
+
+.friend-action-card__text {
+  color: #4b5563;
+}
+
+.friend-action-card__button,
+.friend-room-card__submit,
+.friend-room-card__secondary,
+.friend-room-card__link,
+.btn-primary,
+.btn-secondary,
+.fc-button {
+  border-radius: 10px;
+  text-decoration: none;
+}
+
+.friend-action-card__button--primary,
+.friend-room-card__submit,
+.btn-primary,
+.fc-button--primary {
+  background: #247a42;
+  color: #ffffff;
+  border-color: #247a42;
+  box-shadow: 0 8px 18px rgba(36, 122, 66, 0.2);
+}
+
+.friend-action-card__button--secondary,
+.friend-room-card__secondary,
+.btn-secondary,
+.fc-button--secondary {
+  background: #fffaf0;
+  color: #25533e;
+  border: 1px solid #d8cfbc;
+  box-shadow: none;
+}
+
+.friend-room-card__input {
+  background: #fffaf0;
+  color: var(--antique-ink);
+  border-color: #d8cfbc;
+}
+
+.friend-room-card__hint,
+.friend-room-card__link {
+  color: #4b5563;
+}
+
+.friend-room-card__error {
+  background: #fef2f2;
+  border-color: #fecaca;
+  color: #991b1b;
+}
+
+.friend-page__cta,
+.friend-sticky-bar {
+  display: none;
+}
+
+.battle-layout {
+  background: #173823;
+}
+
+.battle-layout__stage {
+  background: #1f4b31;
+  border-color: rgba(255, 255, 255, 0.14);
+  box-shadow: none;
+}
+
+@media (max-width: 720px) {
+  .home-shell__topbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .home-shell__nav,
+  .home-shell__quick-links {
+    justify-content: center;
+  }
+
+  .home-shell__profile {
+    justify-content: center;
+  }
+}
+
 /* === ホームランディング（画像デザイン準拠） === */
 .home-landing {
   min-height: 100svh;

--- a/apps/hub/app/home/_components/DesktopHero.tsx
+++ b/apps/hub/app/home/_components/DesktopHero.tsx
@@ -7,186 +7,52 @@ export default function DesktopHero({ username = 'GUEST' }: Props) {
   const normalizedName = username?.trim() || 'GUEST';
 
   return (
-    <>
-      <div
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100vw',
-          height: '100vh',
-          backgroundImage: "url('/assets/home_f.png')",
-          backgroundSize: 'cover',
-          backgroundPosition: 'center',
-          backgroundRepeat: 'no-repeat',
-          pointerEvents: 'none',
-          zIndex: -1,
-        }}
-        aria-hidden
-      />
-      <section
-        style={{
-          position: 'relative',
-          zIndex: 1,
-          minHeight: '100vh',
-          width: '100%',
-          color: '#2a2a2a',
-        }}
-      >
-        <header
-          style={{
-            position: 'absolute',
-            top: '1rem',
-            left: '1rem',
-            right: '1rem',
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            gap: '1rem',
-            zIndex: 2,
-            fontSize: '0.9rem',
-            fontWeight: 600,
-          }}
-        >
-          <nav
-            aria-label="補助リンク"
-            style={{ display: 'flex', alignItems: 'center', gap: '1rem', textAlign: 'left' }}
-          >
-            <Link href="/rules" style={{ textDecoration: 'underline', textUnderlineOffset: '4px' }}>
-              📖 ルール説明
-            </Link>
-            <div style={{ textDecoration: 'underline', textUnderlineOffset: '4px' }}>
-              <LanguageToggle className="" />
-            </div>
-          </nav>
-
-          <div style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem' }}>
-            <span>ユーザー:</span>
-            <Link
-              href="/setup"
-              style={{
-                fontWeight: 'bold',
-                color: '#155724',
-                textDecoration: 'underline',
-                textUnderlineOffset: '4px',
-              }}
-              aria-label={`${normalizedName}のプロフィール設定を開く`}
-            >
-              {normalizedName}
-            </Link>
-          </div>
-        </header>
-
-        <div
-          style={{
-            position: 'relative',
-            zIndex: 1,
-            minHeight: '100vh',
-            width: '100%',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            textAlign: 'center',
-          }}
-        >
-          <h1
-            style={{
-              fontSize: '4rem',
-              fontWeight: 'bold',
-              color: '#1a4d1a',
-              marginBottom: '3rem',
-              textShadow: '2px 2px 4px rgba(255,255,255,0.7)',
-            }}
-          >
-            5本のきゅうり
-          </h1>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem', width: '320px' }}>
-            <Link
-              href="/cucumber/cpu/settings"
-              aria-label="CPU対戦を始める"
-              style={{ textDecoration: 'none' }}
-            >
-              <button
-                type="button"
-                style={{
-                  width: '100%',
-                  padding: '1.2rem 2rem',
-                  fontSize: '1.5rem',
-                  fontWeight: 'bold',
-                  color: 'white',
-                  background: 'linear-gradient(to bottom, #4ade80, #16a34a)',
-                  border: 'none',
-                  borderRadius: '12px',
-                  cursor: 'pointer',
-                  boxShadow: '0 4px 12px rgba(0,0,0,0.2)',
-                }}
-              >
-                CPU対戦
-              </button>
-            </Link>
-            <Link
-              href="/friend/create"
-              aria-label="フレンド対戦を始める"
-              style={{ textDecoration: 'none' }}
-            >
-              <button
-                type="button"
-                style={{
-                  width: '100%',
-                  padding: '1.2rem 2rem',
-                  fontSize: '1.5rem',
-                  fontWeight: 'bold',
-                  color: 'white',
-                  background: 'linear-gradient(to bottom, #fdba74, #f97316)',
-                  border: 'none',
-                  borderRadius: '12px',
-                  cursor: 'pointer',
-                  boxShadow: '0 4px 12px rgba(0,0,0,0.2)',
-                }}
-              >
-                フレンド対戦
-              </button>
-            </Link>
-          </div>
-        </div>
-
-        <footer
-          aria-label="その他のリンク"
-          style={{
-            position: 'absolute',
-            bottom: '2rem',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            display: 'flex',
-            gap: '2rem',
-            fontSize: '0.9rem',
-            fontWeight: 600,
-            color: '#1a4d1a',
-            flexWrap: 'wrap',
-            justifyContent: 'center',
-          }}
-        >
-          <Link href="/rules" style={{ color: '#1a4d1a', textDecoration: 'underline' }}>
+    <section className="home-shell">
+      <header className="home-shell__topbar" aria-label="ホームナビゲーション">
+        <nav className="home-shell__nav" aria-label="補助リンク">
+          <Link href="/rules" className="home-shell__text-link">
             ルール
           </Link>
-          <Link
-            href="/cucumber/cpu/settings"
-            style={{ color: '#1a4d1a', textDecoration: 'underline' }}
-          >
-            CPU対戦設定
+          <LanguageToggle className="home-shell__language" />
+        </nav>
+
+        <Link
+          href="/setup"
+          className="home-shell__profile"
+          aria-label={`${normalizedName}のプロフィール設定を開く`}
+        >
+          <span className="home-shell__profile-label">ユーザー名</span>
+          <strong>{normalizedName}</strong>
+        </Link>
+      </header>
+
+      <div className="home-shell__content">
+        <div className="home-shell__title-block">
+          <p className="home-shell__eyebrow">FIVE CUCUMBER</p>
+          <h1 className="home-shell__title">5本のきゅうり</h1>
+          <p className="home-shell__lead">
+            まずはCPU対戦で遊ぶか、フレンド対戦の入口からルーム作成・参加を選んでください。
+          </p>
+        </div>
+
+        <div className="home-shell__primary-actions" aria-label="主な操作">
+          <Link href="/cucumber/cpu/settings" className="home-shell__action home-shell__action--primary">
+            <span>CPU対戦</span>
+            <small>ひとりで開始</small>
           </Link>
-          <Link href="/online" style={{ color: '#1a4d1a', textDecoration: 'underline' }}>
-            オンライン対戦
+          <Link href="/friend" className="home-shell__action home-shell__action--secondary">
+            <span>フレンド対戦</span>
+            <small>作成・参加を選ぶ</small>
           </Link>
-          <Link href="/friend/create" style={{ color: '#1a4d1a', textDecoration: 'underline' }}>
-            フレンド対戦
-          </Link>
-          <Link href="/setup" style={{ color: '#1a4d1a', textDecoration: 'underline' }}>
-            プロフィール設定
-          </Link>
-        </footer>
-      </section>
-    </>
+        </div>
+
+        <nav className="home-shell__quick-links" aria-label="ショートカット">
+          <Link href="/setup">ユーザー名設定</Link>
+          <Link href="/friend/create">ルーム作成</Link>
+          <Link href="/friend/join">ルーム参加</Link>
+          <Link href="/rules/cucumber5">ルール確認</Link>
+        </nav>
+      </div>
+    </section>
   );
 }

--- a/apps/hub/components/ui/BackgroundFrame.tsx
+++ b/apps/hub/components/ui/BackgroundFrame.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import React from "react";
 
 export type BackgroundFrameProps = {
-  src: string;
+  src?: string | null;
   priority?: boolean;
   objectPosition?: string;
   children: React.ReactNode;
@@ -24,16 +24,18 @@ export function BackgroundFrame({
 }: BackgroundFrameProps) {
   return (
     <div className={mergeClassNames("background-frame", className)}>
-      <div className="background-frame__image">
-        <Image
-          src={src}
-          alt=""
-          fill
-          sizes="100vw"
-          priority={priority}
-          style={{ objectFit: "cover", objectPosition }}
-        />
-      </div>
+      {src ? (
+        <div className="background-frame__image">
+          <Image
+            src={src}
+            alt=""
+            fill
+            sizes="100vw"
+            priority={priority}
+            style={{ objectFit: "cover", objectPosition }}
+          />
+        </div>
+      ) : null}
 
       {children}
     </div>

--- a/apps/hub/components/ui/SettingsLayout.tsx
+++ b/apps/hub/components/ui/SettingsLayout.tsx
@@ -24,7 +24,7 @@ export function SettingsLayout({
 }: SettingsLayoutProps) {
   return (
     <BackgroundFrame
-      src={backgroundSrc ?? "/images/home1.png"}
+      src={backgroundSrc}
       objectPosition={objectPosition}
       priority
       className={className}


### PR DESCRIPTION
## Summary
- remove generated background layers from home/settings/friend/CPU play surfaces for a cleaner baseline
- simplify home and friend navigation so friend match flows through the friend entry page
- make friend room create/join/waiting pages fall back to local review rooms when server sync auth/shared-store is unavailable
- keep CPU card visuals but suppress the antique table/background image layer until layout is stable

## Verification
- `pnpm -w run type-check`
- `pnpm --filter @five-cucumber/hub test -- friend-room`
- `pnpm -w run build`
- `git diff --check`
- local HTTP checks: `/home`, `/cucumber/cpu/settings`, `/cucumber/cpu/play`, `/friend/create` returned 200 on port 3002
- local API check: unauthenticated `/api/friend/create` returned 401, now handled by client-side local fallback

Note: Browser screenshot automation could not run because Playwright was unavailable in this local runtime.